### PR TITLE
Add Positions view and navigation link

### DIFF
--- a/DragonShield/DatabaseManager+OtherData.swift
+++ b/DragonShield/DatabaseManager+OtherData.swift
@@ -1,17 +1,35 @@
 // DragonShield/DatabaseManager+OtherData.swift
-// MARK: - Version 1.0 (2025-05-30)
+// MARK: - Version 1.1 (2025-06-13)
 // MARK: - History
+// - 1.0 -> 1.1: Added PositionData struct and sample data in fetchPositions().
 // - Initial creation: Refactored from DatabaseManager.swift (placeholder methods).
 
 import SQLite3 // Though not strictly needed for current placeholders, good for consistency
 import Foundation
 
+// Data structure representing a position entry
+struct PositionData: Identifiable {
+    let id: Int
+    let portfolioName: String
+    let accountName: String
+    let instrumentName: String
+    let quantity: Double
+    let valueChf: Double
+    let uploadedAt: Date
+    let reportDate: Date
+}
+
 extension DatabaseManager {
 
     // Placeholder, to be implemented
-    func fetchPositions() -> [(portfolioName: String, instrumentName: String, quantity: Double, valueChf: Double)] {
-        print("⚠️ fetchPositions() - Not yet implemented")
-        return []
+    func fetchPositions() -> [PositionData] {
+        print("ℹ️ fetchPositions() called - returning sample data.")
+        let formatter = ISO8601DateFormatter()
+        return [
+            PositionData(id: 1, portfolioName: "Main", accountName: "Sample Custody", instrumentName: "Apple Inc.", quantity: 10, valueChf: 2500.0, uploadedAt: formatter.date(from: "2025-06-01T10:00:00Z")!, reportDate: formatter.date(from: "2025-05-31T00:00:00Z")!),
+            PositionData(id: 2, portfolioName: "Main", accountName: "Sample Custody", instrumentName: "iShares MSCI World ETF", quantity: 20, valueChf: 1500.0, uploadedAt: formatter.date(from: "2025-06-01T10:00:00Z")!, reportDate: formatter.date(from: "2025-05-31T00:00:00Z")!),
+            PositionData(id: 3, portfolioName: "Crypto", accountName: "Ledger", instrumentName: "Bitcoin", quantity: 0.5, valueChf: 14000.0, uploadedAt: formatter.date(from: "2025-06-02T11:00:00Z")!, reportDate: formatter.date(from: "2025-06-01T00:00:00Z")!)
+        ]
     }
     
     // Placeholder, to be implemented

--- a/DragonShield/Views/PositionsView.swift
+++ b/DragonShield/Views/PositionsView.swift
@@ -1,0 +1,226 @@
+// DragonShield/Views/PositionsView.swift
+// MARK: - Version 1.0 (2025-06-13)
+// MARK: - History
+// - Initial creation: Displays positions with upload and report dates.
+
+import SwiftUI
+
+struct PositionsView: View {
+    @EnvironmentObject var dbManager: DatabaseManager
+
+    @State private var positions: [PositionData] = []
+    @State private var selectedPosition: PositionData? = nil
+    @State private var searchText = ""
+
+    @State private var headerOpacity: Double = 0
+    @State private var contentOffset: CGFloat = 30
+
+    var filteredPositions: [PositionData] {
+        if searchText.isEmpty { return positions }
+        return positions.filter { position in
+            position.instrumentName.localizedCaseInsensitiveContains(searchText) ||
+            position.accountName.localizedCaseInsensitiveContains(searchText) ||
+            position.portfolioName.localizedCaseInsensitiveContains(searchText)
+        }
+    }
+
+    var body: some View {
+        ZStack {
+            LinearGradient(
+                colors: [
+                    Color(red: 0.98, green: 0.99, blue: 1.0),
+                    Color(red: 0.95, green: 0.97, blue: 0.99),
+                    Color(red: 0.93, green: 0.95, blue: 0.98)
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                modernHeader
+                positionsContent
+            }
+        }
+        .onAppear {
+            loadPositions()
+            animateEntrance()
+        }
+    }
+
+    // MARK: - Modern Header
+    private var modernHeader: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 12) {
+                    Image(systemName: "tablecells")
+                        .font(.system(size: 32))
+                        .foregroundColor(.blue)
+                    Text("Positions")
+                        .font(.system(size: 32, weight: .bold, design: .rounded))
+                }
+                Text("Current holdings with report details")
+                    .font(.subheadline)
+                    .foregroundColor(.gray)
+            }
+            Spacer()
+            HStack(spacing: 16) {
+                modernStatCard(title: "Total", value: "\(positions.count)", icon: "number.circle.fill", color: .blue)
+            }
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 20)
+        .opacity(headerOpacity)
+        .offset(y: contentOffset)
+    }
+
+    private var positionsContent: some View {
+        VStack(spacing: 0) {
+            modernTableHeader
+            ScrollView {
+                LazyVStack(spacing: CGFloat(dbManager.tableRowSpacing)) {
+                    ForEach(filteredPositions) { position in
+                        ModernPositionRowView(
+                            position: position,
+                            isSelected: selectedPosition?.id == position.id,
+                            rowPadding: CGFloat(dbManager.tableRowPadding),
+                            onTap: { selectedPosition = position }
+                        )
+                    }
+                }
+            }
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(.regularMaterial)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(Color.gray.opacity(0.1), lineWidth: 1)
+                    )
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .shadow(color: .black.opacity(0.05), radius: 8, x: 0, y: 4)
+        }
+    }
+
+    private var modernTableHeader: some View {
+        HStack {
+            Text("Portfolio").font(.system(size: 14, weight: .semibold)).foregroundColor(.gray).frame(width: 120, alignment: .leading)
+            Text("Account").font(.system(size: 14, weight: .semibold)).foregroundColor(.gray).frame(width: 150, alignment: .leading)
+            Text("Instrument").font(.system(size: 14, weight: .semibold)).foregroundColor(.gray).frame(maxWidth: .infinity, alignment: .leading)
+            Text("Qty").font(.system(size: 14, weight: .semibold)).foregroundColor(.gray).frame(width: 60, alignment: .trailing)
+            Text("Value CHF").font(.system(size: 14, weight: .semibold)).foregroundColor(.gray).frame(width: 90, alignment: .trailing)
+            Text("Uploaded").font(.system(size: 14, weight: .semibold)).foregroundColor(.gray).frame(width: 110, alignment: .center)
+            Text("Report").font(.system(size: 14, weight: .semibold)).foregroundColor(.gray).frame(width: 110, alignment: .center)
+        }
+        .padding(.horizontal, CGFloat(dbManager.tableRowPadding))
+        .padding(.vertical, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color.gray.opacity(0.1))
+        )
+        .padding(.bottom, 1)
+    }
+
+    private func modernStatCard(title: String, value: String, icon: String, color: Color) -> some View {
+        VStack(spacing: 4) {
+            HStack(spacing: 4) {
+                Image(systemName: icon)
+                    .font(.system(size: 12))
+                    .foregroundColor(color)
+                Text(title)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(.gray)
+            }
+            Text(value)
+                .font(.system(size: 18, weight: .bold))
+                .foregroundColor(.primary)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(.regularMaterial)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(color.opacity(0.2), lineWidth: 1)
+                )
+        )
+        .shadow(color: color.opacity(0.1), radius: 3, x: 0, y: 1)
+    }
+
+    private func loadPositions() {
+        positions = dbManager.fetchPositions()
+    }
+
+    private func animateEntrance() {
+        withAnimation(.easeOut(duration: 0.6).delay(0.1)) { headerOpacity = 1.0 }
+        withAnimation(.spring(response: 0.6, dampingFraction: 0.8).delay(0.3)) { contentOffset = 0 }
+    }
+}
+
+struct ModernPositionRowView: View {
+    let position: PositionData
+    let isSelected: Bool
+    let rowPadding: CGFloat
+    let onTap: () -> Void
+
+    private static var dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+
+    var body: some View {
+        HStack {
+            Text(position.portfolioName)
+                .font(.system(size: 14, weight: .medium))
+                .foregroundColor(.primary)
+                .frame(width: 120, alignment: .leading)
+
+            Text(position.accountName)
+                .font(.system(size: 13))
+                .foregroundColor(.secondary)
+                .frame(width: 150, alignment: .leading)
+
+            Text(position.instrumentName)
+                .font(.system(size: 14))
+                .foregroundColor(.primary)
+                .lineLimit(1)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            Text(String(format: "%.2f", position.quantity))
+                .font(.system(size: 14, design: .monospaced))
+                .foregroundColor(.primary)
+                .frame(width: 60, alignment: .trailing)
+
+            Text(String(format: "%.2f", position.valueChf))
+                .font(.system(size: 14, weight: .medium, design: .monospaced))
+                .foregroundColor(.primary)
+                .frame(width: 90, alignment: .trailing)
+
+            Text(position.uploadedAt, formatter: Self.dateFormatter)
+                .font(.system(size: 12))
+                .foregroundColor(.secondary)
+                .frame(width: 110, alignment: .center)
+
+            Text(position.reportDate, formatter: Self.dateFormatter)
+                .font(.system(size: 12))
+                .foregroundColor(.secondary)
+                .frame(width: 110, alignment: .center)
+        }
+        .padding(.horizontal, rowPadding)
+        .padding(.vertical, rowPadding / 1.8)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(isSelected ? Color.blue.opacity(0.1) : Color.clear)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(isSelected ? Color.blue.opacity(0.3) : Color.clear, lineWidth: 1)
+                )
+        )
+        .contentShape(Rectangle())
+        .onTapGesture { onTap() }
+        .animation(.easeInOut(duration: 0.2), value: isSelected)
+    }
+}
+

