### PR TITLE
Add parser finder helper and tests

### DIFF
--- a/DragonShield/python_scripts/parser_utils.py
+++ b/DragonShield/python_scripts/parser_utils.py
@@ -1,0 +1,37 @@
+# python_scripts/parser_utils.py
+
+# MARK: - Version 1.0
+# MARK: - History
+# - 1.0: Initial creation with helper to locate bundled parser script.
+
+from pathlib import Path
+from typing import Tuple, List, Protocol
+
+
+class FileManagerProtocol(Protocol):
+    def exists(self, path: str) -> bool:
+        ...
+
+
+class DefaultFileManager:
+    @staticmethod
+    def exists(path: str) -> bool:  # pragma: no cover - simple wrapper
+        return Path(path).exists()
+
+
+def findParserScript(file_manager: FileManagerProtocol = DefaultFileManager()) -> Tuple[str, List[str]]:
+    """Return the path to the bundled parser script and list of checked paths."""
+    script_name = "zkb_parser.py"
+    module_dir = Path(__file__).resolve().parent
+    project_dir = module_dir.parents[2]
+    candidates = [
+        module_dir / script_name,
+        project_dir / 'python_scripts' / script_name,
+    ]
+    checked: List[str] = []
+    for path in candidates:
+        path_str = str(path)
+        checked.append(path_str)
+        if file_manager.exists(path_str):
+            return path_str, checked
+    raise FileNotFoundError(f"Parser script not found. Checked: {checked}")

--- a/tests/test_parser_utils.py
+++ b/tests/test_parser_utils.py
@@ -1,0 +1,48 @@
+# Version 1.0
+# History
+# - 1.0: Tests for parser_utils.findParserScript helper.
+
+from pathlib import Path
+import pytest
+
+from DragonShield.python_scripts import parser_utils
+
+
+class DummyFM:
+    def __init__(self, existing_path: str = ""):
+        self.existing_path = existing_path
+        self.calls = []
+
+    def exists(self, path: str) -> bool:
+        self.calls.append(path)
+        return path == self.existing_path
+
+
+def test_find_parser_first_candidate():
+    expected = str(Path(parser_utils.__file__).resolve().parent / "zkb_parser.py")
+    fm = DummyFM(existing_path=expected)
+
+    path, checked = parser_utils.findParserScript(fm)
+
+    assert path == expected
+    assert checked == [expected]
+
+
+def test_find_parser_second_candidate():
+    first = str(Path(parser_utils.__file__).resolve().parent / "zkb_parser.py")
+    second = str(Path(parser_utils.__file__).resolve().parents[3] / "python_scripts" / "zkb_parser.py")
+    fm = DummyFM(existing_path=second)
+
+    path, checked = parser_utils.findParserScript(fm)
+
+    assert path == second
+    assert checked == [first, second]
+
+
+def test_find_parser_missing():
+    fm = DummyFM()
+    with pytest.raises(FileNotFoundError) as exc:
+        parser_utils.findParserScript(fm)
+
+    msg = str(exc.value)
+    assert "Parser script not found" in msg


### PR DESCRIPTION
## Summary
- add `parser_utils.findParserScript` with FileManager protocol
- create unit tests covering parser path detection and missing parser error cases

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685650d136cc8323ae87e63e2de82921