### PR TITLE
chore: swap ZKB and Credit-Suisse references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,13 +38,13 @@ All notable changes to this project will be documented in this file.
 - Added GPT shell with OpenAI function calling and JSON schema validation
 - Remove duplicate Python package initializer to resolve Xcode resource error
 - Extend institution seed data with contact info and default currencies
-- Delete existing ZKB position reports for all ZKB accounts before importing new positions
+- Delete existing Credit-Suisse position reports for all Credit-Suisse accounts before importing new positions
 - Replace `account_id` with `institution_id` in `ImportSessions` table
 - Add CLI flags for db_tool to run phases non-interactively
 - Fix incorrect parameter label when starting import sessions
 - Store import sessions by institution and value date, tracking duplicate rows
 - Restyle Currency Maintenance window and update title to "Currency Maintenance"
-- Log mapped Asset-Unterkategorie values to AssetSubClass during ZKB import
+- Log mapped Asset-Unterkategorie values to AssetSubClass during Credit-Suisse import
 - Populate sub-class allocation sheet with editable sliders and totals check
 - Display sub-class rows correctly and allow saving with totals other than 100%
 - Fix deprecated onChange warning in Target Allocation view
@@ -73,13 +73,13 @@ All notable changes to this project will be documented in this file.
 - Modernize Asset Class add/edit windows with standard design and logging
 - Modernize Asset Class list view with search, animations and action bar
 - Fix missing modernStatCard helper in Asset Classes view
-- Add ZKB position import with progress logging and summary alert
-- Fix quantity extraction for ZKB position import and document Excel column mapping
+- Add Credit-Suisse position import with progress logging and summary alert
+- Fix quantity extraction for Credit-Suisse position import and document Excel column mapping
 - Parse ticker symbol from Valor and build instrument names including institution and currency
-- Default quantity to zero for "ZKB Call Account USD" when cell is blank
+- Default quantity to zero for "Credit-Suisse Call Account USD" when cell is blank
 - Prompt for instrument details when new securities are imported
-- Automatically create ZKB custody and cash accounts when missing and save position reports
-- Fix unused variable warning when auto-creating ZKB cash accounts
+- Automatically create Credit-Suisse custody and cash accounts when missing and save position reports
+- Fix unused variable warning when auto-creating Credit-Suisse cash accounts
 - Exclude cash instruments from performance and allocation views
 - Fix missing instrument popup and save newly added instruments
 - Fix instrument lookup to prompt when new securities are parsed
@@ -87,20 +87,20 @@ All notable changes to this project will be documented in this file.
 - Provide instrument add dialog with Save/Ignore/Abort when new ISINs are encountered
 - Restyle import popups using instrument maintenance window design
 - Fix compile errors in position review and import views
-- Prompt to delete existing ZKB positions before importing and show count
-- Parse value date from ZKB sheets, show import details summary and improve instrument popups
+- Prompt to delete existing Credit-Suisse positions before importing and show count
+- Parse value date from Credit-Suisse sheets, show import details summary and improve instrument popups
 - Correct custody account number detection from cell B6 and extend new instrument prompt with dropdowns
 - Fix compile error in instrument prompt view when selecting subclass or currency
-- Record ZKB import sessions and link position reports
+- Record Credit-Suisse import sessions and link position reports
 - Eliminate QoS warnings by presenting modals synchronously
 - Condense instrument popups and rename review dialog title
 - Show import summary in modern styled popup
 - Condense import details popup row spacing
-- Default custody positions to "ZKB Custody Account" name
+- Default custody positions to "Credit-Suisse Custody Account" name
 - Fix saving position reports when no import session is created
-- Map ZKB categories to AssetSubClasses using documented table and treat cash
+- Map Credit-Suisse categories to AssetSubClasses using documented table and treat cash
   rows as accounts instead of instruments
