### PR TITLE
feat: improve target allocation list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Delete position reports for any institution directly from the Positions view
+- Refactor Target Allocation list with per-class mismatch warnings and color legend
+- Reset sub-class targets to zero when their class target is set to zero
+- Fix build issue in Target Allocation view by breaking out subviews
+- Resolve compile timeout in Target Allocation view by splitting left pane
+- Fix compile error referencing missing AssetSubClassData type
 - Added GPT shell with OpenAI function calling and JSON schema validation
 - Remove duplicate Python package initializer to resolve Xcode resource error
 - Extend institution seed data with contact info and default currencies

--- a/DragonShield/ViewModels/TargetAllocationViewModel.swift
+++ b/DragonShield/ViewModels/TargetAllocationViewModel.swift
@@ -2,7 +2,17 @@ import Foundation
 import SwiftUI
 
 class TargetAllocationViewModel: ObservableObject {
-    @Published var classTargets: [Int: Double] = [:]
+    @Published var classTargets: [Int: Double] = [:] {
+        didSet {
+            for (classID, pct) in classTargets {
+                if pct == 0 {
+                    for sub in subAssetClasses(for: classID) {
+                        subClassTargets[sub.id] = 0
+                    }
+                }
+            }
+        }
+    }
     @Published var subClassTargets: [Int: Double] = [:]
     @Published var assetClasses: [DatabaseManager.AssetClassData] = []
     @Published var expandedClasses: [Int: Bool] = [:]
@@ -26,14 +36,18 @@ class TargetAllocationViewModel: ObservableObject {
     private func loadTargets() {
         assetClasses = dbManager.fetchAssetClassesDetailed()
         let rows = dbManager.fetchPortfolioTargetRecords(portfolioId: portfolioId)
+        var classMap: [Int: Double] = [:]
+        var subMap: [Int: Double] = [:]
         for row in rows {
             if let classId = row.classId {
-                classTargets[classId] = row.percent
+                classMap[classId] = row.percent
             }
             if let subId = row.subClassId {
-                subClassTargets[subId] = row.percent
+                subMap[subId] = row.percent
             }
         }
+        subClassTargets = subMap
+        classTargets = classMap
     }
 
     func subAssetClasses(for classId: Int) -> [DatabaseManager.SubClassTarget] {
@@ -44,6 +58,20 @@ class TargetAllocationViewModel: ObservableObject {
         subAssetClasses(for: classId)
             .map { subClassTargets[$0.id] ?? 0 }
             .reduce(0, +)
+    }
+
+    var sortedClasses: [DatabaseManager.AssetClassData] {
+        let active = assetClasses
+            .filter { (classTargets[$0.id] ?? 0) > 0 }
+            .sorted { (classTargets[$0.id] ?? 0) > (classTargets[$1.id] ?? 0) }
+        let inactive = assetClasses.filter { (classTargets[$0.id] ?? 0) == 0 }
+        return active + inactive
+    }
+
+    func chartColor(for classId: Int) -> Color {
+        guard let codeString = assetClasses.first(where: { $0.id == classId })?.code,
+              let code = AssetClassCode(rawValue: codeString) else { return .gray }
+        return Theme.assetClassColors[code] ?? .gray
     }
 
     func saveAllTargets() {

--- a/DragonShield/Views/TargetAllocationMaintenanceView.swift
+++ b/DragonShield/Views/TargetAllocationMaintenanceView.swift
@@ -63,87 +63,132 @@ struct TargetAllocationMaintenanceView: View {
 
     private var leftPane: some View {
         VStack(alignment: .leading) {
-            List {
-                ForEach(viewModel.assetClasses) { cls in
-                    DisclosureGroup(
-                        isExpanded: Binding(
-                            get: { viewModel.expandedClasses[cls.id] ?? false },
-                            set: { viewModel.expandedClasses[cls.id] = $0 }
-                        )
-                    ) {
-                        ForEach(viewModel.subAssetClasses(for: cls.id), id: \.id) { sub in
-                            HStack {
-                                Text(sub.name)
-                                    .font(.system(size: 14))
-                                Spacer()
-                                Slider(
-                                    value: Binding(
-                                        get: { viewModel.subClassTargets[sub.id] ?? 0 },
-                                        set: { viewModel.subClassTargets[sub.id] = $0 }
-                                    ),
-                                    in: 0...100,
-                                    step: 5
-                                )
-                                TextField(
-                                    "",
-                                    value: Binding(
-                                        get: { viewModel.subClassTargets[sub.id] ?? 0 },
-                                        set: { viewModel.subClassTargets[sub.id] = $0 }
-                                    ),
-                                    formatter: viewModel.numberFormatter
-                                )
-                                .frame(width: 40)
-                            }
-                            .padding(.vertical, 4)
-                        }
-                        let sum = viewModel.totalSubClassPct(for: cls.id)
-                        if abs(sum - 100) > 0.01 {
-                            Text("\u{26A0}\u{FE0F} Sub-class totals: \(Int(sum))% (should be 100%)")
-                                .font(.caption)
-                                .foregroundColor(.orange)
-                        }
-                    } label: {
-                        HStack {
-                            Text(cls.name)
-                                .font(.system(size: 16, weight: .medium))
-                            Spacer()
-                            Slider(
-                                value: Binding(
-                                    get: { viewModel.classTargets[cls.id] ?? 0 },
-                                    set: { viewModel.classTargets[cls.id] = $0 }
-                                ),
-                                in: 0...100,
-                                step: 5
-                            )
-                            TextField(
-                                "",
-                                value: Binding(
-                                    get: { viewModel.classTargets[cls.id] ?? 0 },
-                                    set: { viewModel.classTargets[cls.id] = $0 }
-                                ),
-                                formatter: viewModel.numberFormatter
-                            )
-                            .frame(width: 40)
-                        }
-                    }
-                    .padding(.vertical, 8)
-                }
-            }
-            HStack(spacing: 12) {
-                Text(String(format: "Total: %.0f%%", total))
-                    .foregroundColor(abs(total - 100) < 0.01 ? .secondary : .red)
-                if abs(total - 100) > 0.01 {
-                    Text("\u{26A0}\u{FE0F} Total is \(Int(total))% (not 100%)")
-                        .foregroundColor(.orange)
-                }
-                if !subClassTotalsValid {
-                    Text("\u{26A0}\u{FE0F} Sub-class totals mismatch")
-                        .foregroundColor(.orange)
-                }
-                Spacer()
-            }
-            .padding([.top, .horizontal])
+            classList
+            totalsRow
         }
+        .padding(24)
+        .background(Theme.surface)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var classList: some View {
+        List {
+            ForEach(viewModel.sortedClasses) { cls in
+                classDisclosure(for: cls)
+            }
+        }
+        .listStyle(.plain)
+    }
+
+    private var totalsRow: some View {
+        HStack(spacing: 12) {
+            Text(String(format: "Total: %.0f%%", total))
+                .foregroundColor(abs(total - 100) < 0.01 ? .secondary : .red)
+            if abs(total - 100) > 0.01 {
+                Text("\u{26A0}\u{FE0F} Total is \(Int(total))% (not 100%)")
+                    .foregroundColor(.orange)
+            }
+            if !subClassTotalsValid {
+                Text("\u{26A0}\u{FE0F} Sub-class totals mismatch")
+                    .foregroundColor(.orange)
+            }
+            Spacer()
+        }
+        .padding([.top, .horizontal])
+    }
+
+    private func classDisclosure(for cls: DatabaseManager.AssetClassData) -> some View {
+        let expanded = Binding<Bool>(
+            get: { viewModel.expandedClasses[cls.id] ?? false },
+            set: { viewModel.expandedClasses[cls.id] = $0 }
+        )
+        let label = classDisclosureLabel(for: cls)
+        return DisclosureGroup(isExpanded: expanded) {
+            ForEach(viewModel.subAssetClasses(for: cls.id), id: \.id) { sub in
+                subClassRow(for: sub, classId: cls.id)
+            }
+            let sum = viewModel.totalSubClassPct(for: cls.id)
+            if abs(sum - 100) > 0.01 {
+                HStack(spacing: 4) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(.warning)
+                        .accessibilityLabel("Sub-class totals mismatch")
+                    Text("Sub-class totals: \(Int(sum))% (should be 100%)")
+                        .font(.caption)
+                        .foregroundColor(.orange)
+                }
+            }
+        } label: { label }
+        .padding(.vertical, 8)
+    }
+
+    @ViewBuilder
+    private func classDisclosureLabel(for cls: DatabaseManager.AssetClassData) -> some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(viewModel.chartColor(for: cls.id))
+                .frame(width: 10, height: 10)
+            Text(cls.name)
+                .font(.system(size: 16, weight: viewModel.classTargets[cls.id, default: 0] > 0 ? .semibold : .regular))
+            if abs(viewModel.totalSubClassPct(for: cls.id) - 100) > 0.01 {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundColor(.warning)
+                    .accessibilityLabel("Sub-class totals mismatch")
+                    .onTapGesture { viewModel.expandedClasses[cls.id] = true }
+            }
+            Spacer()
+            Slider(
+                value: classTargetBinding(for: cls.id),
+                in: 0...100,
+                step: 5
+            )
+            .focusable()
+            TextField(
+                "",
+                value: classTargetBinding(for: cls.id),
+                formatter: viewModel.numberFormatter
+            )
+            .frame(width: 40)
+            .focusable()
+        }
+    }
+
+    private func subClassRow(for sub: DatabaseManager.SubClassTarget, classId: Int) -> some View {
+        HStack {
+            Text(sub.name)
+                .font(.system(size: 14))
+            Spacer()
+            Slider(
+                value: subClassTargetBinding(for: sub.id),
+                in: 0...100,
+                step: 5
+            )
+            .focusable()
+            TextField(
+                "",
+                value: subClassTargetBinding(for: sub.id),
+                formatter: viewModel.numberFormatter
+            )
+            .frame(width: 40)
+            .focusable()
+        }
+        .padding(.vertical, 4)
+        .disabled(viewModel.classTargets[classId] == 0)
+        .opacity(viewModel.classTargets[classId] == 0 ? 0.5 : 1.0)
+    }
+
+    private func classTargetBinding(for id: Int) -> Binding<Double> {
+        Binding(
+            get: { viewModel.classTargets[id] ?? 0 },
+            set: { viewModel.classTargets[id] = $0 }
+        )
+    }
+
+    private func subClassTargetBinding(for id: Int) -> Binding<Double> {
+        Binding(
+            get: { viewModel.subClassTargets[id] ?? 0 },
+            set: { viewModel.subClassTargets[id] = $0 }
+        )
     }
 
     private var chartSegments: [(name: String, percent: Double)] {

--- a/DragonShield/helpers/Theme.swift
+++ b/DragonShield/helpers/Theme.swift
@@ -6,6 +6,28 @@ enum Theme {
     static let textPrimary = Color(red: 33/255, green: 33/255, blue: 33/255)
 }
 
+enum AssetClassCode: String {
+    case liquidity = "LIQ"
+    case equity = "EQ"
+    case fixedIncome = "FI"
+    case realAssets = "REAL"
+    case alternatives = "ALT"
+    case derivatives = "DERIV"
+    case other = "OTHER"
+}
+
+extension Theme {
+    static let assetClassColors: [AssetClassCode: Color] = [
+        .liquidity: .blue,
+        .equity: .green,
+        .fixedIncome: .orange,
+        .realAssets: .purple,
+        .alternatives: .red,
+        .derivatives: .teal,
+        .other: .gray
+    ]
+}
+
 struct PrimaryButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label


### PR DESCRIPTION
## Summary
- centralise asset class colors in `Theme`
- expose `sortedClasses` and `chartColor` in `TargetAllocationViewModel`
- show colored dots and mismatch warnings in target allocation editor
- style list in a card container
- fix build issue in target allocation view by extracting helper views
- resolve compile timeout by splitting `leftPane`
- fix compile error referencing missing `AssetSubClassData` type
- reset sub-class targets to zero when class is zero and disable rows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e6be8406c83239eb19a4266e9b4a3