### PR TITLE
Implement OSLog logging for ZKB parser

### DIFF
--- a/DragonShield/Logger.swift
+++ b/DragonShield/Logger.swift
@@ -1,0 +1,21 @@
+// DragonShield/Logger.swift
+// MARK: - Version 1.0.0.0
+// MARK: - History
+// - 0.0.0.0 -> 1.0.0.0: Provide OSLog categories for the app.
+
+import Foundation
+import OSLog
+
+extension Logger {
+    /// Subsystem identifier for DragonShield logs.
+    private static var subsystem = Bundle.main.bundleIdentifier ?? "DragonShield"
+
+    /// General purpose logs.
+    static let general = Logger(subsystem: subsystem, category: "general")
+    /// Logs related to user interface components.
+    static let ui = Logger(subsystem: subsystem, category: "ui")
+    /// Logs produced during parsing operations.
+    static let parser = Logger(subsystem: subsystem, category: "parser")
+    /// Logs emitted by database operations.
+    static let database = Logger(subsystem: subsystem, category: "database")
+}

--- a/DragonShield/LoggingService.swift
+++ b/DragonShield/LoggingService.swift
@@ -1,9 +1,11 @@
 // DragonShield/LoggingService.swift
-// MARK: - Version 1.0.0.0
+// MARK: - Version 1.0.1.0
 // MARK: - History
 // - 0.0.0.0 -> 1.0.0.0: Initial logging service writing messages to a log file.
+// - 1.0.0.0 -> 1.0.1.0: Also forward messages to OSLog with categories.
 
 import Foundation
+import OSLog
 
 final class LoggingService {
     static let shared = LoggingService()
@@ -24,9 +26,10 @@ final class LoggingService {
         }
     }
 
-    func log(_ message: String) {
+    func log(_ message: String, logger: Logger = .general) {
         let timestamp = formatter.string(from: Date())
         let line = "[\(timestamp)] \(message)\n"
+        logger.info("\(message, privacy: .public)")
         queue.async {
             if let handle = try? FileHandle(forWritingTo: self.fileURL) {
                 defer { try? handle.close() }


### PR DESCRIPTION
## Summary
- introduce `Logger` extension with OSLog categories
- update `LoggingService` to forward messages to OSLog
- route ImportManager logs through OSLog categories
- add OSLog logging throughout `ZKBXLSXProcessor`

## Testing
- `PYTHONPATH=$(pwd) pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f95a01d348323b80a7f0b94a90b2f