-- Fix sub-class mapping using the defined ZKB keywords
+- Fix sub-class mapping using the defined Credit-Suisse keywords
 - Search existing instruments by ticker symbol before prompting
 - Use single custody account for all parsed positions
 - Display a status alert after each position save attempt
@@ -108,39 +108,39 @@ All notable changes to this project will be documented in this file.
 - Prompt to create new accounts when account number is missing and retry if insertion fails
 - Fix compile errors in AccountPromptView due to incorrect parameter labels
 - Improve account lookup when importing positions to match numbers with spaces
-  and require account name containing "ZKB" to prevent repeated prompts
+  and require account name containing "Credit-Suisse" to prevent repeated prompts
 - Append numbers to import session names when duplicates exist
-- Fallback to account lookup by number only to use existing ZKB Custody Account
+- Fallback to account lookup by number only to use existing Credit-Suisse Custody Account
 - Fix account lookup to ignore non-breaking spaces in numbers
 - Retry import session creation when file_hash is unique in older databases
 - Improve custody account search by ignoring hyphens and case
-- Restrict ZKB position deletions to accounts linked to the ZKB institution
-- Add ZKB institution to seed data script for tests
+- Restrict Credit-Suisse position deletions to accounts linked to the Credit-Suisse institution
+- Add Credit-Suisse institution to seed data script for tests
 - Add debug logs for custody account lookups to help diagnose duplicates
-- Strip all non-alphanumeric characters when searching account numbers so the ZKB custody account is detected
+- Strip all non-alphanumeric characters when searching account numbers so the Credit-Suisse custody account is detected
 - Clarify that `Instruments.isin` is optional rather than mandatory
-- Add ZKB Custody Test Account with sample position reports to seed data
+- Add Credit-Suisse Custody Test Account with sample position reports to seed data
 - Look up instruments by ISIN ignoring spaces and case so existing records are detected
-- Store institution_id from the linked account when saving PositionReports and prompt before removing existing ZKB positions
-- Track purchase and current price in PositionReports when importing ZKB files
+- Store institution_id from the linked account when saving PositionReports and prompt before removing existing Credit-Suisse positions
+- Track purchase and current price in PositionReports when importing Credit-Suisse files
 - Display institution name in Positions view
 - Fix Positions view table headers for quantity and price columns
-- Remove OLD-BANK-007 from seed data and rename ZKB Custody test account
+- Remove OLD-BANK-007 from seed data and rename Credit-Suisse Custody test account
 - Populate purchase and current price in seed position reports
 - Fix argument order when constructing PositionReportData to resolve compile error
 - Enlarge the import details popup so all information is visible
-- Delete ZKB position reports using institution_id so all matching entries are removed
+- Delete Credit-Suisse position reports using institution_id so all matching entries are removed
 - Use IN query when deleting by institution so duplicates with the same name are fully removed
 - Ensure seed PositionReports contain only one entry per account and instrument
-- Remove ZKB position reports even when old rows lack an institution_id by joining through Accounts
-- Bind deletion query parameters correctly so ZKB records are removed
-- Delete ZKB positions by institution_id with a single query for reliability
-- Delete ZKB positions by building a dynamic IN clause for all matching institution IDs and log the IDs removed
-- Automatically start ZKB position import when a file is chosen without asking to delete existing rows
+- Remove Credit-Suisse position reports even when old rows lack an institution_id by joining through Accounts
+- Bind deletion query parameters correctly so Credit-Suisse records are removed
+- Delete Credit-Suisse positions by institution_id with a single query for reliability
+- Delete Credit-Suisse positions by building a dynamic IN clause for all matching institution IDs and log the IDs removed
+- Automatically start Credit-Suisse position import when a file is chosen without asking to delete existing rows
 - Condense import popups, enlarge windows and use smaller fonts for better readability
 - Guess asset sub-class from statement categories when adding new instruments
 - Fix asset sub-class dropdown defaulting to Cash when prompting for new instruments
