### PR TITLE
Add allocation variance heatmap to dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Restyle Currency Maintenance window and update title to "Currency Maintenance"
 - Log mapped Asset-Unterkategorie values to AssetSubClass during ZKB import
 - Add asset allocation variance heatmap tile to dashboard
+- Fix overlapping labels and gesture issues in allocation heatmap
 - Allow editing Asset Class in Asset SubClass popup
 - Create cash accounts during position import and record deposits
 - Extend Institutions with contact info, currency and country fields

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Store import sessions by institution and value date, tracking duplicate rows
 - Restyle Currency Maintenance window and update title to "Currency Maintenance"
 - Log mapped Asset-Unterkategorie values to AssetSubClass during ZKB import
+- Add asset allocation variance heatmap tile to dashboard
 - Allow editing Asset Class in Asset SubClass popup
 - Create cash accounts during position import and record deposits
 - Extend Institutions with contact info, currency and country fields

--- a/DragonShield/DatabaseManager+Dashboard.swift
+++ b/DragonShield/DatabaseManager+Dashboard.swift
@@ -33,6 +33,15 @@ struct OptionHoldingItem: Identifiable {
     let type: String // Call or Put
 }
 
+struct AssetAllocationVarianceItem: Identifiable {
+    let id: String
+    let assetClassName: String
+    let currentPercent: Double
+    let targetPercent: Double
+    let currentValue: Double
+    let lastRebalance: Date?
+}
+
 extension DatabaseManager {
 
     func fetchLargestPositions(count: Int = 5) -> [LargestPositionItem] {
@@ -75,5 +84,18 @@ extension DatabaseManager {
             OptionHoldingItem(id: "AAPL2512C150", name: "AAPL DEC 2025 150C", quantity: 10, currentPrice: 5.50, expiryDate: oneMonthFromNow, strikePrice: 150.00, underlyingAsset: "AAPL", type: "Call"),
             OptionHoldingItem(id: "SPY2509P400", name: "SPY SEP 2025 400P", quantity: 5, currentPrice: 8.20, expiryDate: threeMonthsFromNow, strikePrice: 400.00, underlyingAsset: "SPY", type: "Put"),
         ]
+    }
+
+    func fetchAssetAllocationVariance() -> (items: [AssetAllocationVarianceItem], portfolioValue: Double) {
+        print("ℹ️ fetchAssetAllocationVariance() called - returning sample data.")
+
+        let portfolioValue = 56000.0
+        let allocations = [
+            AssetAllocationVarianceItem(id: "Equity", assetClassName: "Equities", currentPercent: (35500/portfolioValue)*100, targetPercent: 60, currentValue: 35500, lastRebalance: Date(timeIntervalSinceNow: -60*60*24*30)),
+            AssetAllocationVarianceItem(id: "ETF", assetClassName: "ETFs", currentPercent: (11000/portfolioValue)*100, targetPercent: 25, currentValue: 11000, lastRebalance: Date(timeIntervalSinceNow: -60*60*24*60)),
+            AssetAllocationVarianceItem(id: "Crypto", assetClassName: "Cryptocurrencies", currentPercent: (9500/portfolioValue)*100, targetPercent: 10, currentValue: 9500, lastRebalance: Date(timeIntervalSinceNow: -60*60*24*10))
+        ]
+
+        return (allocations, portfolioValue)
     }
 }

--- a/DragonShield/Views/AllocationHeatMapTile.swift
+++ b/DragonShield/Views/AllocationHeatMapTile.swift
@@ -13,42 +13,61 @@ struct AllocationHeatMapTile: View {
         let rect: CGRect
     }
 
