### PR TITLE
Enable manual CRUD for positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Fix build issue in Target Allocation view by breaking out subviews
 - Resolve compile timeout in Target Allocation view by splitting left pane
 - Fix compile error referencing missing AssetSubClassData type
+- Correct portfolio target SQL queries to use instrument-based columns
 - Added GPT shell with OpenAI function calling and JSON schema validation
 - Remove duplicate Python package initializer to resolve Xcode resource error
 - Extend institution seed data with contact info and default currencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 - Delete position reports for any institution directly from the Positions view
 - Enable manual add, edit and delete of positions with notes field
+- Include all position fields in the add/edit position form
 - Fix compilation errors in Positions view after CRUD refactor
 - Fix SQLITE_TRANSIENT not found when binding position report text fields
 - Refactor Target Allocation list with per-class mismatch warnings and color legend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Delete position reports for any institution directly from the Positions view
+- Enable manual add, edit and delete of positions with notes field
 - Refactor Target Allocation list with per-class mismatch warnings and color legend
 - Fix build issue in Target Allocation view by breaking out subviews
 - Resolve compile timeout in Target Allocation view by splitting left pane

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 - Delete position reports for any institution directly from the Positions view
 - Enable manual add, edit and delete of positions with notes field
 - Fix compilation errors in Positions view after CRUD refactor
+- Fix SQLITE_TRANSIENT not found when binding position report text fields
 - Refactor Target Allocation list with per-class mismatch warnings and color legend
 - Fix build issue in Target Allocation view by breaking out subviews
 - Resolve compile timeout in Target Allocation view by splitting left pane

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 - Delete position reports for any institution directly from the Positions view
 - Enable manual add, edit and delete of positions with notes field
+- Fix compilation errors in Positions view after CRUD refactor
 - Refactor Target Allocation list with per-class mismatch warnings and color legend
 - Fix build issue in Target Allocation view by breaking out subviews
 - Resolve compile timeout in Target Allocation view by splitting left pane

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Include all position fields in the add/edit position form
 - Fix compilation errors in Positions view after CRUD refactor
 - Fix SQLITE_TRANSIENT not found when binding position report text fields
+- Allow optional import session when saving positions and add picker placeholders
 - Refactor Target Allocation list with per-class mismatch warnings and color legend
 - Fix build issue in Target Allocation view by breaking out subviews
 - Resolve compile timeout in Target Allocation view by splitting left pane

--- a/DragonShield/DatabaseManager+PositionReports.swift
+++ b/DragonShield/DatabaseManager+PositionReports.swift
@@ -174,6 +174,7 @@ extension DatabaseManager {
             return nil
         }
         defer { sqlite3_finalize(stmt) }
+        let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
         sqlite3_bind_int(stmt, 1, Int32(accountId))
         sqlite3_bind_int(stmt, 2, Int32(institutionId))
         sqlite3_bind_int(stmt, 3, Int32(instrumentId))
@@ -197,6 +198,7 @@ extension DatabaseManager {
             return false
         }
         defer { sqlite3_finalize(stmt) }
+        let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
         sqlite3_bind_int(stmt, 1, Int32(accountId))
         sqlite3_bind_int(stmt, 2, Int32(institutionId))
         sqlite3_bind_int(stmt, 3, Int32(instrumentId))

--- a/DragonShield/DatabaseManager+PositionReports.swift
+++ b/DragonShield/DatabaseManager+PositionReports.swift
@@ -17,6 +17,7 @@ struct PositionReportData: Identifiable {
         var quantity: Double
         var purchasePrice: Double?
         var currentPrice: Double?
+        var notes: String?
         var reportDate: Date
         var uploadedAt: Date
 }
