### PR TITLE
Add Target Allocation maintenance view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Extend Institutions with contact info, currency and country fields
 - Add Target Allocation maintenance screen for editing portfolio targets
 - Fix compile error in Target Allocation maintenance view
+- Expand target allocation screen with dynamic class and sub-class editing
 - Fix deprecated isoRegionCodes warning in Institutions view
 - Add sample institutions dataset for testing
 - Replace Institutions seed data with new dataset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Fix compile error in Target Allocation maintenance view
 - Expand target allocation screen with dynamic class and sub-class editing
 - Improve target allocation editor with modal sub-class panel and slider tweaks
+- Fix build errors from ForEach bindings in target allocation view
 - Fix deprecated isoRegionCodes warning in Institutions view
 - Add sample institutions dataset for testing
 - Replace Institutions seed data with new dataset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Allow editing Asset Class in Asset SubClass popup
 - Create cash accounts during position import and record deposits
 - Extend Institutions with contact info, currency and country fields
+- Add Target Allocation maintenance screen for editing portfolio targets
 - Fix deprecated isoRegionCodes warning in Institutions view
 - Add sample institutions dataset for testing
 - Replace Institutions seed data with new dataset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - Add Target Allocation maintenance screen for editing portfolio targets
 - Fix compile error in Target Allocation maintenance view
 - Expand target allocation screen with dynamic class and sub-class editing
+- Improve target allocation editor with modal sub-class panel and slider tweaks
 - Fix deprecated isoRegionCodes warning in Institutions view
 - Add sample institutions dataset for testing
 - Replace Institutions seed data with new dataset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,3 +108,5 @@ All notable changes to this project will be documented in this file.
 - Display instrument currency in Positions view
 - Toggle parsing checkpoints to suppress import popups and show inline summary
 - Make import summary panel scrollable and arrange import view in two columns
+- Fix compile errors in Target Allocation maintenance view on macOS by removing
+  number-pad keyboard modifier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - Expand target allocation screen with dynamic class and sub-class editing
 - Improve target allocation editor with modal sub-class panel and slider tweaks
 - Fix build errors from ForEach bindings in target allocation view
+- Refactor Target Allocation maintenance view to avoid type-checking timeouts
 - Fix deprecated isoRegionCodes warning in Institutions view
 - Add sample institutions dataset for testing
 - Replace Institutions seed data with new dataset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - Create cash accounts during position import and record deposits
 - Extend Institutions with contact info, currency and country fields
 - Add Target Allocation maintenance screen for editing portfolio targets
+- Fix compile error in Target Allocation maintenance view
 - Fix deprecated isoRegionCodes warning in Institutions view
 - Add sample institutions dataset for testing
 - Replace Institutions seed data with new dataset

--- a/DragonShield/DatabaseManager+PortfolioTargets.swift
+++ b/DragonShield/DatabaseManager+PortfolioTargets.swift
@@ -9,6 +9,21 @@ extension DatabaseManager {
         var currentPercent: Double
     }
 
+    struct SubClassTarget: Identifiable, Hashable {
+        let id: Int
+        var name: String
+        var targetPercent: Double
+        var currentPercent: Double
+    }
+
+    struct ClassTarget: Identifiable, Hashable {
+        let id: Int
+        var name: String
+        var targetPercent: Double
+        var currentPercent: Double
+        var subTargets: [SubClassTarget]
+    }
+
     /// Returns current and target allocation percentages grouped by asset class.
     /// This uses sample data from `fetchAssetAllocationVariance()` for now.
     func fetchPortfolioTargets() -> [AllocationTarget] {
@@ -32,5 +47,71 @@ extension DatabaseManager {
             )
         }
         // Actual SQL update omitted in sample code base
