### PR TITLE
Add OpenAI function calling shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Delete position reports for any institution directly from the Positions view
+- Added GPT shell with OpenAI function calling and JSON schema validation
 - Delete existing ZKB position reports for all ZKB accounts before importing new positions
 - Replace `account_id` with `institution_id` in `ImportSessions` table
 - Fix incorrect parameter label when starting import sessions

--- a/DragonShield/python_scripts/gpt_shell.py
+++ b/DragonShield/python_scripts/gpt_shell.py
@@ -1,0 +1,89 @@
+import argparse
+import json
+from typing import Any, Dict
+
+import openai
+from jsonschema import validate, ValidationError
+
+# Example function schema definitions
+FUNCTIONS: Dict[str, Dict[str, Any]] = {
+    "echo": {
+        "description": "Return the provided text.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "text": {"type": "string", "description": "Text to echo back"},
+            },
+            "required": ["text"],
+        },
+    },
+}
+
+MODEL = "gpt-3.5-turbo-0613"
+
+
+def list_functions() -> None:
+    for name, desc in FUNCTIONS.items():
+        print(f"{name}: {desc.get('description', '')}")
+
+
+def get_schema(name: str) -> Dict[str, Any]:
+    if name not in FUNCTIONS:
+        raise KeyError(f"Unknown function: {name}")
+    return FUNCTIONS[name]["parameters"]
+
+
+def validate_params(name: str, params: Dict[str, Any]) -> None:
+    schema = get_schema(name)
+    validate(params, schema)
+
+
+def call_function(name: str, params: Dict[str, Any]) -> Dict[str, Any]:
+    descriptor = {"name": name, **FUNCTIONS[name]}
+    response = openai.ChatCompletion.create(
+        model=MODEL,
+        messages=[{"role": "user", "content": f"Call function {name}"}],
+        functions=[descriptor],
+        function_call={"name": name, "arguments": json.dumps(params)},
+    )
+    message = response["choices"][0]["message"]
+    fc = message.get("function_call")
+    if fc:
+        return json.loads(fc.get("arguments", "{}"))
+    return {}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Simple OpenAI function shell")
+    sub = parser.add_subparsers(dest="cmd")
+
+    sub.add_parser("list", help="List available functions")
+
+    schema_p = sub.add_parser("schema", help="Show JSON schema for function")
+    schema_p.add_argument("name")
+
+    call_p = sub.add_parser("call", help="Call a function")
+    call_p.add_argument("name")
+    call_p.add_argument("params", help="JSON encoded parameters")
+
+    args = parser.parse_args()
+
+    if args.cmd == "list":
+        list_functions()
+    elif args.cmd == "schema":
+        print(json.dumps(get_schema(args.name), indent=2))
+    elif args.cmd == "call":
+        params = json.loads(args.params)
+        try:
+            validate_params(args.name, params)
+        except ValidationError as e:
+            print(f"Parameter validation failed: {e.message}")
+            return
+        result = call_function(args.name, params)
+        print(json.dumps(result, indent=2))
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/README.md
+++ b/README.md
@@ -132,6 +132,15 @@ Run the deploy script to rebuild the database from the schema and copy it to the
 python3 python_scripts/deploy_db.py
 ```
 
+
+### GPT Shell
+A small CLI to experiment with OpenAI function calls. Requires `OPENAI_API_KEY` in the environment.
+
+```bash
+python3 python_scripts/gpt_shell.py list
+python3 python_scripts/gpt_shell.py schema echo
+python3 python_scripts/gpt_shell.py call echo '{"text": "hello"}'
+```
 ## 💡 Usage
 
 At present the application must be run from Xcode. Future releases will ship a signed & notarized .app bundle.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ pysqlcipher3
 pandas
 openpyxl
 pdfplumber
+openai
+jsonschema

--- a/tests/test_gpt_shell.py
+++ b/tests/test_gpt_shell.py
@@ -1,0 +1,52 @@
+import json
+
+from pathlib import Path
+import pytest
+import types
+import sys
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPT_DIR))
+
+# Provide stub openai module if not installed
+if "openai" not in sys.modules:
+    sys.modules["openai"] = types.SimpleNamespace(ChatCompletion=types.SimpleNamespace(create=lambda **_: None))
+if "jsonschema" not in sys.modules:
+    sys.modules["jsonschema"] = types.SimpleNamespace(validate=lambda *a, **k: None, ValidationError=Exception)
+
+from DragonShield.python_scripts import gpt_shell
+
+
+def test_get_schema():
+    schema = gpt_shell.get_schema("echo")
+    assert "properties" in schema
+
+
+def test_validate_and_call(monkeypatch):
+    called = {}
+
+    def fake_create(**kwargs):
+        called.update(kwargs)
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "function_call": {
+                            "arguments": json.dumps({"text": "hi"})
+                        }
+                    }
+                }
+            ]
+        }
+
+    monkeypatch.setattr(gpt_shell.openai.ChatCompletion, "create", fake_create)
+
+    params = {"text": "hi"}
+    gpt_shell.validate_params("echo", params)
+    result = gpt_shell.call_function("echo", params)
+
+    assert result == {"text": "hi"}
+    assert called["function_call"]["name"] == "echo"
+
+
+

--- a/tests/test_parser_utils.py
+++ b/tests/test_parser_utils.py
@@ -3,7 +3,11 @@
 # - 1.0: Tests for parser_utils.findParserScript helper.
 
 from pathlib import Path
+import sys
 import pytest
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPT_DIR))
 
 from DragonShield.python_scripts import parser_utils
 
@@ -46,3 +50,4 @@ def test_find_parser_missing():
 
     msg = str(exc.value)
     assert "Parser script not found" in msg
+


### PR DESCRIPTION
## Summary
- provide a package init so Python tests can import DragonShield
- implement `gpt_shell.py` with OpenAI function calling and jsonschema validation
- document GPT shell usage in README
- add stubbed tests for the shell
- update dependencies and changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d71339ab083239ec9112ed67f1e7e