-- Document asset class concept version 2.1 with ZKB mapping
+- Document asset class concept version 2.1 with Credit-Suisse mapping
 - Reduce vertical spacing in import dialogs so all fields fit without scrolling
 - Display instrument currency in Positions view
 - Toggle parsing checkpoints to suppress import popups and show inline summary
@@ -158,4 +158,5 @@ All notable changes to this project will be documented in this file.
 - Add risk-adjusted performance dashboard powered by Python analytics
 - Embed risk scorecard into Portfolio Overview
 - Introduce interactive Asset Dashboard grouped by asset class
+- Swap ZKB and Credit-Suisse references across code and docs
 

--- a/DragonShield/CreditSuisseXLSXProcessor.swift
+++ b/DragonShield/CreditSuisseXLSXProcessor.swift
@@ -1,11 +1,11 @@
-// DragonShield/ZKBXLSXProcessor.swift
+// DragonShield/CreditSuisseXLSXProcessor.swift
 // MARK: - Version 1.0.7.0
 // MARK: - History
-// - 0.0.0.0 -> 1.0.0.0: Initial implementation applying zkb_parser logic in Swift.
+// - 0.0.0.0 -> 1.0.0.0: Initial implementation applying credit_suisse_parser logic in Swift.
 // - 1.0.0.0 -> 1.0.1.0: Log progress and read report date from cell A1.
 // - 1.0.1.0 -> 1.0.1.1: Fix conditional binding when reading cell value.
 // - 1.0.1.1 -> 1.0.1.2: Correct regex pattern for statement date parsing.
-// - 1.0.1.2 -> 1.0.2.0: Parse positions according to ZKB_Parser_Mapping documentation.
+// - 1.0.1.2 -> 1.0.2.0: Parse positions according to Credit-Suisse_Parser_Mapping documentation.
 // - 1.0.2.0 -> 1.0.2.1: Add detailed progress messages for each row.
 // - 1.0.2.1 -> 1.0.3.0: Emit OSLog entries for parsing progress.
 // - 1.0.3.0 -> 1.0.4.0: Log messages via LoggingService and improve number parsing.
@@ -16,7 +16,7 @@
 import Foundation
 import OSLog
 