+    }
+
+    /// Returns all asset classes with optional subclass targets. This sample
+    /// implementation combines basic asset class data with placeholder
+    /// subclass information.
+    func fetchPortfolioClassTargets() -> [ClassTarget] {
+        let classes = fetchAssetClassesDetailed()
+        let varianceMap = Dictionary(uniqueKeysWithValues: fetchPortfolioTargets().map { ($0.assetClassName, $0) })
+
+        return classes.map { cls in
+            let base = varianceMap[cls.name]
+            let subs = fetchSubClasses(for: cls.id).map { sub in
+                SubClassTarget(id: sub.id,
+                               name: sub.name,
+                               targetPercent: 0,
+                               currentPercent: 0)
+            }
+            return ClassTarget(id: cls.id,
+                               name: cls.name,
+                               targetPercent: base?.targetPercent ?? 0,
+                               currentPercent: base?.currentPercent ?? 0,
+                               subTargets: subs)
+        }
+    }
+
+    /// Placeholder for saving class and subclass targets separately.
+    func savePortfolioClassTargets(_ classes: [ClassTarget]) {
+        for cls in classes {
+            LoggingService.shared.log(
+                "Saving class target for \(cls.name): \(cls.targetPercent)%",
+                type: .info,
+                logger: .database
+            )
+            for sub in cls.subTargets {
+                LoggingService.shared.log(
+                    "  Sub \(sub.name): \(sub.targetPercent)%",
+                    type: .info,
+                    logger: .database
+                )
+            }
+        }
+        // Actual SQL update omitted in sample code base
+    }
+
+    private func fetchSubClasses(for classId: Int) -> [(id: Int, name: String)] {
+        var subClasses: [(id: Int, name: String)] = []
+        let query = "SELECT sub_class_id, sub_class_name FROM AssetSubClasses WHERE class_id = ? ORDER BY sort_order, sub_class_name"
+
+        var statement: OpaquePointer?
+        if sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_int(statement, 1, Int32(classId))
+            while sqlite3_step(statement) == SQLITE_ROW {
+                let id = Int(sqlite3_column_int(statement, 0))
+                if let namePtr = sqlite3_column_text(statement, 1) {
+                    subClasses.append((id: id, name: String(cString: namePtr)))
+                }
+            }
+        } else {
+            LoggingService.shared.log(
+                "Failed to prepare fetchSubClasses: \(String(cString: sqlite3_errmsg(db)))",
+                type: .error,
+                logger: .database
+            )
+        }
+        sqlite3_finalize(statement)
+        return subClasses
     }
 }

--- a/DragonShield/DatabaseManager+PortfolioTargets.swift
+++ b/DragonShield/DatabaseManager+PortfolioTargets.swift
@@ -1,0 +1,36 @@
+import Foundation
+import SwiftUI
+
+extension DatabaseManager {
+    struct AllocationTarget: Identifiable, Hashable {
+        let id: String
+        var assetClassName: String
+        var targetPercent: Double
+        var currentPercent: Double
+    }
+
+    /// Returns current and target allocation percentages grouped by asset class.
+    /// This uses sample data from `fetchAssetAllocationVariance()` for now.
+    func fetchPortfolioTargets() -> [AllocationTarget] {
+        let variance = fetchAssetAllocationVariance()
+        return variance.items.map { item in
+            AllocationTarget(id: item.id,
+                              assetClassName: item.assetClassName,
+                              targetPercent: item.targetPercent,
+                              currentPercent: item.currentPercent)
+        }
+    }
+
+    /// Persists updated target percentages. The demo implementation only logs
+    /// the values but would update `PortfolioInstruments` in a full build.
+    func savePortfolioTargets(_ targets: [AllocationTarget]) {
+        for target in targets {
+            LoggingService.shared.log(
+                "Saving target for \(target.assetClassName): \(target.targetPercent)%",
+                type: .info,
+                logger: .database
+            )
+        }
+        // Actual SQL update omitted in sample code base
+    }
+}

