### PR TITLE
feat(backup): allow custom directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 - Fix compile error on macOS by using `.navigation` toolbar placement
 - Allow choosing a writable backup directory with defaults in Documents
+- Prompt for save location when backing up and include mode/version in filename
 - Refactor Database Management screen into subviews to resolve type-check timeout
 - Delete position reports for any institution directly from the Positions view
 - Enable manual add, edit and delete of positions with notes field

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Fix compile error on macOS by using `.navigation` toolbar placement
+- Allow choosing a writable backup directory with defaults in Documents
 - Refactor Database Management screen into subviews to resolve type-check timeout
 - Delete position reports for any institution directly from the Positions view
 - Enable manual add, edit and delete of positions with notes field

--- a/DragonShield/BackupService.swift
+++ b/DragonShield/BackupService.swift
@@ -97,18 +97,20 @@ class BackupService: ObservableObject {
         scheduleTimer()
     }
 
-    func performBackup(dbPath: String) throws -> URL {
-        let fm = FileManager.default
-        try fm.createDirectory(at: backupDirectory, withIntermediateDirectories: true)
+    static func defaultFileName(mode: DatabaseMode, version: String) -> String {
         let df = DateFormatter()
         df.dateFormat = "yyyy-MM-dd-HHmmss"
-        let name = "backup-\(df.string(from: Date())).db"
-        let dest = backupDirectory.appendingPathComponent(name)
-        try fm.copyItem(atPath: dbPath, toPath: dest.path)
+        let modeTag = mode == .production ? "PROD" : "TEST"
+        return "DragonShield-\(modeTag)-v\(version)-\(df.string(from: Date())).db"
+    }
+
+    func performBackup(dbPath: String, to destination: URL) throws -> URL {
+        let fm = FileManager.default
+        try fm.copyItem(atPath: dbPath, toPath: destination.path)
         lastBackup = Date()
         UserDefaults.standard.set(lastBackup, forKey: UserDefaultsKeys.lastBackupTimestamp)
-        appendLog(action: "Backup", file: dest.path, success: true)
-        return dest
+        appendLog(action: "Backup", file: destination.path, success: true)
+        return destination
     }
 
     func performRestore(dbManager: DatabaseManager, from url: URL) throws {

--- a/DragonShield/DragonShield.entitlements
+++ b/DragonShield/DragonShield.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
-	<key>com.apple.security.files.user-selected.read-only</key>
-	<true/>
+        <key>com.apple.security.files.user-selected.read-write</key>
+        <true/>
 </dict>
 </plist>

--- a/DragonShield/Views/DatabaseManagementView.swift
+++ b/DragonShield/Views/DatabaseManagementView.swift
@@ -154,10 +154,20 @@ struct DatabaseManagementView: View {
     }
 
     private func backupNow() {
+        let panel = NSSavePanel()
+        panel.canCreateDirectories = true
+        panel.allowedFileTypes = ["db"]
+        panel.directoryURL = backupService.backupDirectory
+        panel.nameFieldStringValue = BackupService.defaultFileName(
+            mode: dbManager.dbMode,
+            version: dbManager.dbVersion
+        )
+        guard panel.runModal() == .OK, let url = panel.url else { return }
         processing = true
         DispatchQueue.global().async {
             do {
-                _ = try backupService.performBackup(dbPath: dbManager.dbFilePath)
+                try? backupService.updateBackupDirectory(to: url.deletingLastPathComponent())
+                _ = try backupService.performBackup(dbPath: dbManager.dbFilePath, to: url)
                 DispatchQueue.main.async { processing = false }
             } catch {
                 DispatchQueue.main.async {

--- a/DragonShield/Views/DatabaseManagementView.swift
+++ b/DragonShield/Views/DatabaseManagementView.swift
@@ -29,6 +29,17 @@ struct DatabaseManagementView: View {
                 Text("Schema Version:")
                 Text(dbManager.dbVersion)
             }
+            GridRow {
+                Text("Backup Directory:")
+                HStack {
+                    Text(backupService.backupDirectory.path)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .font(.caption)
+                    Button("Change…") { chooseBackupDirectory() }
+                        .buttonStyle(SecondaryButtonStyle())
+                }
+            }
         }
     }
 
@@ -168,6 +179,22 @@ struct DatabaseManagementView: View {
                     processing = false
                     errorMessage = error.localizedDescription
                 }
+            }
+        }
+    }
+
+    private func chooseBackupDirectory() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.canCreateDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.directoryURL = backupService.backupDirectory
+        if panel.runModal() == .OK, let url = panel.url {
+            do {
+                try backupService.updateBackupDirectory(to: url)
+            } catch {
+                errorMessage = error.localizedDescription
             }
         }
     }

--- a/DragonShield/helpers/UserDefaultsKeys.swift
+++ b/DragonShield/helpers/UserDefaultsKeys.swift
@@ -13,4 +13,6 @@ struct UserDefaultsKeys {
     static let backupLog = "backupLog"
     static let lastBackupTimestamp = "lastBackupTimestamp"
     static let databaseMode = "databaseMode"
+    static let backupDirectoryURL = "backupDirectoryURL"
+    static let backupDirectoryBookmark = "backupDirectoryBookmark"
 }


### PR DESCRIPTION
## Summary
- let users select where backups are stored
- default to `~/Documents/DragonShieldBackups`
- log backup path and persist directory in UserDefaults
- show backup location in Database Management screen
- allow read/write access to user-selected directories

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68720e2962e48323be713e7e2a2b5882