### PR TITLE
Update DB path for production

### DIFF
--- a/DragonShield/python_scripts/db_tool.py
+++ b/DragonShield/python_scripts/db_tool.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 # python_scripts/db_tool.py
-# MARK: - Version 1.0
+# MARK: - Version 1.1
 # MARK: - History
+# - 1.0 -> 1.1: Updated default target directory to production container path.
 # - 1.0: Initial creation. Build database from schema and seed data and deploy to target directory.
 
 import argparse
@@ -9,13 +10,21 @@ import os
 import shutil
 from pathlib import Path
 
+DEFAULT_TARGET_DIR = (
+    "/Users/renekeller/Library/Containers/"
+    "com.rene.DragonShield/Data/Library/Application Support/DragonShield"
+)
+
 import deploy_db
 
 
 def main(argv=None):
     parser = argparse.ArgumentParser(description="Build and deploy Dragon Shield database")
-    parser.add_argument('--target-dir', default=os.path.expanduser(os.path.join('~', 'Library', 'Application Support', 'DragonShield')),
-                        help='Destination directory for dragonshield.sqlite')
+    parser.add_argument(
+        '--target-dir',
+        default=DEFAULT_TARGET_DIR,
+        help='Destination directory for dragonshield.sqlite'
+    )
     parser.add_argument('--schema', default=str(Path(__file__).resolve().parents[1] / 'database' / 'schema.sql'),
                         help='Path to schema.sql')
     parser.add_argument('--seed', default=str(Path(__file__).resolve().parents[1] / 'database' / 'schema.txt'),

--- a/DragonShield/python_scripts/deploy_db.py
+++ b/DragonShield/python_scripts/deploy_db.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 # python_scripts/deploy_db.py
-# MARK: - Version 1.2
+# MARK: - Version 1.3
 # MARK: - History
+# - 1.2 -> 1.3: Deploys database to container path used by the production app.
 # - 1.1 -> 1.2: Display detailed progress and final summary information.
 # - 1.0 -> 1.1: Builds DB from schema, stores version, and deploys to app support.
 
@@ -9,6 +10,11 @@ import os
 import shutil
 import sqlite3
 import re
+
+DEFAULT_TARGET_DIR = (
+    "/Users/renekeller/Library/Containers/"
+    "com.rene.DragonShield/Data/Library/Application Support/DragonShield"
+)
 
 def parse_version(sql_path: str) -> str:
     with open(sql_path, 'r', encoding='utf-8') as f:
@@ -57,7 +63,7 @@ def main() -> None:
     size = os.path.getsize(source_path)
     print(f"✅ Created database at {source_path} (v{version}, {table_count} tables, {size} bytes)")
 
-    dest_dir = os.path.expanduser(os.path.join('~', 'Library', 'Application Support', 'DragonShield'))
+    dest_dir = DEFAULT_TARGET_DIR
     os.makedirs(dest_dir, exist_ok=True)
     dest_path = os.path.join(dest_dir, 'dragonshield.sqlite')
     shutil.copy2(source_path, dest_path)

--- a/DragonShield/python_scripts/import_tool.py
+++ b/DragonShield/python_scripts/import_tool.py
@@ -1,7 +1,8 @@
 # python_scripts/import_tool.py
 
-# MARK: - Version 1.2
+# MARK: - Version 1.3
 # MARK: - History
+# - 1.2 -> 1.3: Updated default database path to production container location.
 # - 1.1 -> 1.2: Support importing multiple files in one run and print summary.
 # - 1.0 -> 1.1: Replace builtin generics with typing equivalents for
 #   compatibility with older Python versions.
@@ -17,8 +18,9 @@ from typing import Any, Dict, Tuple, Optional
 
 import zkb_parser  # existing parser in the same folder
 
-DB_PATH = os.path.expanduser(
-    os.path.join('~', 'Library', 'Application Support', 'DragonShield', 'dragonshield.sqlite')
+DB_PATH = os.path.join(
+    "/Users/renekeller/Library/Containers/com.rene.DragonShield/Data/Library/Application Support/DragonShield",
+    "dragonshield.sqlite",
 )
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dragon Shield – Personal Asset Management 🐉🛡️
 
-**Version 2.5** | June 18, 2025
+**Version 2.6** | June 18, 2025
 
 Dragon Shield is a native macOS application for private investors to track, analyze and document all assets entirely offline. Every byte of financial data remains on your Mac, encrypted in a local database—no cloud, no telemetry.
 
@@ -119,14 +119,14 @@ DragonShield/
 ## 💾 Database Information
 
 - **Type**: SQLite
-- **Path**: `~/Library/Application Support/DragonShield/dragonshield.sqlite` (generate with `python3 python_scripts/deploy_db.py`)
+- **Path**: `/Users/renekeller/Library/Containers/com.rene.DragonShield/Data/Library/Application Support/DragonShield/dragonshield.sqlite` (generate with `python3 python_scripts/deploy_db.py`)
 - **Encryption**: SQLCipher (AES-256)
 - **Schema**: `docs/schema.sql`
 - **Dev Key**: Temporary; do not use for production data
 
 ## Updating the Database
 
-Run the deploy script to rebuild the database from the schema and copy it to your Application Support folder. The script prints the schema version and final path:
+Run the deploy script to rebuild the database from the schema and copy it to the container's Application Support folder. The script prints the schema version and final path:
 
 ```bash
 python3 python_scripts/deploy_db.py
@@ -145,6 +145,7 @@ This is a personal passion project, but issues and PRs are welcome. Please keep 
 Dragon Shield is released under the MIT License. See LICENSE for full text.
 
 ## Version History
+- 2.6: Updated default database path to container directory.
 - 2.5: Settings view shows database info and added `db_tool.py` utility.
 - 2.4: Import script supports multiple files and shows summaries.
 - 2.3: Import tool compatible with Python 3.8+.

--- a/tests/test_db_tool.py
+++ b/tests/test_db_tool.py
@@ -1,5 +1,6 @@
-# Version 1.0
+# Version 1.1
 # History
+# - 1.0 -> 1.1: Adjusted for production container path constant.
 # - 1.0: Test db_tool build and copy logic.
 
 import os

--- a/tests/test_deploy_db.py
+++ b/tests/test_deploy_db.py
@@ -1,5 +1,6 @@
-# Version 1.1
+# Version 1.2
 # History
+# - 1.1 -> 1.2: Updated for container target path constant.
 # - 1.0: Initial test for deploy_db main copy behavior.
 # - 1.0 -> 1.1: Stub os.path.getsize to avoid missing file error.
 
@@ -30,7 +31,7 @@ def test_main_copies_db(monkeypatch, tmp_path):
 
     monkeypatch.setattr(deploy_db.shutil, 'copy2', fake_copy)
     monkeypatch.setattr(deploy_db.os, 'makedirs', fake_makedirs)
-    monkeypatch.setattr(deploy_db.os.path, 'expanduser', lambda p: str(tmp_path))
+    monkeypatch.setattr(deploy_db, 'DEFAULT_TARGET_DIR', str(tmp_path))
     monkeypatch.setattr(deploy_db.os.path, 'getsize', lambda p: 0)
     monkeypatch.setattr('builtins.input', lambda _: 'y')
 


### PR DESCRIPTION
## Summary
- update README for new container DB location
- deploy DB to container path
- update db_tool default deploy dir
- point import_tool to new container DB
- adjust tests for new path constants

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a156c63c83238c65ac85b74d632b