-struct ZKBXLSXProcessor {
+struct CreditSuisseXLSXProcessor {
     private let parser: XLSXParsingService
     private let log = Logger.parser
     private let logging = LoggingService.shared

--- a/DragonShield/Views/ImportStatementView.swift
+++ b/DragonShield/Views/ImportStatementView.swift
@@ -2,7 +2,7 @@
 // MARK: - Version 1.4.0.0
 // MARK: - History
 // - 1.0 -> 1.1: Corrected use of .foregroundColor to .foregroundStyle for hierarchical styles.
-// - 1.1 -> 1.2: Added ZKB upload section and integrated ImportManager parsing.
+// - 1.1 -> 1.2: Added Credit-Suisse upload section and integrated ImportManager parsing.
 // - 1.2 -> 1.3: Present alert pop-ups when import errors occur.
 // - 1.3 -> 1.4.0.0: Display progress log messages during import.
 
@@ -53,7 +53,7 @@ struct ImportStatementView: View {
                                 }
                                 Divider()
                                 VStack {
-                                    Text("Upload ZKB Statement")
+                                    Text("Upload Credit-Suisse Statement")
                                         .font(.headline)
                                     zkbDropZoneView
                                 }
@@ -180,7 +180,7 @@ struct ImportStatementView: View {
                 .font(.system(size: 80))
                 .foregroundStyle(isTargeted ? Color.accentColor : .gray.opacity(0.4))
 
-            Text("Drag & Drop ZKB File")
+            Text("Drag & Drop Credit-Suisse File")
                 .font(.title2).bold()
                 .foregroundStyle(.secondary)
 
@@ -194,7 +194,7 @@ struct ImportStatementView: View {
             } label: {
                 HStack {
                     Image(systemName: "folder.fill")
-                    Text("Select ZKB File")
+                    Text("Select Credit-Suisse File")
                 }
                 .font(.headline)
             }

--- a/DragonShield/database/schema.txt
+++ b/DragonShield/database/schema.txt
@@ -140,7 +140,7 @@ INSERT INTO Institutions (institution_id, institution_name, institution_type, bi
     contact_info, default_currency, country_code, notes, is_active,
     created_at, updated_at
 ) VALUES
- (1, 'ZKB', 'BANK', 'ZKBKCHZZ80A', 'https://www.zkb.ch',
+ (1, 'Credit-Suisse', 'BANK', 'Credit-SuisseKCHZZ80A', 'https://www.zkb.ch',
     '0844 848 848', 'CHF', 'CH', NULL, 1, '2025-07-08 00:00:00', '2025-07-08 00:00:00'),
  (2, 'Credit Suisse', 'BANK', 'CRESCHZZ80A', 'https://www.credit-suisse.com',
     '0848 880 084', 'CHF', 'CH', NULL, 1, '2025-07-08 00:00:00', '2025-07-08 00:00:00'),
@@ -167,7 +167,7 @@ INSERT INTO Accounts (account_number, account_name, institution_id, account_type
 ('COINBASE-PRO-001', 'Coinbase Pro Account', 4, 3, 'USD', '2024-02-15', 1, 0, 'Trading account, not part of main portfolio value.'),
 ('LEDGER-WALLET-001', 'Ledger Hardware Wallet', 5, 3, 'BTC', '2024-01-01', 1, 1, NULL),
 ('VIAC-3A-12345', 'VIAC 3a Account', 6, 4, 'CHF', '2023-01-01', 0, 1, 'Old pension, currently inactive.'),
-('S 398424-05', 'ZKB Custody Account', 8, 2, 'CHF', '2024-06-01', 1, 1, 'Test ZKB account.');
+('S 398424-05', 'Credit-Suisse Custody Account', 8, 2, 'CHF', '2024-06-01', 1, 1, 'Test Credit-Suisse account.');
 INSERT INTO TransactionTypes (type_code, type_name, type_description, affects_position, affects_cash, is_income, sort_order) VALUES
 ('BUY', 'Purchase', 'Buy securities or assets', 1, 1, 0, 1),
 ('SELL', 'Sale', 'Sell securities or assets', 1, 1, 0, 2),
@@ -250,8 +250,8 @@ INSERT INTO ImportSessions (
         '/uploads/UBS_Positions_2025-06-30.csv', 'CSV', 2060, 'HASH010', 1,
         'COMPLETED', 2, 2, 0, 0, 'Quarter end',
         '2025-07-01 08:00:00', '2025-07-01 08:00:10'),
-    (11, 'ZKB Positions 2025-07-01', 'ZKB_Positions_2025-07-01.xlsx',
-        '/uploads/ZKB_Positions_2025-07-01.xlsx', 'XLSX', 3072, 'HASH011', 8,
+    (11, 'Credit-Suisse Positions 2025-07-01', 'Credit-Suisse_Positions_2025-07-01.xlsx',
+        '/uploads/Credit-Suisse_Positions_2025-07-01.xlsx', 'XLSX', 3072, 'HASH011', 8,
         'COMPLETED', 3, 3, 0, 0, 'Initial import',
         '2025-07-02 09:00:00', '2025-07-02 09:00:15');
 INSERT INTO PositionReports (

--- a/DragonShield/docs/AssetClassDefinitionConcept.md
+++ b/DragonShield/docs/AssetClassDefinitionConcept.md
@@ -17,7 +17,7 @@
 | 1.0     | 2025-06-30 | System                   | Initial creation of the asset class conceptual document.                                     |
 | 1.1     | 2025-06-30 | System                   | Added brief introductory description at the top.                                            |
 | 2.0     | 2025-07-08 | DragonShield Maintainers | Merged hierarchical and unified model; added crypto subclass; consolidated benefits.        |
-| 2.1     | 2025-07-08 | DragonShield Maintainers | Added ZKB Mapping section.                                                                  |
+| 2.1     | 2025-07-08 | DragonShield Maintainers | Added Credit-Suisse Mapping section.                                                                  |
 
 ---
 
@@ -109,9 +109,9 @@ Each instrument record includes:
 
 ---
 
-## 7. ZKB Mapping
+## 7. Credit-Suisse Mapping
 
-| ZKB Group               | AssetClass Code | AssetSubClass Code | Notes                         |
+| Credit-Suisse Group               | AssetClass Code | AssetSubClass Code | Notes                         |
 |-------------------------|-----------------|--------------------|-------------------------------|
 | Cash                    | LIQ             | CASH               | Bank deposit cash balances.   |
 | Money Market Funds      | LIQ             | MMKT               | Money market instruments.     |
@@ -129,20 +129,20 @@ Each instrument record includes:
 
 ---
 
-Below is a concrete illustration of how a ZKB setup would look in your unified model. We show three tables—​Accounts, Instruments, and Positions—​with sample data for:
-	•	Two cash accounts at ZKB (CHF and USD)
-	•	One ZKB custody account
+Below is a concrete illustration of how a Credit-Suisse setup would look in your unified model. We show three tables—​Accounts, Instruments, and Positions—​with sample data for:
+	•	Two cash accounts at Credit-Suisse (CHF and USD)
+	•	One Credit-Suisse custody account
 	•	Cash instruments & two equities
 
-# ZKB Example in DragonShield Model
+# Credit-Suisse Example in DragonShield Model
 
 ## 1. Accounts
 
 | account_id | account_name             | account_type | bank |
 |-----------:|--------------------------|--------------|------|
-| 101        | ZKB CHF Cash Account     | CASH         | ZKB  |
-| 102        | ZKB USD Cash Account     | CASH         | ZKB  |
-| 201        | ZKB Custody Account      | CUSTODY      | ZKB  |
+| 101        | Credit-Suisse CHF Cash Account     | CASH         | Credit-Suisse  |
+| 102        | Credit-Suisse USD Cash Account     | CASH         | Credit-Suisse  |
+| 201        | Credit-Suisse Custody Account      | CUSTODY      | Credit-Suisse  |
 
 ## 2. Instruments
 
@@ -179,5 +179,5 @@ Below is a concrete illustration of how a ZKB setup would look in your unified m
   - Deposits/withdrawals and buy/sell operations all reference an `instrument_id`.  
   - Single Positions view aggregates cash and securities identically.  
 
-*End of Asset Class Definition Concept (v2.1 with ZKB mapping)*
+*End of Asset Class Definition Concept (v2.1 with Credit-Suisse mapping)*
 

--- a/DragonShield/python_scripts/credit_suisse_parser.py
+++ b/DragonShield/python_scripts/credit_suisse_parser.py
@@ -1,4 +1,4 @@
-# python_scripts/zkb_parser.py
+# python_scripts/credit_suisse_parser.py
 
 # MARK: - Version 0.11
 # MARK: - History
@@ -146,7 +146,7 @@ def process_file(filepath: str, sheet_name_or_index: Optional[Any] = None) -> in
     # (Initialization of parsed_data and stats variables remains the same)
     parsed_data = {
         "main_custody_account_nr": None,
-        "institution_name": "ZKB",
+        "institution_name": "Credit-Suisse",
         "parsed_statement_date": parse_statement_date_from_filename(filepath.split('/')[-1]), # Pass only filename
         "summary": {
             "processed_file": filepath, "total_data_rows_attempted": 0, 
@@ -240,7 +240,7 @@ def process_file(filepath: str, sheet_name_or_index: Optional[Any] = None) -> in
 
             parsed_data["summary"]["data_rows_successfully_parsed"] += 1
             record_data: Dict[str, Any] = {}
-            record_data["institution_name"] = "ZKB"
+            record_data["institution_name"] = "Credit-Suisse"
             record_data["main_custody_account_nr_from_file"] = main_custody_account_nr_internal
             asset_unterkategorie_str = get_str_val_from_tuple(COL_ASSET_UNTERKATEGORIE)
             mapped_group = get_mapped_instrument_group(anlagekategorie_str, asset_unterkategorie_str, unmapped_category_pairs_internal)
@@ -311,6 +311,6 @@ if __name__ == "__main__":
         code = process_file(filepath_arg)
         sys.exit(code)
     else:
-        print(json.dumps({"error": "Please provide the XLSX file path as an argument.", "usage": "python zkb_parser.py <path_to_your_ZKB_file.xlsx>"}))
+        print(json.dumps({"error": "Please provide the XLSX file path as an argument.", "usage": "python credit_suisse_parser.py <path_to_your_Credit-Suisse_file.xlsx>"}))
         sys.exit(1)
 

--- a/DragonShield/python_scripts/import_tool.py
+++ b/DragonShield/python_scripts/import_tool.py
@@ -16,7 +16,7 @@ import io
 import contextlib
 from typing import Any, Dict, Tuple, Optional
 
-import zkb_parser  # existing parser in the same folder
+import credit_suisse_parser  # existing parser in the same folder
 
 DB_PATH = os.path.join(
     "/Users/renekeller/Library/Containers/com.rene.DragonShield/Data/Library/Application Support/DragonShield",
@@ -112,7 +112,7 @@ def update_session(conn: sqlite3.Connection, sess_id: int, status: str,
 def parse_file(path: str) -> Dict[str, Any]:
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
-        zkb_parser.process_file(path)
+        credit_suisse_parser.process_file(path)
     return json.loads(buf.getvalue())
 
 

--- a/DragonShield/python_scripts/parser_utils.py
+++ b/DragonShield/python_scripts/parser_utils.py
@@ -21,7 +21,7 @@ class DefaultFileManager:
 
 def findParserScript(file_manager: FileManagerProtocol = DefaultFileManager()) -> Tuple[str, List[str]]:
     """Return the path to the bundled parser script and list of checked paths."""
-    script_name = "zkb_parser.py"
+    script_name = "credit_suisse_parser.py"
     module_dir = Path(__file__).resolve().parent
     project_dir = module_dir.parents[2]
     candidates = [

--- a/DragonShield/test_data/institutions.sql
+++ b/DragonShield/test_data/institutions.sql
@@ -13,7 +13,7 @@ INSERT INTO Institutions (
     created_at,
     updated_at
 ) VALUES
-    (1, 'ZKB', 'BANK', 'ZKBKCHZZ80A', 'https://www.zkb.ch', '0844 848 848', 'CHF', 'CH', NULL, 1, '2025-07-08 00:00:00', '2025-07-08 00:00:00'),
+    (1, 'Credit-Suisse', 'BANK', 'Credit-SuisseKCHZZ80A', 'https://www.zkb.ch', '0844 848 848', 'CHF', 'CH', NULL, 1, '2025-07-08 00:00:00', '2025-07-08 00:00:00'),
     (2, 'Credit Suisse', 'BANK', 'CRESCHZZ80A', 'https://www.credit-suisse.com', '0848 880 084', 'CHF', 'CH', NULL, 1, '2025-07-08 00:00:00', '2025-07-08 00:00:00'),
     (3, 'Sygnum Bank', 'BANK', 'SYGNCHZZ', 'https://www.sygnum.com', 'info@sygnum.com', 'CHF', 'CH', 'Digital asset bank', 1, '2025-07-08 00:00:00', '2025-07-08 00:00:00'),
     (4, 'Graubündner Kantonalbank', 'BANK', 'GRKBCH2270A', 'https://www.gkb.ch', 'info@gkb.ch', 'CHF', 'CH', 'Regional cantonal bank', 1, '2025-07-08 00:00:00', '2025-07-08 00:00:00'),

--- a/tests/test_import_tool.py
+++ b/tests/test_import_tool.py
@@ -106,7 +106,7 @@ def test_parse_file(monkeypatch, tmp_path):
     def fake_process_file(path):
         print(json.dumps(sample))
 
-    monkeypatch.setattr(import_tool, 'zkb_parser', type('M', (), {'process_file': fake_process_file}))
+    monkeypatch.setattr(import_tool, 'credit_suisse_parser', type('M', (), {'process_file': fake_process_file}))
 
     f = tmp_path / 'doc.csv'
     f.write_text('x')

--- a/tests/test_parser_utils.py
+++ b/tests/test_parser_utils.py
@@ -23,7 +23,7 @@ class DummyFM:
 
 
 def test_find_parser_first_candidate():
-    expected = str(Path(parser_utils.__file__).resolve().parent / "zkb_parser.py")
+    expected = str(Path(parser_utils.__file__).resolve().parent / "credit_suisse_parser.py")
     fm = DummyFM(existing_path=expected)
 
     path, checked = parser_utils.findParserScript(fm)
@@ -33,8 +33,8 @@ def test_find_parser_first_candidate():
 
 
 def test_find_parser_second_candidate():
-    first = str(Path(parser_utils.__file__).resolve().parent / "zkb_parser.py")
-    second = str(Path(parser_utils.__file__).resolve().parents[3] / "python_scripts" / "zkb_parser.py")
+    first = str(Path(parser_utils.__file__).resolve().parent / "credit_suisse_parser.py")
+    second = str(Path(parser_utils.__file__).resolve().parents[3] / "python_scripts" / "credit_suisse_parser.py")
     fm = DummyFM(existing_path=second)
 
     path, checked = parser_utils.findParserScript(fm)

--- a/tests/test_position_deletion.py
+++ b/tests/test_position_deletion.py
@@ -27,10 +27,10 @@ def setup_db():
         )
     """)
     # Insert institutions
-    conn.execute("INSERT INTO Institutions VALUES (1, 'ZKB')")
+    conn.execute("INSERT INTO Institutions VALUES (1, 'Credit-Suisse')")
     conn.execute("INSERT INTO Institutions VALUES (2, 'OtherBank')")
     # Insert accounts
-    conn.execute("INSERT INTO Accounts VALUES (1, 'ZKB-ACC', 1)")
+    conn.execute("INSERT INTO Accounts VALUES (1, 'Credit-Suisse-ACC', 1)")
     conn.execute("INSERT INTO Accounts VALUES (2, 'OTHER-ACC', 2)")
     # Insert position reports - some with correct institution_id, some with wrong
     conn.execute("INSERT INTO PositionReports VALUES (1, 1, 1, 1, 10, '2024-01-01')")
@@ -66,8 +66,8 @@ def test_delete_query_with_missing_param():
 
 def test_delete_multiple_ids():
     conn = setup_db()
-    conn.execute("INSERT INTO Institutions VALUES (3, 'ZKB')")
-    conn.execute("INSERT INTO Accounts VALUES (3, 'ZKB2', 3)")
+    conn.execute("INSERT INTO Institutions VALUES (3, 'Credit-Suisse')")
+    conn.execute("INSERT INTO Accounts VALUES (3, 'Credit-Suisse2', 3)")
     conn.execute("INSERT INTO PositionReports VALUES (4, 3, 3, 1, 40, '2024-01-01')")
     query = build_delete_query(2)
     ids = (1, 3, 1, 3)


### PR DESCRIPTION
## Summary
- replace ZKB with Credit-Suisse across code and docs
- rename parser and processor classes to CreditSuisse
- adjust test fixtures for new parser name
- update institutions seed data
- add changelog entry

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687231a4bf248323b985a149257f4c79