@@ -29,6 +30,7 @@ extension DatabaseManager {
             SELECT pr.position_id, pr.import_session_id, a.account_name,
                    ins.institution_name, i.instrument_name, i.currency,
                    pr.quantity, pr.purchase_price, pr.current_price,
+                   pr.notes,
                    pr.report_date, pr.uploaded_at
             FROM PositionReports pr
             JOIN Accounts a ON pr.account_id = a.account_id
@@ -59,8 +61,9 @@ extension DatabaseManager {
                 if sqlite3_column_type(statement, 8) != SQLITE_NULL {
                     currentPrice = sqlite3_column_double(statement, 8)
                 }
-                let reportDateStr = String(cString: sqlite3_column_text(statement, 9))
-                let uploadedAtStr = String(cString: sqlite3_column_text(statement, 10))
+                let notes: String? = sqlite3_column_text(statement, 9).map { String(cString: $0) }
+                let reportDateStr = String(cString: sqlite3_column_text(statement, 10))
+                let uploadedAtStr = String(cString: sqlite3_column_text(statement, 11))
                 let reportDate = DateFormatter.iso8601DateOnly.date(from: reportDateStr) ?? Date()
                 let uploadedAt = DateFormatter.iso8601DateTime.date(from: uploadedAtStr) ?? Date()
                 reports.append(PositionReportData(
@@ -73,6 +76,7 @@ extension DatabaseManager {
                     quantity: quantity,
                     purchasePrice: purchasePrice,
                     currentPrice: currentPrice,
+                    notes: notes,
                     reportDate: reportDate,
                     uploadedAt: uploadedAt
                 ))
@@ -158,5 +162,66 @@ extension DatabaseManager {
         }
         print("🗑️ Deleting positions for \(institutionName) institutions with ids: \(ids)")
         return deletePositionReports(institutionIds: ids)
+    }
+
+    // MARK: - Single Position CRUD
+
+    func addPositionReport(accountId: Int, institutionId: Int, instrumentId: Int, quantity: Double, purchasePrice: Double?, currentPrice: Double?, notes: String?, reportDate: Date) -> Int? {
+        let sql = "INSERT INTO PositionReports (account_id, institution_id, instrument_id, quantity, purchase_price, current_price, notes, report_date) VALUES (?, ?, ?, ?, ?, ?, ?, ?);"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            print("❌ Failed to prepare insert position: \(String(cString: sqlite3_errmsg(db)))")
+            return nil
+        }
+        defer { sqlite3_finalize(stmt) }
+        sqlite3_bind_int(stmt, 1, Int32(accountId))
+        sqlite3_bind_int(stmt, 2, Int32(institutionId))
+        sqlite3_bind_int(stmt, 3, Int32(instrumentId))
+        sqlite3_bind_double(stmt, 4, quantity)
+        if let p = purchasePrice { sqlite3_bind_double(stmt, 5, p) } else { sqlite3_bind_null(stmt, 5) }
+        if let c = currentPrice { sqlite3_bind_double(stmt, 6, c) } else { sqlite3_bind_null(stmt, 6) }
+        if let n = notes { sqlite3_bind_text(stmt, 7, n, -1, SQLITE_TRANSIENT) } else { sqlite3_bind_null(stmt, 7) }
+        sqlite3_bind_text(stmt, 8, DateFormatter.iso8601DateOnly.string(from: reportDate), -1, SQLITE_TRANSIENT)
+        guard sqlite3_step(stmt) == SQLITE_DONE else {
+            print("❌ Insert position failed: \(String(cString: sqlite3_errmsg(db)))")
+            return nil
+        }
+        return Int(sqlite3_last_insert_rowid(db))
+    }
+
+    func updatePositionReport(id: Int, accountId: Int, institutionId: Int, instrumentId: Int, quantity: Double, purchasePrice: Double?, currentPrice: Double?, notes: String?, reportDate: Date) -> Bool {
+        let sql = "UPDATE PositionReports SET account_id = ?, institution_id = ?, instrument_id = ?, quantity = ?, purchase_price = ?, current_price = ?, notes = ?, report_date = ?, uploaded_at = CURRENT_TIMESTAMP WHERE position_id = ?;"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            print("❌ Failed to prepare update position: \(String(cString: sqlite3_errmsg(db)))")
+            return false
+        }
+        defer { sqlite3_finalize(stmt) }
+        sqlite3_bind_int(stmt, 1, Int32(accountId))
+        sqlite3_bind_int(stmt, 2, Int32(institutionId))
+        sqlite3_bind_int(stmt, 3, Int32(instrumentId))
+        sqlite3_bind_double(stmt, 4, quantity)
+        if let p = purchasePrice { sqlite3_bind_double(stmt, 5, p) } else { sqlite3_bind_null(stmt, 5) }
+        if let c = currentPrice { sqlite3_bind_double(stmt, 6, c) } else { sqlite3_bind_null(stmt, 6) }
+        if let n = notes { sqlite3_bind_text(stmt, 7, n, -1, SQLITE_TRANSIENT) } else { sqlite3_bind_null(stmt, 7) }
+        sqlite3_bind_text(stmt, 8, DateFormatter.iso8601DateOnly.string(from: reportDate), -1, SQLITE_TRANSIENT)
+        sqlite3_bind_int(stmt, 9, Int32(id))
+        let result = sqlite3_step(stmt) == SQLITE_DONE
+        if !result { print("❌ Update position failed: \(String(cString: sqlite3_errmsg(db)))") }
+        return result
+    }
+
+    func deletePositionReport(id: Int) -> Bool {
+        let sql = "DELETE FROM PositionReports WHERE position_id = ?;"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            print("❌ Failed to prepare delete position: \(String(cString: sqlite3_errmsg(db)))")
+            return false
+        }
+        defer { sqlite3_finalize(stmt) }
+        sqlite3_bind_int(stmt, 1, Int32(id))
+        let result = sqlite3_step(stmt) == SQLITE_DONE
+        if !result { print("❌ Delete position failed: \(String(cString: sqlite3_errmsg(db)))") }
+        return result
     }
 }

