### PR TITLE
Add database metadata info and db tool

### DIFF
--- a/DragonShield/DatabaseManager.swift
+++ b/DragonShield/DatabaseManager.swift
@@ -1,6 +1,8 @@
 // DragonShield/DatabaseManager.swift
-// MARK: - Version 1.5
+// MARK: - Version 1.6
 // MARK: - History
+// - 1.5 -> 1.6: Expose database path, creation date and modification date via
+//               @Published properties.
 // - 1.3 -> 1.4: Added @Published properties for defaultTimeZone, tableRowSpacing, tableRowPadding.
 // - 1.4 -> 1.5: Added dbVersion property and logging of database version.
 // - 1.2 -> 1.3: Modified #if DEBUG block to use a UserDefaults setting for forcing DB re-copy.
@@ -24,6 +26,9 @@ class DatabaseManager: ObservableObject {
     @Published var tableRowSpacing: Double = 1.0
     @Published var tableRowPadding: Double = 12.0
     @Published var dbVersion: String = ""
+    @Published var dbFilePath: String = ""
+    @Published var dbCreated: Date?
+    @Published var dbModified: Date?
     // Add other config items as @Published if they need to be globally observable
     // For fx_api_provider, fx_update_frequency, we might just display them or use TextFields
 
@@ -65,6 +70,7 @@ class DatabaseManager: ObservableObject {
         
         openDatabase()
         loadConfiguration()
+        updateFileMetadata()
         print("📂 Database path: \(dbPath) | version: \(dbVersion)")
     }
     
@@ -82,6 +88,19 @@ class DatabaseManager: ObservableObject {
             }
         } else {
             print("❌ Failed to open database: \(String(cString: sqlite3_errmsg(db)))")
+        }
+    }
+
+    private func updateFileMetadata() {
+        do {
+            let attrs = try FileManager.default.attributesOfItem(atPath: dbPath)
+            DispatchQueue.main.async {
+                self.dbFilePath = self.dbPath
+                self.dbCreated = attrs[.creationDate] as? Date
+                self.dbModified = attrs[.modificationDate] as? Date
+            }
+        } catch {
+            print("⚠️ Failed to read DB file attributes: \(error)")
         }
     }
     

--- a/DragonShield/Views/SettingsView.swift
+++ b/DragonShield/Views/SettingsView.swift
@@ -1,6 +1,7 @@
 // DragonShield/Views/SettingsView.swift
-// MARK: - Version 1.3
+// MARK: - Version 1.4
 // MARK: - History
+// - 1.3 -> 1.4: Added database information section (path, created, updated).
 // - 1.2 -> 1.3: Replaced script-based versioning with a 100% Swift solution (AppVersionProvider) to fix build errors.
 // - 1.1 -> 1.2: Removed redundant .onChange modifiers that were causing a state update crash loop.
 // - 1.0 -> 1.1: Added editable fields for Configuration settings (base_currency, decimal_precision, etc.).
@@ -103,7 +104,29 @@ struct SettingsView: View {
                 }
             }
             #endif
