### PR TITLE
Fix toolbar placement for macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Fix compile error on macOS by using `.navigation` toolbar placement
 - Delete position reports for any institution directly from the Positions view
 - Enable manual add, edit and delete of positions with notes field
 - Include all position fields in the add/edit position form

--- a/DragonShield/DragonShieldApp.swift
+++ b/DragonShield/DragonShieldApp.swift
@@ -17,7 +17,7 @@ struct DragonShieldApp: App {
             .environmentObject(assetManager) // Your existing one
             .environmentObject(databaseManager) // <<<< ADD THIS LINE
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .navigation) {
                     ModeBadge()
                         .environmentObject(databaseManager)
                 }


### PR DESCRIPTION
## Summary
- use `.navigation` toolbar placement in DragonShieldApp
- note the macOS compile fix in the changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68718f4a756c8323972ee351e82e0aed