### PR TITLE
Enhance ZKB import logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ __pycache__/
 DragonShield/Helpers/Version.swift
 # Version History
 # 1.1: Ignore generated database
+
+# Import logs
+import.log
+

--- a/DragonShield/LoggingService.swift
+++ b/DragonShield/LoggingService.swift
@@ -1,0 +1,48 @@
+// DragonShield/LoggingService.swift
+// MARK: - Version 1.0.0.0
+// MARK: - History
+// - 0.0.0.0 -> 1.0.0.0: Initial logging service writing messages to a log file.
+
+import Foundation
+
+final class LoggingService {
+    static let shared = LoggingService()
+
+    private let fileURL: URL
+    private let queue = DispatchQueue(label: "LoggingService")
+    private let formatter: ISO8601DateFormatter
+
+    private init() {
+        let dir = FileManager.default.temporaryDirectory
+        self.fileURL = dir.appendingPathComponent("import.log")
+        self.formatter = ISO8601DateFormatter()
+    }
+
+    func clearLog() {
+        queue.sync {
+            try? "".write(to: fileURL, atomically: true, encoding: .utf8)
+        }
+    }
+
+    func log(_ message: String) {
+        let timestamp = formatter.string(from: Date())
+        let line = "[\(timestamp)] \(message)\n"
+        queue.async {
+            if let handle = try? FileHandle(forWritingTo: self.fileURL) {
+                defer { try? handle.close() }
+                handle.seekToEndOfFile()
+                if let data = line.data(using: .utf8) {
+                    try? handle.write(contentsOf: data)
+                }
+            } else {
+                try? line.write(to: self.fileURL, atomically: true, encoding: .utf8)
+            }
+        }
+    }
+
+    func readLog() -> String {
+        queue.sync {
+            (try? String(contentsOf: fileURL)) ?? ""
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add LoggingService to persist import progress to a file
- log to file from ImportManager and forward progress to the UI
- provide detailed row-level progress in ZKBXLSXProcessor
- ignore generated import.log file

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f918dcda88323840ed6abdb314788