### PR TITLE
Implement persistent target allocation view model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Populate sub-class allocation sheet with editable sliders and totals check
 - Display sub-class rows correctly and allow saving with totals other than 100%
 - Fix deprecated onChange warning in Target Allocation view
+- Persist portfolio class and sub-class targets using dictionaries
 - Add asset allocation variance heatmap tile to dashboard
 - Fix overlapping labels and gesture issues in allocation heatmap
 - Allow editing Asset Class in Asset SubClass popup

--- a/DragonShield/ViewModels/TargetAllocationViewModel.swift
+++ b/DragonShield/ViewModels/TargetAllocationViewModel.swift
@@ -1,0 +1,43 @@
+import Foundation
+import SwiftUI
+
+class TargetAllocationViewModel: ObservableObject {
+    @Published var classTargets: [Int: Double] = [:]
+    @Published var subClassTargets: [Int: Double] = [:]
+    @Published var assetClasses: [DatabaseManager.AssetClassData] = []
+
+    private let dbManager: DatabaseManager
+    private let portfolioId: Int
+
+    init(dbManager: DatabaseManager, portfolioId: Int) {
+        self.dbManager = dbManager
+        self.portfolioId = portfolioId
+        loadTargets()
+    }
+
+    private func loadTargets() {
+        assetClasses = dbManager.fetchAssetClassesDetailed()
+        let rows = dbManager.fetchPortfolioTargetRecords(portfolioId: portfolioId)
+        for row in rows {
+            if let classId = row.classId {
+                classTargets[classId] = row.percent
+            }
+            if let subId = row.subClassId {
+                subClassTargets[subId] = row.percent
+            }
+        }
+    }
+
+    func subAssetClasses(for classId: Int) -> [DatabaseManager.SubClassTarget] {
+        dbManager.subAssetClasses(for: classId)
+    }
+
+    func saveTargets() {
+        for (classId, pct) in classTargets {
+            dbManager.upsertClassTarget(portfolioId: portfolioId, classId: classId, percent: pct)
+        }
+        for (subId, pct) in subClassTargets {
+            dbManager.upsertSubClassTarget(portfolioId: portfolioId, subClassId: subId, percent: pct)
+        }
+    }
+}

--- a/DragonShield/Views/SidebarView.swift
+++ b/DragonShield/Views/SidebarView.swift
@@ -15,6 +15,8 @@ import AppKit
 private let importManager = ImportManager.shared
 
 struct SidebarView: View {
+    @EnvironmentObject var dbManager: DatabaseManager
+
     var body: some View {
         List {
             // MARK: - Key Features Section
@@ -76,7 +78,7 @@ struct SidebarView: View {
                     Label("Edit Asset SubClasses", systemImage: "folder.fill")
                 }
 
-                NavigationLink(destination: TargetAllocationMaintenanceView()) {
+                NavigationLink(destination: TargetAllocationMaintenanceView(viewModel: TargetAllocationViewModel(dbManager: dbManager, portfolioId: 1))) {
                     Label("Edit Target Allocation", systemImage: "chart.pie")
                 }
                 


### PR DESCRIPTION
## Summary
- add `TargetAllocationViewModel` storing class and sub-class targets in dictionaries
- extend `DatabaseManager` with queries to load and upsert target allocations
- refactor `TargetAllocationMaintenanceView` to use the new view model
- pass the view model from `SidebarView`
- document the change in `CHANGELOG`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e4a4814ac83238a8b889515f0301e