### PR TITLE
Clean target dir before DB deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,3 +110,4 @@ All notable changes to this project will be documented in this file.
 - Make import summary panel scrollable and arrange import view in two columns
 - Fix compile errors in Target Allocation maintenance view on macOS by removing
   number-pad keyboard modifier
+- Delete existing files in target directory before deploying database

--- a/DragonShield/python_scripts/db_tool.py
+++ b/DragonShield/python_scripts/db_tool.py
@@ -123,6 +123,9 @@ def main(argv=None):
         logger.info(json.dumps({"phase": 3, "status": "start"}))
         dest_dir = Path(args.target_dir).expanduser()
         os.makedirs(dest_dir, exist_ok=True)
+        for item in dest_dir.iterdir():
+            if item.is_file():
+                item.unlink()
         dest_path = dest_dir / 'dragonshield.sqlite'
         shutil.copy2(source_path, dest_path)
         logger.info(json.dumps({"phase": 3, "status": "done", "dest": str(dest_path)}))

--- a/tests/test_db_tool.py
+++ b/tests/test_db_tool.py
@@ -34,8 +34,12 @@ def test_db_tool_copies(monkeypatch, tmp_path):
     monkeypatch.setattr(db_tool, 'load_seed_data', lambda *a, **k: 0)
     monkeypatch.setattr('builtins.input', lambda _: 'y')
 
+    old_file = tmp_path / 'old.sqlite'
+    old_file.write_text('old')
+
     db_tool.main(['--target-dir', str(tmp_path)])
 
     assert copied['src'].endswith('dragonshield.sqlite')
     assert copied['dst'] == os.path.join(str(tmp_path), 'dragonshield.sqlite')
     assert copied['dir'] == str(tmp_path)
+    assert not old_file.exists()


### PR DESCRIPTION
## Summary
- remove existing files from target dir before deploying DB
- test that db_tool cleans the target directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e3a5ace7083238df1f014a0a69b1b