### PR TITLE
feat(backup): support reference data export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Backup reference data separately via new UI button and CLI flag
+- Replace deprecated allowedFileTypes API in Database Management view
 - Fix compile error on macOS by using `.navigation` toolbar placement
 - Allow choosing a writable backup directory with defaults in Documents
 - Prompt for save location when backing up and include mode/version in filename

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Backup reference data separately via new UI button and CLI flag
 - Fix compile error on macOS by using `.navigation` toolbar placement
 - Allow choosing a writable backup directory with defaults in Documents
 - Prompt for save location when backing up and include mode/version in filename

--- a/DragonShield/Views/DatabaseManagementView.swift
+++ b/DragonShield/Views/DatabaseManagementView.swift
@@ -168,7 +168,13 @@ struct DatabaseManagementView: View {
     private func backupNow() {
         let panel = NSSavePanel()
         panel.canCreateDirectories = true
-        panel.allowedFileTypes = ["db"]
+        if #available(macOS 12.0, *) {
+            if let dbType = UTType(filenameExtension: "db") {
+                panel.allowedContentTypes = [dbType]
+            }
+        } else {
+            panel.allowedFileTypes = ["db"]
+        }
         panel.directoryURL = backupService.backupDirectory
         panel.nameFieldStringValue = BackupService.defaultFileName(
             mode: dbManager.dbMode,
@@ -193,7 +199,13 @@ struct DatabaseManagementView: View {
     private func backupReferenceNow() {
         let panel = NSSavePanel()
         panel.canCreateDirectories = true
-        panel.allowedFileTypes = ["sql"]
+        if #available(macOS 12.0, *) {
+            if let sqlType = UTType(filenameExtension: "sql") {
+                panel.allowedContentTypes = [sqlType]
+            }
+        } else {
+            panel.allowedFileTypes = ["sql"]
+        }
         panel.directoryURL = backupService.backupDirectory
         panel.nameFieldStringValue = BackupService.defaultReferenceFileName(
             mode: dbManager.dbMode,

--- a/DragonShield/helpers/UserDefaultsKeys.swift
+++ b/DragonShield/helpers/UserDefaultsKeys.swift
@@ -12,6 +12,7 @@ struct UserDefaultsKeys {
     static let automaticBackupTime = "automaticBackupTime"
     static let backupLog = "backupLog"
     static let lastBackupTimestamp = "lastBackupTimestamp"
+    static let lastReferenceBackupTimestamp = "lastReferenceBackupTimestamp"
     static let databaseMode = "databaseMode"
     static let backupDirectoryURL = "backupDirectoryURL"
     static let backupDirectoryBookmark = "backupDirectoryBookmark"


### PR DESCRIPTION
## Summary
- add reference data dump option to `db_tool.py`
- track last reference backup in user defaults
- allow backing up reference tables via UI with new button
- store reference backup filename using refined naming convention
- test new CLI reference backup flow

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68721eb02108832382fbc0e7841ad593