### PR TITLE
Switch to Swift-based CSV parsing

### DIFF
--- a/DragonShield/BankRecordRepository.swift
+++ b/DragonShield/BankRecordRepository.swift
@@ -1,0 +1,37 @@
+// DragonShield/BankRecordRepository.swift
+// MARK: - Version 1.0.0.0
+// MARK: - History
+// - 0.0.0.0 -> 1.0.0.0: Initial repository for saving records using SQLite.
+
+import Foundation
+import SQLite3
+
+class BankRecordRepository {
+    private let db: OpaquePointer
+
+    init(db: OpaquePointer) {
+        self.db = db
+    }
+
+    func saveRecords(_ records: [MyBankRecord]) throws {
+        let sql = "INSERT INTO bankRecord (id, transactionDate, description, amount, currency, bankAccount) VALUES (?, ?, ?, ?, ?, ?)"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            throw NSError(domain: "BankRecordRepository", code: 1, userInfo: [NSLocalizedDescriptionKey: "Prepare failed"])
+        }
+        defer { sqlite3_finalize(stmt) }
+        let formatter = ISO8601DateFormatter()
+        for record in records {
+            sqlite3_bind_text(stmt, 1, record.id.uuidString, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_text(stmt, 2, formatter.string(from: record.transactionDate), -1, SQLITE_TRANSIENT)
+            sqlite3_bind_text(stmt, 3, record.description, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_double(stmt, 4, record.amount)
+            sqlite3_bind_text(stmt, 5, record.currency, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_text(stmt, 6, record.bankAccount, -1, SQLITE_TRANSIENT)
+            if sqlite3_step(stmt) != SQLITE_DONE {
+                throw NSError(domain: "BankRecordRepository", code: 2, userInfo: [NSLocalizedDescriptionKey: "Insert failed"])
+            }
+            sqlite3_reset(stmt)
+        }
+    }
+}

--- a/DragonShield/BankRecordRepository.swift
+++ b/DragonShield/BankRecordRepository.swift
@@ -14,6 +14,7 @@ class BankRecordRepository {
     }
 
     func saveRecords(_ records: [MyBankRecord]) throws {
+        let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
         let sql = "INSERT INTO bankRecord (id, transactionDate, description, amount, currency, bankAccount) VALUES (?, ?, ?, ?, ?, ?)"
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {

--- a/DragonShield/CSVParsingService.swift
+++ b/DragonShield/CSVParsingService.swift
@@ -1,0 +1,25 @@
+// DragonShield/CSVParsingService.swift
+// MARK: - Version 1.0.0.0
+// MARK: - History
+// - 0.0.0.0 -> 1.0.0.0: Initial basic CSV parsing implementation.
+
+import Foundation
+
+struct CSVParsingService {
+    func parse(csvString: String, delimiter: Character = ",") -> [[String: String]] {
+        var rows: [[String: String]] = []
+        let lines = csvString.split(whereSeparator: \n).map(String.init)
+        guard let headerLine = lines.first else { return rows }
+        let headers = headerLine.split(separator: delimiter).map { String($0).trimmingCharacters(in: .whitespaces) }
+        for line in lines.dropFirst() {
+            if line.trimmingCharacters(in: .whitespaces).isEmpty { continue }
+            let values = line.split(separator: delimiter, omittingEmptySubsequences: false).map { String($0).trimmingCharacters(in: .whitespaces) }
+            var dict: [String: String] = [:]
+            for (index, header) in headers.enumerated() {
+                dict[header] = index < values.count ? values[index] : ""
+            }
+            rows.append(dict)
+        }
+        return rows
+    }
+}

--- a/DragonShield/CSVProcessor.swift
+++ b/DragonShield/CSVProcessor.swift
@@ -1,0 +1,22 @@
+// DragonShield/CSVProcessor.swift
+// MARK: - Version 1.0.0.0
+// MARK: - History
+// - 0.0.0.0 -> 1.0.0.0: Initial orchestrator combining parsing and validation.
+
+import Foundation
+
+class CSVProcessor {
+    private let parser: CSVParsingService
+    private let validator: DataValidationService
+
+    init(parser: CSVParsingService = CSVParsingService(), validator: DataValidationService = DataValidationService()) {
+        self.parser = parser
+        self.validator = validator
+    }
+
+    func processCSVFile(url: URL) throws -> [MyBankRecord] {
+        let content = try String(contentsOf: url, encoding: .utf8)
+        let rawRows = parser.parse(csvString: content)
+        return try rawRows.map { try validator.validate(rawRecord: $0) }
+    }
+}

--- a/DragonShield/DataValidationService.swift
+++ b/DragonShield/DataValidationService.swift
@@ -1,0 +1,36 @@
+// DragonShield/DataValidationService.swift
+// MARK: - Version 1.0.0.0
+// MARK: - History
+// - 0.0.0.0 -> 1.0.0.0: Initial validation logic for parsed CSV rows.
+
+import Foundation
+
+enum ValidationError: Error {
+    case missingField(String)
+    case invalidDate(String)
+    case invalidNumber(String)
+}
+
+struct DataValidationService {
+    private let dateFormatter: DateFormatter
+
+    init() {
+        dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+    }
+
+    func validate(rawRecord: [String: String]) throws -> MyBankRecord {
+        guard let dateString = rawRecord["Date"], let date = dateFormatter.date(from: dateString) else {
+            throw ValidationError.invalidDate(rawRecord["Date"] ?? "")
+        }
+        guard let amountString = rawRecord["Amount"], let amount = Double(amountString) else {
+            throw ValidationError.invalidNumber(rawRecord["Amount"] ?? "")
+        }
+        guard let description = rawRecord["Description"] else {
+            throw ValidationError.missingField("Description")
+        }
+        let currency = rawRecord["Currency"] ?? "CHF"
+        let account = rawRecord["Account"] ?? ""
+        return MyBankRecord(transactionDate: date, description: description, amount: amount, currency: currency, bankAccount: account)
+    }
+}

--- a/DragonShield/ImportManager.swift
+++ b/DragonShield/ImportManager.swift
@@ -1,147 +1,48 @@
 // DragonShield/ImportManager.swift
-
-// MARK: - Version 1.11
+// MARK: - Version 2.0.0.0
 // MARK: - History
-// - 1.0 -> 1.1: Added fallback search for parser and error alert handling.
-// - 1.1 -> 1.2: Search bundle resource path before falling back to CWD.
-// - 1.2 -> 1.3: Improved parser lookup with debug logging and exit code checks.
-// - 1.3 -> 1.4: Return checked paths so UI can show detailed error messages.
-// - 1.4 -> 1.5: Added environment variable and Application Support search paths.
-// - 1.5 -> 1.6: Search PATH directories and parent folders for parser.
-// - 1.6 -> 1.7: Simplify lookup to module directory and run parser via -m.
-// - 1.7 -> 1.8: Add fallback search using the project source path.
-// - 1.8 -> 1.9: Invoke parser via /usr/bin/env to avoid sandbox python issues.
-// - 1.9 -> 1.10: Run parser using /usr/bin/python3 to bypass xcrun sandbox error.
-// - 1.10 -> 1.11: Allow custom Python interpreter path via env var and Homebrew locations.
-
+// - 1.11 -> 2.0.0.0: Rewritten to use native Swift CSV processing instead of Python parser.
 
 import Foundation
 import AppKit
 
-/// Manages document imports by invoking the bundled Python parser.
+/// Manages document imports using the native CSV processing pipeline.
 class ImportManager {
     static let shared = ImportManager()
-  
-    /// Attempts to locate the directory containing the Python parser module.
-    /// Returns that directory path and the list of checked locations.
-    private func findParserModuleDir() -> (path: String?, checked: [String]) {
-        var checked: [String] = []
-        let fm = FileManager.default
-
-        var candidates: [String] = []
-        func add(_ p: String?) { if let p = p, !candidates.contains(p) { candidates.append(p) } }
-
-        add(ProcessInfo.processInfo.environment["ZKB_PARSER_DIR"])
-        add(Bundle.main.url(forResource: "zkb_parser", withExtension: "py", subdirectory: "python_scripts")?.deletingLastPathComponent().path)
-        add(Bundle.main.resourceURL?.appendingPathComponent("python_scripts").path)
-        add(Bundle.main.bundleURL.appendingPathComponent("Contents/Resources/python_scripts").path)
-        add(Bundle.main.executableURL?.deletingLastPathComponent().appendingPathComponent("python_scripts").path)
-
-        // Search relative to the project source directory where this file resides
-        let sourceFileURL = URL(fileURLWithPath: #file)
-        var srcParent = sourceFileURL.deletingLastPathComponent()
-        add(srcParent.appendingPathComponent("python_scripts").path)
-        for _ in 0..<4 {
-            srcParent.deleteLastPathComponent()
-            add(srcParent.appendingPathComponent("python_scripts").path)
-            add(srcParent.appendingPathComponent("DragonShield/python_scripts").path)
-        }
-
-        var parentURL = Bundle.main.bundleURL
-        for _ in 0..<3 {
-            parentURL.deleteLastPathComponent()
-            add(parentURL.appendingPathComponent("python_scripts").path)
-            add(parentURL.appendingPathComponent("DragonShield/python_scripts").path)
-        }
-
-        let cwd = fm.currentDirectoryPath
-        add(cwd + "/python_scripts")
-        add(cwd + "/DragonShield/python_scripts")
-
-        for dir in candidates {
-            checked.append(dir)
-            if fm.fileExists(atPath: dir + "/zkb_parser.py") { return (dir, checked) }
-        }
-
-        print("❌ Parser module not found. Directories checked:\n - " + checked.joined(separator: "\n - "))
-        return (nil, checked)
+    private let csvProcessor = CSVProcessor()
+    private var repository: BankRecordRepository? {
+        guard let db = DatabaseManager().db else { return nil }
+        return BankRecordRepository(db: db)
     }
 
-    /// Determine which Python interpreter to use for running the parser.
-    /// Searches environment variables and common Homebrew locations before falling back.
-    private func resolvePythonPath() -> String {
-        let fm = FileManager.default
-        let env = ProcessInfo.processInfo.environment
-        let envCandidates = [env["DS_PYTHON_PATH"], env["PYTHON_BINARY"], env["PYTHON_PATH"]]
-        for candidate in envCandidates.compactMap({ $0 }) {
-            if fm.isExecutableFile(atPath: candidate) { return candidate }
-        }
-        let known = ["/opt/homebrew/bin/python3", "/usr/local/bin/python3", "/usr/bin/python3"]
-        for path in known {
-            if fm.isExecutableFile(atPath: path) { return path }
-        }
-        return "python3"
-    }
-
-    /// Parses a document using the Python parser script.
-    /// - Parameters:
-    ///   - url: URL of the document to parse.
-    ///   - completion: Called with the raw JSON string output or an error.
+    /// Parses a CSV document and saves the records to the database.
     func parseDocument(at url: URL, completion: @escaping (Result<String, Error>) -> Void) {
-        let result = findParserModuleDir()
-        guard let moduleDir = result.path else {
-            let pathsString = result.checked.map { "- " + $0 }.joined(separator: "\n")
-            let message = "Parser module not found. Directories checked:\n" + pathsString
-            completion(.failure(NSError(domain: "ImportManager", code: 1, userInfo: [NSLocalizedDescriptionKey: message])))
-            return
-        }
-
-        let pythonPath = resolvePythonPath()
-
-        print("Using parser directory: \(moduleDir)")
-        print("Using python interpreter: \(pythonPath)")
-
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: pythonPath)
-        process.arguments = ["-m", "zkb_parser", url.path]
-        process.environment = ["PYTHONPATH": moduleDir]
-
-
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = pipe
-
-        do {
-            try process.run()
-        } catch {
-            completion(.failure(error))
-            return
-        }
-
-        process.terminationHandler = { proc in
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            let output = String(data: data, encoding: .utf8) ?? ""
-            let exitCode = proc.terminationStatus
-            DispatchQueue.main.async {
-                if exitCode == 0 {
-                    completion(.success(output))
-                } else {
-                    let err = NSError(
-                        domain: "ImportManager",
-                        code: Int(exitCode),
-                        userInfo: [NSLocalizedDescriptionKey: "Parser exited with code \(exitCode). Output:\n\(output)"]
-                    )
-                    completion(.failure(err))
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                let records = try self.csvProcessor.processCSVFile(url: url)
+                if let repo = self.repository {
+                    try repo.saveRecords(records)
+                }
+                let encoder = JSONEncoder()
+                encoder.dateEncodingStrategy = .iso8601
+                let data = try encoder.encode(records)
+                let json = String(data: data, encoding: .utf8) ?? "[]"
+                DispatchQueue.main.async {
+                    completion(.success(json))
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    completion(.failure(error))
                 }
             }
         }
     }
 
-    /// Presents an open panel and invokes the parser on the selected file.
+    /// Presents an open panel and processes the selected CSV file.
     func openAndParseDocument() {
         let panel = NSOpenPanel()
         panel.allowsMultipleSelection = false
-        panel.allowedFileTypes = ["xlsx", "csv", "pdf"]
+        panel.allowedFileTypes = ["csv"]
         panel.begin { response in
             if response == .OK, let url = panel.url {
                 self.parseDocument(at: url) { result in

--- a/DragonShield/MyBankRecord.swift
+++ b/DragonShield/MyBankRecord.swift
@@ -1,0 +1,24 @@
+// DragonShield/MyBankRecord.swift
+// MARK: - Version 1.0.0.0
+// MARK: - History
+// - 0.0.0.0 -> 1.0.0.0: Initial creation of record model used for CSV imports.
+
+import Foundation
+
+struct MyBankRecord: Codable, Identifiable {
+    let id: UUID
+    let transactionDate: Date
+    let description: String
+    let amount: Double
+    let currency: String
+    let bankAccount: String
+
+    init(id: UUID = UUID(), transactionDate: Date, description: String, amount: Double, currency: String, bankAccount: String) {
+        self.id = id
+        self.transactionDate = transactionDate
+        self.description = description
+        self.amount = amount
+        self.currency = currency
+        self.bankAccount = bankAccount
+    }
+}


### PR DESCRIPTION
## Summary
- replace Python parser invocation with a native Swift implementation
- add CSV parsing, validation, and repository layers
- define `MyBankRecord` model for imported data
- store parsed records using SQLite

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685c1efd328c83239c36246774c1650a