### PR TITLE
Implement sub-class allocation editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to this project will be documented in this file.
 - Store import sessions by institution and value date, tracking duplicate rows
 - Restyle Currency Maintenance window and update title to "Currency Maintenance"
 - Log mapped Asset-Unterkategorie values to AssetSubClass during ZKB import
+- Populate sub-class allocation sheet with editable sliders and totals check
+- Display sub-class rows correctly and allow saving with totals other than 100%
+- Fix deprecated onChange warning in Target Allocation view
 - Add asset allocation variance heatmap tile to dashboard
 - Fix overlapping labels and gesture issues in allocation heatmap
 - Allow editing Asset Class in Asset SubClass popup

--- a/DragonShield/DatabaseManager+PortfolioTargets.swift
+++ b/DragonShield/DatabaseManager+PortfolioTargets.swift
@@ -91,6 +91,17 @@ extension DatabaseManager {
         // Actual SQL update omitted in sample code base
     }
 
+    /// Returns all sub-classes for a given asset class.
+    /// Target values default to 0 and should be bound by the caller.
+    func subAssetClasses(for classId: Int) -> [SubClassTarget] {
+        fetchSubClasses(for: classId).map { row in
+            SubClassTarget(id: row.id,
+                           name: row.name,
+                           targetPercent: 0,
+                           currentPercent: 0)
+        }
+    }
+
     private func fetchSubClasses(for classId: Int) -> [(id: Int, name: String)] {
         var subClasses: [(id: Int, name: String)] = []
         let query = "SELECT sub_class_id, sub_class_name FROM AssetSubClasses WHERE class_id = ? ORDER BY sort_order, sub_class_name"


### PR DESCRIPTION
## Summary
- fill sub-class allocation sheet when editing allocations
- expose helper to fetch sub-classes in the DB manager
- update sub-class row layout
- resolve onChange deprecation
- display sub-class rows correctly and allow saving without strict 100% total

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e3be9af588323a8cd11e3b437eeae