-            
+
+            Section(header: Text("Database Info")) {
+                HStack {
+                    Text("Path")
+                    Spacer()
+                    Text(dbManager.dbFilePath)
+                        .font(.caption)
+                        .multilineTextAlignment(.trailing)
+                }
+                HStack {
+                    Text("Created")
+                    Spacer()
+                    Text(dbManager.dbCreated.map { DateFormatter.localizedString(from: $0, dateStyle: .medium, timeStyle: .short) } ?? "-")
+                        .foregroundColor(.secondary)
+                }
+                HStack {
+                    Text("Last Updated")
+                    Spacer()
+                    Text(dbManager.dbModified.map { DateFormatter.localizedString(from: $0, dateStyle: .medium, timeStyle: .short) } ?? "-")
+                        .foregroundColor(.secondary)
+                }
+            }
+
             Section(header: Text("About")) {
                 HStack {
                     Text("App Version")

--- a/DragonShield/python_scripts/db_tool.py
+++ b/DragonShield/python_scripts/db_tool.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# python_scripts/db_tool.py
+# MARK: - Version 1.0
+# MARK: - History
+# - 1.0: Initial creation. Build database from schema and seed data and deploy to target directory.
+
+import argparse
+import os
+import shutil
+from pathlib import Path
+
+import deploy_db
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Build and deploy Dragon Shield database")
+    parser.add_argument('--target-dir', default=os.path.expanduser(os.path.join('~', 'Library', 'Application Support', 'DragonShield')),
+                        help='Destination directory for dragonshield.sqlite')
+    parser.add_argument('--schema', default=str(Path(__file__).resolve().parents[1] / 'database' / 'schema.sql'),
+                        help='Path to schema.sql')
+    parser.add_argument('--seed', default=str(Path(__file__).resolve().parents[1] / 'database' / 'schema.txt'),
+                        help='Path to schema.txt')
+    args = parser.parse_args(argv)
+
+    project_root = Path(__file__).resolve().parents[1]
+    source_path = project_root / 'dragonshield.sqlite'
+
+    version = deploy_db.parse_version(args.schema)
+    table_count = deploy_db.build_database(args.schema, args.seed, str(source_path), version)
+
+    dest_dir = Path(args.target_dir).expanduser()
+    os.makedirs(dest_dir, exist_ok=True)
+    dest_path = dest_dir / 'dragonshield.sqlite'
+    shutil.copy2(source_path, dest_path)
+
+    print(f"✅ Built database v{version} with {table_count} tables and deployed to {dest_path}")
+
+
+if __name__ == '__main__':
+    main()

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dragon Shield – Personal Asset Management 🐉🛡️
 
-**Version 2.4** | June 18, 2025
+**Version 2.5** | June 18, 2025
 
 Dragon Shield is a native macOS application for private investors to track, analyze and document all assets entirely offline. Every byte of financial data remains on your Mac, encrypted in a local database—no cloud, no telemetry.
 
@@ -145,6 +145,7 @@ This is a personal passion project, but issues and PRs are welcome. Please keep 
 Dragon Shield is released under the MIT License. See LICENSE for full text.
 
 ## Version History
+- 2.5: Settings view shows database info and added `db_tool.py` utility.
 - 2.4: Import script supports multiple files and shows summaries.
 - 2.3: Import tool compatible with Python 3.8+.
 - 2.2: Removed bundled database; added generation instructions and ignore rule.

--- a/tests/test_db_tool.py
+++ b/tests/test_db_tool.py
@@ -1,0 +1,37 @@
+# Version 1.0
+# History
+# - 1.0: Test db_tool build and copy logic.
+
+import os
+import sys
+from pathlib import Path
+
+import types
+import importlib
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / 'DragonShield' / 'python_scripts'
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import db_tool
+
+
+def test_db_tool_copies(monkeypatch, tmp_path):
+    copied = {}
+
+    def fake_copy(src, dst):
+        copied['src'] = str(src)
+        copied['dst'] = str(dst)
+
+    def fake_makedirs(path, exist_ok=True):
+        copied['dir'] = str(path)
+
+    monkeypatch.setattr(db_tool.shutil, 'copy2', fake_copy)
+    monkeypatch.setattr(db_tool.os, 'makedirs', fake_makedirs)
+    monkeypatch.setattr(db_tool.deploy_db, 'build_database', lambda *a, **k: 0)
+    monkeypatch.setattr(db_tool.deploy_db, 'parse_version', lambda p: 'test')
+
+    db_tool.main(['--target-dir', str(tmp_path)])
+
+    assert copied['src'].endswith('dragonshield.sqlite')
+    assert copied['dst'] == os.path.join(str(tmp_path), 'dragonshield.sqlite')
+    assert copied['dir'] == str(tmp_path)

--- a/tests/test_deploy_db.py
+++ b/tests/test_deploy_db.py
@@ -30,6 +30,8 @@ def test_main_copies_db(monkeypatch, tmp_path):
     monkeypatch.setattr(deploy_db.shutil, 'copy2', fake_copy)
     monkeypatch.setattr(deploy_db.os, 'makedirs', fake_makedirs)
     monkeypatch.setattr(deploy_db.os.path, 'expanduser', lambda p: str(tmp_path))
+    monkeypatch.setattr(deploy_db, 'build_database', lambda *a, **k: 0)
+    monkeypatch.setattr('builtins.input', lambda _: 'y')
 
     deploy_db.main()
 


### PR DESCRIPTION
## Summary
- show database file path and timestamps in SettingsView
- expose DB metadata in DatabaseManager
- provide `db_tool.py` CLI for manual database creation
- update tests for new tool and settings
- document new version 2.5 and features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853cb0d1ba88323a8e57616875f005c