### PR TITLE
Fix import dialog spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,3 +86,4 @@ All notable changes to this project will be documented in this file.
 - Guess asset sub-class from statement categories when adding new instruments
 - Fix asset sub-class dropdown defaulting to Cash when prompting for new instruments
 - Document asset class concept version 2.1 with ZKB mapping
+- Reduce vertical spacing in import dialogs so all fields fit without scrolling

--- a/DragonShield/Views/ImportSummaryView.swift
+++ b/DragonShield/Views/ImportSummaryView.swift
@@ -66,7 +66,7 @@ struct ImportSummaryView: View {
     }
 
     private func infoRow(title: String, value: String, icon: String) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
+        VStack(alignment: .leading, spacing: 1) {
             HStack(spacing: 4) {
                 Image(systemName: icon)
                     .font(.system(size: 12))
@@ -79,7 +79,7 @@ struct ImportSummaryView: View {
             Text(value)
                 .font(.system(size: 14))
         }
-        .padding(.vertical, 1)
+        .padding(.vertical, 0)
         .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
     }
 }

--- a/DragonShield/Views/PositionReviewView.swift
+++ b/DragonShield/Views/PositionReviewView.swift
@@ -78,7 +78,7 @@ struct PositionReviewView: View {
         icon: String,
         isRequired: Bool
     ) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: 2) {
             HStack {
                 Image(systemName: icon)
                     .font(.system(size: 13))

--- a/DragonShield/helpers/ViewModifiers.swift
+++ b/DragonShield/helpers/ViewModifiers.swift
@@ -21,7 +21,8 @@ struct CompactFormSection: ViewModifier {
     let color: Color
     func body(content: Content) -> some View {
         content
-            .padding(12)
+            .padding(.vertical, 6)
+            .padding(.horizontal, 12)
             .background(glassMorphismBackground(color: color))
             .clipShape(RoundedRectangle(cornerRadius: 12))
             .overlay(RoundedRectangle(cornerRadius: 12).stroke(color.opacity(0.2), lineWidth: 1))


### PR DESCRIPTION
## Summary
- reduce vertical padding for `CompactFormSection`
- tighten rows in `ImportSummaryView`
- tighten rows in `PositionReviewView`
- document spacing fix in changelog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'DragonShield')*

------
https://chatgpt.com/codex/tasks/task_e_686cc5fa51288323be74875f1eb9c6fb