-    var body: some View {
-        GeometryReader { geo in
-            let layouts = computeLayout(in: geo.size)
-            ZStack {
-                ForEach(layouts) { layout in
-                    Rectangle()
-                        .fill(color(for: layout.item))
-                        .frame(width: layout.rect.width, height: layout.rect.height)
-                        .position(x: layout.rect.midX, y: layout.rect.midY)
-                        .overlay(
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(layout.item.assetClassName)
-                                    .font(.caption2)
-                                    .lineLimit(1)
-                                Text(String(format: "%.1f%% / %.1f%%", layout.item.currentPercent, layout.item.targetPercent))
-                                    .font(.caption2)
-                                Text(String(format: "%+.1f%%", layout.item.currentPercent - layout.item.targetPercent))
-                                    .font(.caption2)
-                            }
-                            .padding(4)
-                            .foregroundColor(.white), alignment: .topLeading
-                        )
-                        .onHover { inside in
-                            hovered = inside ? layout.item : nil
-                        }
-                        .onTapGesture(count: 2) {
-                            showDetail = layout.item
-                        }
+    struct HeatMapCell: View {
+        let layout: LayoutItem
+        @Binding var hovered: AssetAllocationVarianceItem?
+        @Binding var showDetail: AssetAllocationVarianceItem?
+        let portfolioValue: Double
+        let color: Color
+
+        private var isHovered: Binding<AssetAllocationVarianceItem?> {
+            Binding {
+                hovered?.id == layout.item.id ? hovered : nil
+            } set: { newValue in
+                hovered = newValue
+            }
+        }
+
+        var body: some View {
+            ZStack(alignment: .topLeading) {
+                Rectangle()
+                    .fill(color)
+                if layout.item.currentPercent >= 1 {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(layout.item.assetClassName)
+                            .font(.caption2)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.5)
+                        Text(String(format: "%.1f%% / %.1f%%",
+                                      layout.item.currentPercent,
+                                      layout.item.targetPercent))
+                            .font(.caption2)
+                        Text(String(format: "%+.1f%%",
+                                      layout.item.currentPercent - layout.item.targetPercent))
+                            .font(.caption2)
+                    }
+                    .padding(4)
+                    .foregroundColor(.white)
+                    .clipped()
                 }
             }
-            .popover(item: $hovered) { item in
+            .mask(Rectangle())
+            .frame(width: layout.rect.width, height: layout.rect.height)
+            .position(x: layout.rect.midX, y: layout.rect.midY)
+            .contentShape(Rectangle())
+            .onHover { inside in
+                hovered = inside ? layout.item : (hovered?.id == layout.item.id ? nil : hovered)
+            }
+            .onTapGesture(count: 2) {
+                showDetail = layout.item
+            }
+            .popover(item: isHovered) { item in
                 VStack(alignment: .leading, spacing: 6) {
                     Text(item.assetClassName).font(.headline)
                     Text(String(format: "Current: %.1f%%", item.currentPercent))
                     Text(String(format: "Target: %.1f%%", item.targetPercent))
-                    Text(String(format: "Deviation: %+.1f%%", item.currentPercent - item.targetPercent))
+                    Text(String(format: "Deviation: %+.1f%%",
+                                 item.currentPercent - item.targetPercent))
                     if let date = item.lastRebalance {
                         Text("Last Rebalance: \(date, style: .date)")
                     }
@@ -57,12 +76,27 @@ struct AllocationHeatMapTile: View {
                 }
                 .padding()
             }
-            .sheet(item: $showDetail) { item in
-                Text("Detailed view for \(item.assetClassName)")
-                    .padding()
+        }
+    }
+
+    var body: some View {
+        GeometryReader { geo in
+            let layouts = computeLayout(in: geo.size)
+            ZStack {
+                ForEach(layouts) { layout in
+                    HeatMapCell(layout: layout,
+                               hovered: $hovered,
+                               showDetail: $showDetail,
+                               portfolioValue: portfolioValue,
+                               color: color(for: layout.item))
+                }
             }
         }
         .frame(minWidth: 300, minHeight: 200)
+        .sheet(item: $showDetail) { item in
+            Text("Detailed view for \(item.assetClassName)")
+                .padding()
+        }
     }
 
     private func color(for item: AssetAllocationVarianceItem) -> Color {

--- a/DragonShield/Views/AllocationHeatMapTile.swift
+++ b/DragonShield/Views/AllocationHeatMapTile.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+
+struct AllocationHeatMapTile: View {
+    let items: [AssetAllocationVarianceItem]
+    let portfolioValue: Double
+
+    @State private var hovered: AssetAllocationVarianceItem?
+    @State private var showDetail: AssetAllocationVarianceItem?
+
+    struct LayoutItem: Identifiable {
+        let id = UUID()
+        let item: AssetAllocationVarianceItem
+        let rect: CGRect
+    }
+
+    var body: some View {
+        GeometryReader { geo in
+            let layouts = computeLayout(in: geo.size)
+            ZStack {
+                ForEach(layouts) { layout in
+                    Rectangle()
+                        .fill(color(for: layout.item))
+                        .frame(width: layout.rect.width, height: layout.rect.height)
+                        .position(x: layout.rect.midX, y: layout.rect.midY)
+                        .overlay(
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(layout.item.assetClassName)
+                                    .font(.caption2)
+                                    .lineLimit(1)
+                                Text(String(format: "%.1f%% / %.1f%%", layout.item.currentPercent, layout.item.targetPercent))
+                                    .font(.caption2)
+                                Text(String(format: "%+.1f%%", layout.item.currentPercent - layout.item.targetPercent))
+                                    .font(.caption2)
+                            }
+                            .padding(4)
+                            .foregroundColor(.white), alignment: .topLeading
+                        )
+                        .onHover { inside in
+                            hovered = inside ? layout.item : nil
+                        }
+                        .onTapGesture(count: 2) {
+                            showDetail = layout.item
+                        }
+                }
+            }
+            .popover(item: $hovered) { item in
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(item.assetClassName).font(.headline)
+                    Text(String(format: "Current: %.1f%%", item.currentPercent))
+                    Text(String(format: "Target: %.1f%%", item.targetPercent))
+                    Text(String(format: "Deviation: %+.1f%%", item.currentPercent - item.targetPercent))
+                    if let date = item.lastRebalance {
+                        Text("Last Rebalance: \(date, style: .date)")
+                    }
+                    let amount = (item.targetPercent - item.currentPercent) / 100 * portfolioValue
+                    Text(String(format: "Rebalance: %.2f CHF", amount))
+                }
+                .padding()
+            }
+            .sheet(item: $showDetail) { item in
+                Text("Detailed view for \(item.assetClassName)")
+                    .padding()
+            }
+        }
+        .frame(minWidth: 300, minHeight: 200)
+    }
+
+    private func color(for item: AssetAllocationVarianceItem) -> Color {
+        let delta = abs(item.currentPercent - item.targetPercent)
+        switch delta {
+        case ..<2:
+            return .success
+        case 2..<5:
+            return .warning
+        case 5..<10:
+            return .orange
+        default:
+            return .error
+        }
+    }
+
+    private func computeLayout(in size: CGSize) -> [LayoutItem] {
+        var layouts: [LayoutItem] = []
+        let total = items.map { $0.currentPercent }.reduce(0, +)
+        var remainingRect = CGRect(origin: .zero, size: size)
+        var horizontal = size.width > size.height
+        for item in items.sorted(by: { $0.currentPercent > $1.currentPercent }) {
+            let ratio = item.currentPercent / total
+            if horizontal {
+                let width = remainingRect.width * CGFloat(ratio)
+                let rect = CGRect(x: remainingRect.minX, y: remainingRect.minY, width: width, height: remainingRect.height)
+                remainingRect.origin.x += width
+                remainingRect.size.width -= width
+                layouts.append(LayoutItem(item: item, rect: rect))
+            } else {
+                let height = remainingRect.height * CGFloat(ratio)
+                let rect = CGRect(x: remainingRect.minX, y: remainingRect.minY, width: remainingRect.width, height: height)
+                remainingRect.origin.y += height
+                remainingRect.size.height -= height
+                layouts.append(LayoutItem(item: item, rect: rect))
+            }
+            horizontal.toggle()
+        }
+        return layouts
+    }
+}
+
+struct AllocationHeatMapTile_Previews: PreviewProvider {
+    static var previews: some View {
+        AllocationHeatMapTile(items: [
+            AssetAllocationVarianceItem(id: "Equity", assetClassName: "Equities", currentPercent: 55, targetPercent: 60, currentValue: 35500, lastRebalance: Date()),
+            AssetAllocationVarianceItem(id: "ETF", assetClassName: "ETFs", currentPercent: 20, targetPercent: 25, currentValue: 11000, lastRebalance: Date()),
+            AssetAllocationVarianceItem(id: "Crypto", assetClassName: "Crypto", currentPercent: 15, targetPercent: 10, currentValue: 9500, lastRebalance: Date())
+        ], portfolioValue: 56000)
+    }
+}

--- a/DragonShield/Views/DashboardView.swift
+++ b/DragonShield/Views/DashboardView.swift
@@ -13,6 +13,8 @@ struct DashboardView: View {
     @State private var largestPositions: [LargestPositionItem] = []
     @State private var assetAllocations: [AssetClassAllocationItem] = []
     @State private var optionHoldings: [OptionHoldingItem] = []
+    @State private var allocationVariance: [AssetAllocationVarianceItem] = []
+    @State private var portfolioValue: Double = 0
     
     // For styling, reuse defined paddings if possible
     private let sectionSpacing: CGFloat = 20
@@ -24,6 +26,11 @@ struct DashboardView: View {
                 Text("Dashboard")
                     .font(.system(size: 32, weight: .bold, design: .rounded))
                     .padding(.bottom, 10)
+
+                DashboardTileView(title: "Allocation Drift", iconName: "rectangle.split.3x3.fill", iconColor: .blue) {
+                    AllocationHeatMapTile(items: allocationVariance, portfolioValue: portfolioValue)
+                        .padding(8)
+                }
 
                 // Section: Top 5 Positions
                 DashboardTileView(title: "Largest Positions", iconName: "star.fill", iconColor: .yellow) {
@@ -137,6 +144,9 @@ struct DashboardView: View {
         self.largestPositions = dbManager.fetchLargestPositions()
         self.assetAllocations = dbManager.fetchAssetClassAllocation()
         self.optionHoldings = dbManager.fetchOptionHoldings()
+        let variance = dbManager.fetchAssetAllocationVariance()
+        self.allocationVariance = variance.items
+        self.portfolioValue = variance.portfolioValue
     }
 }
 

--- a/DragonShield/helpers/Color+Palette.swift
+++ b/DragonShield/helpers/Color+Palette.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+extension Color {
+    static let success = Color(red: 30/255, green: 142/255, blue: 62/255)
+    static let warning = Color(red: 224/255, green: 168/255, blue: 0/255)
+    static let error = Color(red: 211/255, green: 47/255, blue: 47/255)
+}


### PR DESCRIPTION
## Summary
- add color palette extension
- provide asset allocation variance data in dashboard database API
- implement AllocationHeatMapTile view
- surface new heatmap tile in the dashboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e073bd9d48323b6385452bc14e30d