### PR TITLE
Fix cash handling in performance views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - Prompt for instrument details when new securities are imported
 - Automatically create ZKB custody and cash accounts when missing and save position reports
 - Fix unused variable warning when auto-creating ZKB cash accounts
+- Exclude cash instruments from performance and allocation views
 - Fix missing instrument popup and save newly added instruments
 - Fix instrument lookup to prompt when new securities are parsed
 - Review each parsed position with editable popup before saving and fix layout constraints

--- a/DragonShield/database/schema.sql
+++ b/DragonShield/database/schema.sql
@@ -1,6 +1,6 @@
 -- DragonShield/docs/schema.sql
 -- Dragon Shield Database Creation Script
--- Version 4.9 - Replaced InstrumentGroups with AssetClasses and AssetSubClasses
+-- Version 4.10 - Exclude cash from P&L views
 -- Created: 2025-05-24
 -- Updated: 2025-06-19
 --
@@ -431,6 +431,7 @@ WHERE t.transaction_date <= (SELECT value FROM Configuration WHERE key = 'as_of_
   AND a.include_in_portfolio = 1
   AND i.is_active = 1
   AND (p.include_in_total = 1 OR p.include_in_total IS NULL)
+  AND asc.sub_class_code != 'CASH'
 GROUP BY p.portfolio_id, i.instrument_id, a.account_id
 HAVING total_quantity > 0;
 
@@ -453,6 +454,7 @@ SELECT
         SUM(p.total_dividends_chf) / NULLIF(SUM(p.total_invested_chf), 0) * 100, 2
     ) as dividend_yield_percent
 FROM Positions p
+WHERE p.asset_sub_class != 'Cash'
 GROUP BY p.portfolio_name, p.asset_class
 ORDER BY p.portfolio_name, p.asset_class;
 

--- a/DragonShield/database/schema.txt
+++ b/DragonShield/database/schema.txt
@@ -26,8 +26,8 @@ INSERT INTO Configuration (key, value, data_type, description) VALUES
 ('table_row_padding', '12.0', 'number', 'Vertical padding inside table rows in points'),
 ('table_font_size', '14.0', 'number', 'Font size for text in data table rows (in points)'),
 -- Removed duplicate db_version entry causing UNIQUE constraint failure
--- Version 4.9
-('db_version', '4.9', 'string', 'Database schema version');
+-- Version 4.10
+('db_version', '4.10', 'string', 'Database schema version');
 INSERT INTO Currencies (currency_code, currency_name, currency_symbol, api_supported) VALUES
 ('CHF', 'Swiss Franc', 'CHF', 0),
 ('EUR', 'Euro', '€', 1),

--- a/DragonShield/python_scripts/zkb_parser.py
+++ b/DragonShield/python_scripts/zkb_parser.py
@@ -259,6 +259,8 @@ def process_file(filepath: str, sheet_name_or_index: Optional[Any] = None) -> in
                 record_data["balance"] = parse_number_from_cell_value(get_raw_val_from_tuple(COL_ANZAHL_NOMINAL))
                 record_data["value_in_chf"] = parse_number_from_cell_value(get_raw_val_from_tuple(COL_WERT_CHF))
                 record_data["fx_rate_to_chf"] = parse_number_from_cell_value(get_raw_val_from_tuple(COL_DEVISENKURS))
+                record_data["asset_class_code"] = "LIQ"
+                record_data["asset_sub_class_code"] = "CASH"
             else: 
                 # (Security holding processing logic largely the same)
                 parsed_data["summary"]["security_holding_records"] += 1


### PR DESCRIPTION
## Summary
- exclude CASH subclass from portfolio summary and instrument performance
- tag cash account records with `LIQ`/`CASH` codes during parsing
- bump database version to 4.10

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cbeaac00c8323aad97ec66d82cf2f