### PR TITLE
fix(ui): dismiss edit sheet on save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,4 +151,5 @@ All notable changes to this project will be documented in this file.
 - Fix compile errors in Database Management view log lists by splitting `ForEach` expressions
 - Extract log lists into subviews to resolve type-check timeout
 - Remove unused subviews from Database Management view to keep compile times fast
+- Close edit asset class sheet when save succeeds
 

--- a/DragonShield/Views/AssetClassesView.swift
+++ b/DragonShield/Views/AssetClassesView.swift
@@ -700,7 +700,7 @@ struct ModernClassRowView: View {
 }
 
 struct EditAssetClassView: View {
-    @Environment(\.presentationMode) private var presentationMode
+    @Environment(\.dismiss) private var dismiss
     @EnvironmentObject var dbManager: DatabaseManager
     let classId: Int
 
@@ -864,12 +864,12 @@ struct EditAssetClassView: View {
                                             sortOrder: Int(sortOrder) ?? 0)
         isLoading = false
         if ok {
-            alertMessage = "✅ Updated asset class"
             NotificationCenter.default.post(name: NSNotification.Name("RefreshAssetClasses"), object: nil)
+            animateExit()
         } else {
             alertMessage = "❌ Failed to update asset class"
+            showingAlert = true
         }
-        showingAlert = true
     }
 
     private func sectionHeader(title: String, icon: String, color: Color) -> some View {
@@ -924,7 +924,7 @@ struct EditAssetClassView: View {
             sectionsOffset = 50
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-            presentationMode.wrappedValue.dismiss()
+            dismiss()
         }
     }
 }


### PR DESCRIPTION
## Summary
- auto-close EditAssetClassView when save succeeds
- log entry for closing edit sheet in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68721b1ad2088323971e69558064709c