--- a/DragonShield/Views/SidebarView.swift
+++ b/DragonShield/Views/SidebarView.swift
@@ -1,8 +1,9 @@
 // DragonShield/Views/SidebarView.swift
-// MARK: - Version 1.6
+// MARK: - Version 1.7
 // MARK: - History
 // - 1.5 -> 1.6: Enabled "Load Documents" navigation link to point to new ImportStatementView.
 // - 1.4 -> 1.5: Added "Edit Account Types" navigation link.
+// - 1.6 -> 1.7: Added "Positions" navigation link.
 // - (Previous history)
 
 import SwiftUI
@@ -30,6 +31,9 @@ struct SidebarView: View {
                 
                 NavigationLink(destination: TransactionHistoryView()) {
                     Label("Transaction History", systemImage: "clock.arrow.circlepath")
+                }
+                NavigationLink(destination: PositionsView()) {
+                    Label("Positions", systemImage: "tablecells")
                 }
             }
             

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Four drill-down tiles:
 ### Additional Features
 - **Target Allocation & Alerts**: Define goals per class/instrument; automatic gap calculation and alerting
 - **Transaction History**: Chronological log with rich filter & sort, CSV export
+- **Positions**: Table listing all holdings with uploaded and report dates
 - **Strategy Documentation**: Markdown notes field beside each instrument and at portfolio level
 - **Native macOS Experience**: Swift + SwiftUI, system dark/light mode, Touch ID unlock (planned)
 - **Minimalist UI**: Single accent color, generous whitespace, keyboard-first workflow (⌘-K palette)


### PR DESCRIPTION
## Summary
- update `DatabaseManager+OtherData` with `PositionData` and sample data
- create `PositionsView` for listing holdings
- link Positions page in `SidebarView`
- mention new feature in README

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_684ec635bf308323b61d0d35e2d41602