### PR TITLE
Add deploy_db script and update docs

### DIFF
--- a/DragonShield/python_scripts/deploy_db.py
+++ b/DragonShield/python_scripts/deploy_db.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+# python_scripts/deploy_db.py
+# MARK: - Version 1.0
+# MARK: - History
+# - 1.0: Initial creation. Copies repo DB to production path.
+
+import os
+import shutil
+
+
+def main() -> None:
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    source_path = os.path.join(script_dir, '..', 'dragonshield.sqlite')
+    dest_dir = os.path.expanduser(os.path.join('~', 'Library', 'Application Support', 'DragonShield'))
+    os.makedirs(dest_dir, exist_ok=True)
+    dest_path = os.path.join(dest_dir, 'dragonshield.sqlite')
+    shutil.copy2(source_path, dest_path)
+    print(f"Database copied from {source_path} to {dest_path}")
+
+
+if __name__ == '__main__':
+    main()

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dragon Shield – Personal Asset Management 🐉🛡️
 
-**Version 2.0** | June 13, 2025
+**Version 2.1** | June 17, 2025
 
 Dragon Shield is a native macOS application for private investors to track, analyze and document all assets entirely offline. Every byte of financial data remains on your Mac, encrypted in a local database—no cloud, no telemetry.
 
@@ -121,6 +121,14 @@ DragonShield/
 - **Schema**: `docs/schema.sql`
 - **Dev Key**: Temporary; do not use for production data
 
+## Updating the Database
+
+Run the deploy script whenever you need to refresh the production database:
+
+```bash
+python3 python_scripts/deploy_db.py
+```
+
 ## 💡 Usage
 
 At present the application must be run from Xcode. Future releases will ship a signed & notarized .app bundle.
@@ -132,3 +140,8 @@ This is a personal passion project, but issues and PRs are welcome. Please keep 
 ## 📜 License
 
 Dragon Shield is released under the MIT License. See LICENSE for full text.
+
+## Version History
+
+- 2.1: Documented database deployment script.
+- 2.0: Initial project documentation.


### PR DESCRIPTION
## Summary
- create a deploy_db helper to copy the SQLite DB into the user's library folder
- document how to refresh the DB
- bump README version and add version history section

## Testing
- `python3 -m py_compile DragonShield/python_scripts/deploy_db.py`

------
https://chatgpt.com/codex/tasks/task_e_685104fd5d548323b6cee5be9505b3fd