--- a/DragonShield/Views/PositionFormView.swift
+++ b/DragonShield/Views/PositionFormView.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+struct PositionFormView: View {
+    @Environment(\.presentationMode) private var presentationMode
+    @EnvironmentObject var dbManager: DatabaseManager
+
+    var position: PositionReportData?
+    var onSave: () -> Void
+
+    @State private var accounts: [DatabaseManager.AccountData] = []
+    @State private var instruments: [(id: Int, name: String, subClassId: Int, currency: String, tickerSymbol: String?, isin: String?)] = []
+
+    @State private var accountId: Int? = nil
+    @State private var instrumentId: Int? = nil
+    @State private var quantity = ""
+    @State private var purchasePrice = ""
+    @State private var reportDate = Date()
+    @State private var notes = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(position == nil ? "Add Position" : "Edit Position")
+                .font(.title2).bold()
+            formFields
+            HStack {
+                Spacer()
+                Button("Cancel") { presentationMode.wrappedValue.dismiss() }
+                    .buttonStyle(SecondaryButtonStyle())
+                Button("Save") { save() }
+                    .buttonStyle(PrimaryButtonStyle())
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(!isValid)
+            }
+        }
+        .padding(24)
+        .frame(width: 400)
+        .onAppear { loadData(); populate() }
+    }
+
+    private var formFields: some View {
+        Group {
+            Picker("Account", selection: $accountId) {
+                ForEach(accounts, id: \.id) { Text($0.accountName).tag(Optional($0.id)) }
+            }
+            Picker("Instrument", selection: $instrumentId) {
+                ForEach(instruments, id: \.id) { Text($0.name).tag(Optional($0.id)) }
+            }
+            TextField("Quantity", text: $quantity)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+            TextField("Purchase Price", text: $purchasePrice)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+            DatePicker("Value Date", selection: $reportDate, displayedComponents: .date)
+            TextEditor(text: $notes)
+                .frame(height: 60)
+                .overlay(RoundedRectangle(cornerRadius: 4).stroke(Color.gray.opacity(0.3)))
+        }
+    }
+
+    private var isValid: Bool {
+        accountId != nil && instrumentId != nil && Double(quantity) != nil
+    }
+
+    private func loadData() {
+        accounts = dbManager.fetchAccounts()
+        instruments = dbManager.fetchAssets()
+    }
+
+    private func populate() {
+        guard let p = position else { return }
+        accountId = accounts.first(where: { $0.accountName == p.accountName })?.id
+        instrumentId = instruments.first(where: { $0.name == p.instrumentName })?.id
+        quantity = String(p.quantity)
+        if let pp = p.purchasePrice { purchasePrice = String(pp) }
+        reportDate = p.reportDate
+        notes = p.notes ?? ""
+    }
+
+    private func save() {
+        guard let accId = accountId, let instId = instrumentId, let qty = Double(quantity) else { return }
+        let price = Double(purchasePrice)
+        let institutionId = accounts.first(where: { $0.id == accId })?.institutionId ?? 0
+        if let edit = position {
+            _ = dbManager.updatePositionReport(id: edit.id, accountId: accId, institutionId: institutionId, instrumentId: instId, quantity: qty, purchasePrice: price, currentPrice: nil, notes: notes.isEmpty ? nil : notes, reportDate: reportDate)
+        } else {
+            _ = dbManager.addPositionReport(accountId: accId, institutionId: institutionId, instrumentId: instId, quantity: qty, purchasePrice: price, currentPrice: nil, notes: notes.isEmpty ? nil : notes, reportDate: reportDate)
+        }
+        onSave()
+        presentationMode.wrappedValue.dismiss()
+    }
+}

