### PR TITLE
Clean target dir before DB deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,3 +110,5 @@ All notable changes to this project will be documented in this file.
 - Make import summary panel scrollable and arrange import view in two columns
 - Fix compile errors in Target Allocation maintenance view on macOS by removing
   number-pad keyboard modifier
+- Delete existing files in target directory before deploying database
+- Stop DragonShield and Xcode when running the database tool

--- a/DragonShield/python_scripts/db_tool.py
+++ b/DragonShield/python_scripts/db_tool.py
@@ -23,6 +23,7 @@ import json
 import logging
 import os
 import shutil
+import subprocess
 from pathlib import Path
 import sqlite3
 
@@ -79,6 +80,17 @@ def load_seed_data(seed_sql: str, db_path: str, version: str) -> int:
     return rows
 
 
+def stop_apps() -> None:
+    """Quit DragonShield and Xcode using osascript if available."""
+    for app in ("DragonShield", "Xcode"):
+        subprocess.run(
+            ["osascript", "-e", f'tell application "{app}" to quit'],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+
+
 def main(argv=None):
     parser = argparse.ArgumentParser(description="Build and deploy Dragon Shield database")
     parser.add_argument(
@@ -93,6 +105,7 @@ def main(argv=None):
     args = parser.parse_args(argv)
 
     logger = _setup_logger()
+    stop_apps()
 
     project_root = Path(__file__).resolve().parents[1]
     source_path = project_root / 'dragonshield.sqlite'
@@ -123,6 +136,9 @@ def main(argv=None):
         logger.info(json.dumps({"phase": 3, "status": "start"}))
         dest_dir = Path(args.target_dir).expanduser()
         os.makedirs(dest_dir, exist_ok=True)
+        for item in dest_dir.iterdir():
+            if item.is_file():
+                item.unlink()
         dest_path = dest_dir / 'dragonshield.sqlite'
         shutil.copy2(source_path, dest_path)
         logger.info(json.dumps({"phase": 3, "status": "done", "dest": str(dest_path)}))

--- a/tests/test_db_tool.py
+++ b/tests/test_db_tool.py
@@ -32,10 +32,17 @@ def test_db_tool_copies(monkeypatch, tmp_path):
     monkeypatch.setattr(db_tool.deploy_db, 'parse_version', lambda p: 'test')
     monkeypatch.setattr(db_tool, 'create_empty_db', lambda *a, **k: 0)
     monkeypatch.setattr(db_tool, 'load_seed_data', lambda *a, **k: 0)
+    stopped = []
+    monkeypatch.setattr(db_tool, 'stop_apps', lambda: stopped.append(True))
     monkeypatch.setattr('builtins.input', lambda _: 'y')
+
+    old_file = tmp_path / 'old.sqlite'
+    old_file.write_text('old')
 
     db_tool.main(['--target-dir', str(tmp_path)])
 
     assert copied['src'].endswith('dragonshield.sqlite')
     assert copied['dst'] == os.path.join(str(tmp_path), 'dragonshield.sqlite')
     assert copied['dir'] == str(tmp_path)
+    assert not old_file.exists()
+    assert stopped == [True]


### PR DESCRIPTION
## Summary
- remove existing files from target dir before deploying DB
- test that db_tool cleans the target directory
- stop DragonShield and Xcode when running db_tool

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e3a5ace7083238df1f014a0a69b1b