### PR TITLE
Allow editing asset class for sub classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+- Allow editing Asset Class in Asset SubClass popup


### PR DESCRIPTION
## Summary
- enable choosing asset class in Add/Edit Asset SubClass forms
- allow DatabaseManager to fetch asset classes and update sub class class_id
- document change in CHANGELOG

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6862c3e4cccc8323be647f655ddef51e