### PR TITLE
Add operational fields to institutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Log mapped Asset-Unterkategorie values to AssetSubClass during ZKB import
 - Allow editing Asset Class in Asset SubClass popup
 - Create cash accounts during position import and record deposits
+- Extend Institutions with contact info, currency and country fields
 - Rename cash account names using institution and currency codes
 - Restyled Institutions maintenance window for consistent look and feel
 - Retry account prompt until a custody account is created during position import

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Create cash accounts during position import and record deposits
 - Extend Institutions with contact info, currency and country fields
 - Fix deprecated isoRegionCodes warning in Institutions view
+- Add sample institutions dataset for testing
 - Rename cash account names using institution and currency codes
 - Restyled Institutions maintenance window for consistent look and feel
 - Retry account prompt until a custody account is created during position import

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Allow editing Asset Class in Asset SubClass popup
 - Create cash accounts during position import and record deposits
 - Extend Institutions with contact info, currency and country fields
+- Fix deprecated isoRegionCodes warning in Institutions view
 - Rename cash account names using institution and currency codes
 - Restyled Institutions maintenance window for consistent look and feel
 - Retry account prompt until a custody account is created during position import

--- a/DragonShield/Views/InstitutionsView.swift
+++ b/DragonShield/Views/InstitutionsView.swift
@@ -170,7 +170,7 @@ struct AddInstitutionView: View {
         .padding().frame(width: 400, height: 500)
         .onAppear {
             availableCurrencies = dbManager.fetchActiveCurrencies()
-            availableCountries = Locale.isoRegionCodes.sorted()
+            availableCountries = Locale.Region.isoRegions.map(\.identifier).sorted()
         }
         .alert("Result", isPresented: $showingAlert) { Button("OK") { if alertMessage.hasPrefix("✅") { presentationMode.wrappedValue.dismiss() } } } message: { Text(alertMessage) }
     }
@@ -258,7 +258,7 @@ struct EditInstitutionView: View {
         .onAppear {
             if !loaded { load() }
             availableCurrencies = dbManager.fetchActiveCurrencies()
-            availableCountries = Locale.isoRegionCodes.sorted()
+            availableCountries = Locale.Region.isoRegions.map(\.identifier).sorted()
         }
         .alert("Result", isPresented: $showingAlert) { Button("OK") { if alertMessage.hasPrefix("✅") { presentationMode.wrappedValue.dismiss() } } } message: { Text(alertMessage) }
     }

--- a/DragonShield/database/schema.sql
+++ b/DragonShield/database/schema.sql
@@ -1,6 +1,6 @@
 -- DragonShield/docs/schema.sql
 -- Dragon Shield Database Creation Script
--- Version 4.10 - Exclude cash from P&L views
+-- Version 4.11 - Extend Institutions table with operational fields
 -- Created: 2025-05-24
 -- Updated: 2025-06-19
 --
@@ -211,6 +211,10 @@ CREATE TABLE Institutions (
     institution_type TEXT,
     bic TEXT,
     website TEXT,
+    contact_info TEXT,
+    default_currency TEXT CHECK (LENGTH(default_currency) = 3),
+    country_code TEXT CHECK (LENGTH(country_code) = 2),
+    notes TEXT,
     is_active BOOLEAN DEFAULT 1,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP

--- a/DragonShield/database/schema.txt
+++ b/DragonShield/database/schema.txt
@@ -26,8 +26,8 @@ INSERT INTO Configuration (key, value, data_type, description) VALUES
 ('table_row_padding', '12.0', 'number', 'Vertical padding inside table rows in points'),
 ('table_font_size', '14.0', 'number', 'Font size for text in data table rows (in points)'),
 -- Removed duplicate db_version entry causing UNIQUE constraint failure
--- Version 4.10
-('db_version', '4.10', 'string', 'Database schema version');
+-- Version 4.11
+('db_version', '4.11', 'string', 'Database schema version');
 INSERT INTO Currencies (currency_code, currency_name, currency_symbol, api_supported) VALUES
 ('CHF', 'Swiss Franc', 'CHF', 0),
 ('EUR', 'Euro', '€', 1),

--- a/DragonShield/test_data/institutions.sql
+++ b/DragonShield/test_data/institutions.sql
@@ -1,0 +1,25 @@
+-- Sample institutions for testing
+INSERT INTO Institutions (
+    institution_id,
+    institution_name,
+    institution_type,
+    bic,
+    website,
+    contact_info,
+    default_currency,
+    country_code,
+    notes,
+    is_active,
+    created_at,
+    updated_at
+) VALUES
+    (1, 'ZKB', 'BANK', 'ZKBKCHZZ80A', 'https://www.zkb.ch', '0844 848 848', 'CHF', 'CH', NULL, 1, '2025-07-08 00:00:00', '2025-07-08 00:00:00'),
+    (2, 'Credit Suisse', 'BANK', 'CRESCHZZ80A', 'https://www.credit-suisse.com', '0848 880 084', 'CHF', 'CH', NULL, 1, '2025-07-08 00:00:00', '2025-07-08 00:00:00'),
+    (3, 'Sygnum Bank', 'BANK', 'SYGNCHZZ', 'https://www.sygnum.com', 'info@sygnum.com', 'CHF', 'CH', 'Digital asset bank', 1, '2025-07-08 00:00:00', '2025-07-08 00:00:00'),
+    (4, 'Graubündner Kantonalbank', 'BANK', 'GRKBCH2270A', 'https://www.gkb.ch', 'info@gkb.ch', 'CHF', 'CH', 'Regional cantonal bank', 1, '2025-07-08 00:00:00', '2025-07-08 00:00:00'),
+    (5, 'Standard Chartered Bank Singapore', 'BANK', 'SCBLSGSG', 'https://www.sc.com/sg', 'contactus.sg@sc.com', 'SGD', 'SG', 'International bank', 1, '2025-07-08 00:00:00', '2025-07-08 00:00:00'),
+    (6, 'Bitbox2 Bitcoin Wallet', 'WALLET', NULL, 'https://shiftcrypto.ch/bitbox', 'support@shiftcrypto.ch', 'BTC', 'CH', 'Self-custody hardware wallet', 1, '2025-07-08 00:00:00', '2025-07-08 00:00:00'),
+    (7, 'Ledger Wallet', 'WALLET', NULL, 'https://www.ledger.com', 'support@ledger.com', 'BTC', 'FR', 'Self-custody hardware wallet', 1, '2025-07-08 00:00:00', '2025-07-08 00:00:00'),
+    (8, 'Swisspeers', 'MARKETPLACE', NULL, 'https://www.swisspeers.ch', 'info@swisspeers.ch', 'CHF', 'CH', 'P2P lending marketplace', 1, '2025-07-08 00:00:00', '2025-07-08 00:00:00'),
+    (9, 'Crypto.com Crypto Exchange', 'CRYPTO_EXCHANGE', NULL, 'https://crypto.com', 'contact@crypto.com', 'USD', 'SG', 'Crypto exchange', 1, '2025-07-08 00:00:00', '2025-07-08 00:00:00'),
+    (10, 'ColdCard Mk4 Cold Wallet', 'WALLET', NULL, 'https://coldcard.com', 'support@coinkite.com', 'BTC', 'CA', 'Self-custody hardware wallet', 1, '2025-07-08 00:00:00', '2025-07-08 00:00:00');


### PR DESCRIPTION
## Summary
- extend database schema with institution contact info, default currency, country and notes
- record db version 4.11 in seed data
- add columns and bindings in `InstitutionData`
- enhance institutions UI with new fields and badges

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d761a3ca88323a21bce2ef3fcdaa7