### PR TITLE
fix subclass mapping and handle cash accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ All notable changes to this project will be documented in this file.
 - Condense import details popup row spacing
 - Default custody positions to "ZKB Custody Account" name
 - Fix saving position reports when no import session is created
+- Map ZKB categories to AssetSubClasses using documented table and treat cash
+  rows as accounts instead of instruments
 - Use single custody account for all parsed positions
 - Display a status alert after each position save attempt
 - Allow reimporting the same file by removing unique constraint on file hash

--- a/DragonShield/DatabaseManager+Instruments.swift
+++ b/DragonShield/DatabaseManager+Instruments.swift
@@ -253,4 +253,20 @@ extension DatabaseManager {
         }
         return nil
     }
+
+    /// Finds the instrument_id for the given ticker symbol, ignoring case.
+    func findInstrumentId(ticker: String) -> Int? {
+        let query = "SELECT instrument_id FROM Instruments WHERE ticker_symbol = ? COLLATE NOCASE LIMIT 1;"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK else {
+            print("❌ Failed to prepare findInstrumentId(ticker): \(String(cString: sqlite3_errmsg(db)))")
+            return nil
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_text(statement, 1, ticker, -1, nil)
+        if sqlite3_step(statement) == SQLITE_ROW {
+            return Int(sqlite3_column_int(statement, 0))
+        }
+        return nil
+    }
 }

--- a/DragonShield/ImportManager.swift
+++ b/DragonShield/ImportManager.swift
@@ -285,6 +285,26 @@ class ImportManager {
                 var success = 0
                 var failure = 0
                 for parsed in rows {
+                    if parsed.isCash {
+                        let accNumber = parsed.tickerSymbol ?? ""
+                        var cashId = self.dbManager.findAccountId(accountNumber: accNumber)
+                        if cashId == nil {
+                            let instId = self.dbManager.findInstitutionId(name: "ZKB") ?? 1
+                            let typeId = self.dbManager.findAccountTypeId(code: "CASH") ?? 5
+                            _ = self.dbManager.addAccount(accountName: parsed.accountName,
+                                                           institutionId: instId,
+                                                           accountNumber: accNumber,
+                                                           accountTypeId: typeId,
+                                                           currencyCode: parsed.currency,
+                                                           openingDate: nil,
+                                                           closingDate: nil,
+                                                           includeInPortfolio: true,
+                                                           isActive: true,
+                                                           notes: nil)
+                        }
+                        continue
+                    }
+
                     var action: RecordPromptResult = .save(parsed)
                     DispatchQueue.main.sync {
                         action = self.promptForPosition(record: parsed)

--- a/DragonShield/ZKBPositionParser.swift
+++ b/DragonShield/ZKBPositionParser.swift
@@ -106,17 +106,27 @@ struct ZKBPositionParser {
         return (summary, records)
     }
 
+    /// Maps the ZKB "Anlagekategorie" and "Asset-Unterkategorie" strings to an
+    /// `AssetSubClasses.sub_class_id` based on the table in
+    /// `docs/AssetClassDefinitionConcept.md`.
     private static func guessSubClassId(category: String, subCategory: String, isCash: Bool) -> Int? {
-        if isCash { return 1 }
+        if isCash { return 1 } // Cash
+
         let cat = category.lowercased()
         let sub = subCategory.lowercased()
-        if sub.contains("fonds") || sub.contains("etf") {
-            if cat.contains("aktien") { return 4 } // Equity ETF
-            if cat.contains("festverzinsliche") { return 9 } // Bond ETF
-        }
-        if cat.contains("aktien") { return 3 } // Single Stock
-        if cat.contains("festverzinsliche") { return 8 } // Bond
+
+        if sub.contains("geldmarktfonds") { return 2 } // Money Market Instruments
+        if sub.contains("aktienfonds") { return 5 } // Equity Fund
+        if sub.contains("etf") && cat.contains("aktien") { return 4 } // Equity ETF
+        if sub.contains("etf") && cat.contains("festverzinsliche") { return 9 } // Bond ETF
+        if sub.starts(with: "aktien") { return 3 } // Single Stock
+        if sub.contains("obligationenfonds") { return 10 } // Bond Fund
+        if sub.contains("obligationen") { return 8 } // Corporate Bond
+        if sub.contains("hedge") { return 15 } // Hedge Fund
+
         if cat.contains("liquid") { return 1 }
+        if cat.contains("aktien") { return 3 }
+        if cat.contains("festverzinsliche") { return 8 }
         if cat.contains("rohstoff") || cat.contains("immobil") || cat.contains("ai") { return 13 }
         return nil
     }


### PR DESCRIPTION
## Summary
- map ZKB categories to AssetSubClasses using documented table
- avoid creating instruments for cash rows and instead create cash accounts
- add helper to look up instruments by ticker symbol

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686adf35d44083239681cb7c748dad80