### PR TITLE
fix(view): split DatabaseManagementView into subviews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,4 +144,5 @@ All notable changes to this project will be documented in this file.
 - Delete existing files in target directory before deploying database
 - Stop DragonShield and Xcode when running the database tool
 - Fix initialization of database path when detecting the active mode
+- Break out Database Management view subcomponents to resolve compile timeout
 

--- a/DragonShield/Views/DatabaseManagementView.swift
+++ b/DragonShield/Views/DatabaseManagementView.swift
@@ -17,70 +17,14 @@ struct DatabaseManagementView: View {
             Text("Database Management")
                 .font(.system(size: 18, weight: .semibold))
 
-            Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 16) {
-                GridRow {
-                    Text("Database Path:")
-                    Text(dbManager.dbFilePath)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                        .font(.caption)
-                }
-                GridRow {
-                    Text("File Size:")
-                    Text(fileSizeString)
-                }
-                GridRow {
-                    Text("Schema Version:")
-                    Text(dbManager.dbVersion)
-                }
-            }
-
-            HStack(spacing: 12) {
-                Button(action: backupNow) {
-                    if processing { ProgressView() } else { Text("Backup Database") }
-                }
-                .keyboardShortcut("b", modifiers: [.command])
-                .buttonStyle(PrimaryButtonStyle())
-                .disabled(processing)
-                .accessibilityLabel("Backup Database")
-                .focusable()
-                .help("Create a backup copy of the current database")
-
-                Button("Restore from Backup") { showingFileImporter = true }
-                    .keyboardShortcut("r", modifiers: [.command])
-                    .buttonStyle(SecondaryButtonStyle())
-                    .accessibilityLabel("Restore from Backup")
-                    .focusable()
-
-                Button("Switch Mode") { confirmSwitchMode() }
-                    .keyboardShortcut("m", modifiers: [.command, .shift])
-                    .buttonStyle(SecondaryButtonStyle())
-                    .accessibilityLabel("Switch Mode")
-                    .focusable()
-
-                Button("Migrate Database") { migrateDatabase() }
-                    .keyboardShortcut("m", modifiers: [.command])
-                    .buttonStyle(SecondaryButtonStyle())
-                    .accessibilityLabel("Migrate Database")
-                    .focusable()
-            }
+            databaseInfoGrid
+            actionButtons
 
             Text("Last Backup: \(formattedDate(backupService.lastBackup))")
                 .font(.caption)
                 .foregroundColor(.secondary)
 
-            ScrollView {
-                VStack(alignment: .leading, spacing: 2) {
-                    ForEach(backupService.logMessages.prefix(10), id: .self) { entry in
-                        Text(entry)
-                            .font(.system(.caption2, design: .monospaced))
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                }
-            }
-            .frame(maxHeight: 200)
-            .padding(4)
-            .background(RoundedRectangle(cornerRadius: 4).stroke(Color.gray.opacity(0.2)))
+            backupLogView
         }
         .padding(24)
         .background(Theme.surface)
@@ -176,6 +120,76 @@ struct DatabaseManagementView: View {
 
     private var fileSizeString: String {
         ByteCountFormatter.string(fromByteCount: dbManager.dbFileSize, countStyle: .file)
+    }
+
+    // MARK: - Subviews
+    private var databaseInfoGrid: some View {
+        Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 16) {
+            GridRow {
+                Text("Database Path:")
+                Text(dbManager.dbFilePath)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .font(.caption)
+            }
+            GridRow {
+                Text("File Size:")
+                Text(fileSizeString)
+            }
+            GridRow {
+                Text("Schema Version:")
+                Text(dbManager.dbVersion)
+            }
+        }
+    }
+
+    private var actionButtons: some View {
+        HStack(spacing: 12) {
+            Button(action: backupNow) {
+                if processing { ProgressView() } else { Text("Backup Database") }
+            }
+            .keyboardShortcut("b", modifiers: [.command])
+            .buttonStyle(PrimaryButtonStyle())
+            .disabled(processing)
+            .accessibilityLabel("Backup Database")
+            .focusable()
+            .help("Create a backup copy of the current database")
+
+            Button("Restore from Backup") { showingFileImporter = true }
+                .keyboardShortcut("r", modifiers: [.command])
+                .buttonStyle(SecondaryButtonStyle())
+                .accessibilityLabel("Restore from Backup")
+                .focusable()
+
+            Button("Switch Mode") { confirmSwitchMode() }
+                .keyboardShortcut("m", modifiers: [.command, .shift])
+                .buttonStyle(SecondaryButtonStyle())
+                .accessibilityLabel("Switch Mode")
+                .focusable()
+
+            Button("Migrate Database") { migrateDatabase() }
+                .keyboardShortcut("m", modifiers: [.command])
+                .buttonStyle(SecondaryButtonStyle())
+                .accessibilityLabel("Migrate Database")
+                .focusable()
+        }
+    }
+
+    private var backupLogView: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 2) {
+                ForEach(backupService.logMessages.prefix(10), id: .self) { entry in
+                    Text(entry)
+                        .font(.system(.caption2, design: .monospaced))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+        .frame(maxHeight: 200)
+        .padding(4)
+        .background(
+            RoundedRectangle(cornerRadius: 4).stroke(Color.gray.opacity(0.2))
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- break out DatabaseManagementView into helper subviews
- document compile-time improvement in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871908789f88323a8cfdb69f221e50a