### PR TITLE
Fix backup compile error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,3 +179,4 @@ All notable changes to this project will be documented in this file.
 - Fix missing SQLITE_TRANSIENT constant in reference data backup
 
 - Fix nested transaction error during reference data restore
+- Fix missing `rowCounts` call in BackupService causing compilation failure

--- a/DragonShield/BackupService.swift
+++ b/DragonShield/BackupService.swift
@@ -199,7 +199,6 @@ class BackupService: ObservableObject {
 
         try dump.write(to: destination, atomically: true, encoding: .utf8)
 
-        let counts = rowCounts(db: db, tables: referenceTables)
         lastReferenceBackup = Date()
         UserDefaults.standard.set(lastReferenceBackup, forKey: UserDefaultsKeys.lastReferenceBackupTimestamp)
 
@@ -275,7 +274,6 @@ class BackupService: ObservableObject {
         try execute("PRAGMA foreign_keys=ON;", on: db)
 
         dbManager.loadConfiguration()
-        let counts = rowCounts(db: db, tables: referenceTables)
         lastReferenceBackup = Date()
         UserDefaults.standard.set(lastReferenceBackup, forKey: UserDefaultsKeys.lastReferenceBackupTimestamp)
         var counts = [String]()


### PR DESCRIPTION
## Summary
- remove obsolete call to `rowCounts` in `BackupService`
- document fix in CHANGELOG

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68729a65b1f883239c7a8475725fd3dc