### PR TITLE
feat(db): add CLI flags for db_tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project will be documented in this file.
 - Extend institution seed data with contact info and default currencies
 - Delete existing ZKB position reports for all ZKB accounts before importing new positions
 - Replace `account_id` with `institution_id` in `ImportSessions` table
+- Add CLI flags for db_tool to run phases non-interactively
 - Fix incorrect parameter label when starting import sessions
 - Store import sessions by institution and value date, tracking duplicate rows
 - Restyle Currency Maintenance window and update title to "Currency Maintenance"

--- a/tests/test_db_tool.py
+++ b/tests/test_db_tool.py
@@ -34,16 +34,16 @@ def test_db_tool_copies(monkeypatch, tmp_path):
     monkeypatch.setattr(db_tool, 'load_seed_data', lambda *a, **k: 0)
     stopped = []
     monkeypatch.setattr(db_tool, 'stop_apps', lambda: stopped.append(True))
-    monkeypatch.setattr('builtins.input', lambda _: 'y')
 
     old_file = tmp_path / 'old.sqlite'
     old_file.write_text('old')
 
-    db_tool.main(['--target-dir', str(tmp_path)])
+    result = db_tool.main(['--target-dir', str(tmp_path), '--all'])
 
     assert copied['src'].endswith('dragonshield.sqlite')
     assert copied['dst'] == os.path.join(str(tmp_path), 'dragonshield.sqlite')
     assert copied['dir'] == str(tmp_path)
     assert not old_file.exists()
     assert stopped == [True]
+    assert result == 0
 


### PR DESCRIPTION
## Summary
- add argparse flags to `db_tool.py` for non-interactive use
- return exit codes and keep optional interactive mode
- update tests for new CLI
- document the change in the changelog

## Testing
- `python3 -m pytest -q tests/test_db_tool.py::test_db_tool_copies -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_687215028ec4832388795ea615da6537