--- a/DragonShield/Views/PositionFormView.swift
+++ b/DragonShield/Views/PositionFormView.swift
@@ -61,6 +61,7 @@ struct PositionFormView: View {
                 .accessibilityLabel("Import Session")
 
             Picker("Account", selection: $accountId) {
+                Text("Select Account").tag(Optional<Int>(nil))
                 ForEach(accounts, id: \.id) {
                     Text($0.accountName).tag(Optional($0.id))
                 }
@@ -68,6 +69,7 @@ struct PositionFormView: View {
             .accessibilityLabel("Account")
 
             Picker("Institution", selection: $institutionId) {
+                Text("Select Institution").tag(Optional<Int>(nil))
                 ForEach(institutions) { inst in
                     Text(inst.name).tag(Optional(inst.id))
                 }
@@ -75,6 +77,7 @@ struct PositionFormView: View {
             .accessibilityLabel("Institution")
 
             Picker("Instrument", selection: $instrumentId) {
+                Text("Select Instrument").tag(Optional<Int>(nil))
                 ForEach(instruments, id: \.id) {
                     Text($0.name).tag(Optional($0.id))
                 }
@@ -82,6 +85,7 @@ struct PositionFormView: View {
             .accessibilityLabel("Instrument")
 
             Picker("Currency", selection: $currencyCode) {
+                Text("Select Currency").tag("")
                 ForEach(currencies, id: \.code) { curr in
                     Text(curr.code).tag(curr.code)
                 }
@@ -117,7 +121,6 @@ struct PositionFormView: View {
     }
 
     private var isValid: Bool {
-        Int(sessionId) != nil &&
         accountId != nil &&
         institutionId != nil &&
         instrumentId != nil &&
@@ -153,9 +156,10 @@ struct PositionFormView: View {
             let accId = accountId,
             let instId = institutionId,
             let instrId = instrumentId,
-            let qty = Double(quantity),
-            let sess = Int(sessionId)
+            let qty = Double(quantity)
         else { return }
+
+        let sess = Int(sessionId)
 
         let price = Double(purchasePrice)
         let currPrice = Double(currentPrice)

--- a/DragonShield/Views/PositionsView.swift
+++ b/DragonShield/Views/PositionsView.swift
@@ -165,6 +165,7 @@ struct PositionsView: View {
         .padding(24)
         .background(Theme.surface)
         .cornerRadius(8)
+    }
 
     private var modernTableHeader: some View {
         HStack {

--- a/DragonShield/database/schema.sql
+++ b/DragonShield/database/schema.sql
@@ -1,6 +1,6 @@
 -- DragonShield/docs/schema.sql
 -- Dragon Shield Database Creation Script
--- Version 4.11 - Enhanced Institutions with contact info and default currency
+-- Version 4.12 - PositionReports support notes field
 -- Created: 2025-05-24
 -- Updated: 2025-06-19
 --
@@ -14,6 +14,7 @@
 -- - v4.3 -> v4.4: Normalized AccountTypes into a separate table. Updated Accounts table and AccountSummary view.
 -- - v4.8 -> v4.9: Introduced AssetClasses and AssetSubClasses tables.
 -- - v4.10 -> v4.11: Expanded Institutions with contact info and currency fields.
+-- - v4.11 -> v4.12: Added notes column to PositionReports table.
 -- - (Previous history for v4.3 and earlier...)
 --
 
@@ -336,6 +337,7 @@ CREATE TABLE PositionReports (
     quantity REAL NOT NULL,
     purchase_price REAL,
     current_price REAL,
+    notes TEXT,
     report_date DATE NOT NULL,
     uploaded_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (import_session_id) REFERENCES ImportSessions(import_session_id),

--- a/DragonShield/database/schema.txt
+++ b/DragonShield/database/schema.txt
@@ -10,6 +10,7 @@
 -- - v4.6 -> v4.7: Added db_version configuration entry
 -- - v4.8 -> v4.9: Introduced AssetClasses and AssetSubClasses
 -- - v4.10 -> v4.11: Added extended institution details
+-- - v4.11 -> v4.12: Added notes column to PositionReports table
 -- - v4.7 -> v4.7.1: Removed duplicate db_version row causing UNIQUE constraint failure
 -- - v4.4 -> v4.5: Added PositionReports table, renamed CurrentHoldings view to Positions, updated PortfolioSummary and AccountSummary views.
 -- - v4.3 -> v4.4: Normalized AccountTypes into a separate table. Updated Accounts table and AccountSummary view.
@@ -27,8 +28,8 @@ INSERT INTO Configuration (key, value, data_type, description) VALUES
 ('table_row_padding', '12.0', 'number', 'Vertical padding inside table rows in points'),
 ('table_font_size', '14.0', 'number', 'Font size for text in data table rows (in points)'),
 -- Removed duplicate db_version entry causing UNIQUE constraint failure
--- Version 4.11
-('db_version', '4.11', 'string', 'Database schema version');
+-- Version 4.12
+('db_version', '4.12', 'string', 'Database schema version');
 INSERT INTO Currencies (currency_code, currency_name, currency_symbol, api_supported) VALUES
 ('CHF', 'Swiss Franc', 'CHF', 0),
 ('EUR', 'Euro', '€', 1),
@@ -261,15 +262,16 @@ INSERT INTO PositionReports (
     quantity,
     purchase_price,
     current_price,
+    notes,
     report_date,
     uploaded_at
 ) VALUES
-    (1, 1, 1, 1, 8, 108.50, 110.00, '2024-12-31', '2025-01-01 08:00:10'),
-    (1, 1, 1, 2, 12, 95.20, 97.00, '2024-12-31', '2025-01-01 08:00:10'),
-    (4, 3, 3, 5, 4, 185.25, 190.00, '2024-12-31', '2025-01-02 09:00:15'),
-    (4, 3, 3, 6, 2, 415.75, 420.00, '2024-12-31', '2025-01-02 09:00:15'),
-    (4, 3, 3, 9, 40, 87.45, 90.00, '2024-12-31', '2025-01-02 09:00:15'),
-    (7, 4, 4, 13, 0.05, 45000.00, 46000.00, '2024-12-31', '2025-01-02 10:00:10'),
-    (7, 4, 4, 14, 1.0, 2800.00, 3000.00, '2024-12-31', '2025-01-02 10:00:10'),
-    (11, 7, 8, 1, 25, 108.50, 110.00, '2025-07-01', '2025-07-02 09:00:15'),
-    (11, 7, 8, 2, 30, 95.20, 97.00, '2025-07-01', '2025-07-02 09:00:15');
+    (1, 1, 1, 1, 8, 108.50, 110.00, NULL, '2024-12-31', '2025-01-01 08:00:10'),
+    (1, 1, 1, 2, 12, 95.20, 97.00, NULL, '2024-12-31', '2025-01-01 08:00:10'),
+    (4, 3, 3, 5, 4, 185.25, 190.00, NULL, '2024-12-31', '2025-01-02 09:00:15'),
+    (4, 3, 3, 6, 2, 415.75, 420.00, NULL, '2024-12-31', '2025-01-02 09:00:15'),
+    (4, 3, 3, 9, 40, 87.45, 90.00, NULL, '2024-12-31', '2025-01-02 09:00:15'),
+    (7, 4, 4, 13, 0.05, 45000.00, 46000.00, NULL, '2024-12-31', '2025-01-02 10:00:10'),
+    (7, 4, 4, 14, 1.0, 2800.00, 3000.00, NULL, '2024-12-31', '2025-01-02 10:00:10'),
+    (11, 7, 8, 1, 25, 108.50, 110.00, NULL, '2025-07-01', '2025-07-02 09:00:15'),
+    (11, 7, 8, 2, 30, 95.20, 97.00, NULL, '2025-07-01', '2025-07-02 09:00:15');

--- a/DragonShield/helpers/Theme.swift
+++ b/DragonShield/helpers/Theme.swift
@@ -55,3 +55,16 @@ struct SecondaryButtonStyle: ButtonStyle {
             .opacity(configuration.isPressed ? 0.8 : 1)
     }
 }
+
+struct DestructiveButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 14, weight: .semibold))
+            .padding(.horizontal, 20)
+            .padding(.vertical, 12)
+            .background(Color.error)
+            .foregroundColor(.white)
+            .cornerRadius(8)
+            .opacity(configuration.isPressed ? 0.8 : 1)
+    }
+}


### PR DESCRIPTION
## Summary
- add notes field to PositionReports schema and bump DB version
- provide CRUD helpers for single position entries
- style destructive button
- wrap Positions table in card with Add/Edit/Delete flows
- introduce position form sheet

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e79e6ee6c8323a995a8ecf540a978