--- a/DragonShield/Views/SidebarView.swift
+++ b/DragonShield/Views/SidebarView.swift
@@ -75,6 +75,10 @@ struct SidebarView: View {
                 NavigationLink(destination: AssetSubClassesView()) {
                     Label("Edit Asset SubClasses", systemImage: "folder.fill")
                 }
+
+                NavigationLink(destination: TargetAllocationMaintenanceView()) {
+                    Label("Edit Target Allocation", systemImage: "chart.pie")
+                }
                 
                 NavigationLink(destination: TransactionTypesView()) {
                     Label("Edit Transaction Types", systemImage: "tag.circle.fill")

--- a/DragonShield/Views/TargetAllocationMaintenanceView.swift
+++ b/DragonShield/Views/TargetAllocationMaintenanceView.swift
@@ -64,7 +64,7 @@ struct TargetAllocationMaintenanceView: View {
     private var leftPane: some View {
         VStack(alignment: .leading) {
             List {
-                ForEach($classTargets) { $cls in
+                ForEach($classTargets, id: \.id) { $cls in
                     VStack(alignment: .leading, spacing: 12) {
                         HStack {
                             Text(cls.name)
@@ -177,7 +177,7 @@ private struct SubClassEditor: View {
         NavigationView {
             VStack(alignment: .leading) {
                 List {
-                    ForEach($classTarget.subTargets) { $sub in
+                    ForEach($classTarget.subTargets, id: \.id) { $sub in
                         VStack(alignment: .leading, spacing: 8) {
                             HStack {
                                 Text(sub.name)

--- a/DragonShield/Views/TargetAllocationMaintenanceView.swift
+++ b/DragonShield/Views/TargetAllocationMaintenanceView.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+import Charts
+
+struct TargetAllocationMaintenanceView: View {
+    @EnvironmentObject var dbManager: DatabaseManager
+    @Environment(\.presentationMode) private var presentation
+
+    @State private var targets: [DatabaseManager.AllocationTarget] = []
+    @State private var originalTargets: [DatabaseManager.AllocationTarget] = []
+
+    private var total: Double { targets.map(\.$0.targetPercent).reduce(0, +) }
+    private var isValid: Bool { abs(total - 100) < 0.01 }
+    private var hasChanges: Bool { targets != originalTargets }
+
+    private var percentFormatter: NumberFormatter {
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        f.maximumFractionDigits = 0
+        return f
+    }
+
+    var body: some View {
+        HStack {
+            leftPane
+            Divider()
+            rightPane
+        }
+        .padding()
+        .navigationTitle("Target Allocation")
+        .onAppear(perform: loadData)
+        .toolbar {
+            ToolbarItemGroup(placement: .confirmationAction) {
+                Button("Save") { save() }
+                    .keyboardShortcut("s", modifiers: [.command])
+                    .modifier(ModernPrimaryButton(color: .blue, isDisabled: !isValid || !hasChanges))
+            }
+            ToolbarItemGroup(placement: .cancellationAction) {
+                Button("Reset") { targets = originalTargets }
+                    .modifier(ModernPrimaryButton(color: .orange, isDisabled: !hasChanges))
+                Button("Cancel") { presentation.wrappedValue.dismiss() }
+                    .modifier(ModernSubtleButton())
+            }
+        }
+    }
+
+    private var leftPane: some View {
+        VStack(alignment: .leading) {
+            List {
+                ForEach($targets) { $entry in
+                    VStack(alignment: .leading, spacing: 12) {
+                        HStack {
+                            Text(entry.assetClassName)
+                            Spacer()
+                            TextField("", value: $entry.targetPercent, formatter: percentFormatter)
+                                .frame(width: 50)
+                                .textFieldStyle(.roundedBorder)
+                        }
+                        Slider(value: $entry.targetPercent, in: 0...100, step: 1)
+                    }
+                    .padding(24)
+                    .background(Color.white.opacity(0.8))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+            }
+            HStack {
+                Text(String(format: "Total: %.0f%%", total))
+                    .foregroundColor(isValid ? .secondary : .red)
+                Spacer()
+            }
+            .padding([.top, .horizontal])
+        }
+    }
+
+    private var rightPane: some View {
+        Chart(targets) { item in
+            SectorMark(
+                angle: .value("Target", item.targetPercent),
+                innerRadius: .ratio(0.5)
+            )
+            .foregroundStyle(by: .value("Class", item.assetClassName))
+            .annotation(position: .overlay) {
+                if item.targetPercent > 4 {
+                    Text("\(Int(item.targetPercent))%")
+                        .font(.caption2)
+                        .foregroundColor(.white)
+                }
+            }
+        }
+        .chartLegend(.visible)
+        .padding()
+    }
+
+    private func loadData() {
+        targets = dbManager.fetchPortfolioTargets()
+        originalTargets = targets
+    }
+
+    private func save() {
+        dbManager.savePortfolioTargets(targets)
+        originalTargets = targets
+    }
+}
+
+struct TargetAllocationMaintenanceView_Previews: PreviewProvider {
+    static var previews: some View {
+        TargetAllocationMaintenanceView()
+            .environmentObject(DatabaseManager())
+    }
+}

--- a/DragonShield/Views/TargetAllocationMaintenanceView.swift
+++ b/DragonShield/Views/TargetAllocationMaintenanceView.swift
@@ -151,7 +151,6 @@ private struct ClassRow: View {
                 TextField("", value: $classTarget.targetPercent, formatter: percentFormatter)
                     .frame(width: 50)
                     .textFieldStyle(.roundedBorder)
-                    .keyboardType(.numberPad)
                     .onChange(of: classTarget.targetPercent) { newVal in
                         classTarget.targetPercent = min(100, max(0, newVal))
                     }
@@ -232,7 +231,6 @@ private struct SubClassRow: View {
                 TextField("", value: $subTarget.targetPercent, formatter: percentFormatter)
                     .frame(width: 50)
                     .textFieldStyle(.roundedBorder)
-                    .keyboardType(.numberPad)
                     .onChange(of: subTarget.targetPercent) { newVal in
                         subTarget.targetPercent = min(100, max(0, newVal))
                     }

--- a/DragonShield/Views/TargetAllocationMaintenanceView.swift
+++ b/DragonShield/Views/TargetAllocationMaintenanceView.swift
@@ -8,7 +8,9 @@ struct TargetAllocationMaintenanceView: View {
     @State private var targets: [DatabaseManager.AllocationTarget] = []
     @State private var originalTargets: [DatabaseManager.AllocationTarget] = []
 
-    private var total: Double { targets.map(\.$0.targetPercent).reduce(0, +) }
+    private var total: Double {
+        targets.map(\.targetPercent).reduce(0, +)
+    }
     private var isValid: Bool { abs(total - 100) < 0.01 }
     private var hasChanges: Bool { targets != originalTargets }
 


### PR DESCRIPTION
## Summary
- add a Target Allocation maintenance screen with sliders and a pie chart
- stub out portfolio target fetching and saving
- link the screen from the sidebar
- document the new screen in the changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e0f01a01c8323bdf41d213333fb79