### PR TITLE
Enable document import via Python parser

### DIFF
--- a/DragonShield/ImportManager.swift
+++ b/DragonShield/ImportManager.swift
@@ -1,0 +1,60 @@
+import Foundation
+import AppKit
+
+/// Manages document imports by invoking the bundled Python parser.
+class ImportManager {
+    static let shared = ImportManager()
+
+    /// Parses a document using the Python parser script.
+    /// - Parameters:
+    ///   - url: URL of the document to parse.
+    ///   - completion: Called with the raw JSON string output or an error.
+    func parseDocument(at url: URL, completion: @escaping (Result<String, Error>) -> Void) {
+        guard let scriptPath = Bundle.main.path(forResource: "zkb_parser", ofType: "py", inDirectory: "python_scripts") else {
+            completion(.failure(NSError(domain: "ImportManager", code: 1, userInfo: [NSLocalizedDescriptionKey: "Parser script not found in bundle"])))
+            return
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+        process.arguments = [scriptPath, url.path]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        do {
+            try process.run()
+        } catch {
+            completion(.failure(error))
+            return
+        }
+
+        process.terminationHandler = { _ in
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: data, encoding: .utf8) ?? ""
+            DispatchQueue.main.async {
+                completion(.success(output))
+            }
+        }
+    }
+
+    /// Presents an open panel and invokes the parser on the selected file.
+    func openAndParseDocument() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = false
+        panel.allowedFileTypes = ["xlsx", "csv", "pdf"]
+        panel.begin { response in
+            if response == .OK, let url = panel.url {
+                self.parseDocument(at: url) { result in
+                    switch result {
+                    case .success(let output):
+                        print("\n📥 Import result:\n\(output)")
+                    case .failure(let error):
+                        print("❌ Import failed: \(error.localizedDescription)")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/DragonShield/Views/SidebarView.swift
+++ b/DragonShield/Views/SidebarView.swift
@@ -7,6 +7,10 @@
 // - (Previous history)
 
 import SwiftUI
+import AppKit
+
+// Access to the import parser
+private let importManager = ImportManager.shared
 
 struct SidebarView: View {
     var body: some View {
@@ -32,17 +36,12 @@ struct SidebarView: View {
             
             // MARK: - Maintenance Functions Section
             Section("Maintenance Functions") {
-                HStack {
+                Button(action: {
+                    importManager.openAndParseDocument()
+                }) {
                     Label("Load Documents", systemImage: "doc.text.fill")
-                        .foregroundColor(.gray)
-                    Spacer()
-                    Text("(coming soon)")
-                        .font(.caption2)
-                        .foregroundColor(.gray)
-                        .italic()
                 }
-                .onTapGesture {}
-                
+
                 NavigationLink(destination: CurrenciesView()) {
                     Label("Edit Currencies", systemImage: "dollarsign.circle.fill")
                 }


### PR DESCRIPTION
## Summary
- add `ImportManager` class to run Python statement parser
- hook up **Load Documents** button in the sidebar to trigger the parser

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684e60338044832385a9c22e6ffc47af