### PR TITLE
Remove custody terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 - Add dedicated reference data backup and restore with grouped buttons
 - Fix compile error from missing `rowCounts` helper
+- Fix redeclaration of `counts` in BackupService
 - Backup reference data separately via new UI button and CLI flag
 - Restore reference data from SQL or JSON with dedicated button
 - Export reference tables as SQL with CREATE and INSERT statements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to this project will be documented in this file.
 - Fix Full Database restore button not showing file picker
 - Delete position reports for any institution directly from the Positions view
 - Enable manual add, edit and delete of positions with notes field
-- Offer disable or delete option for custody accounts with dependency check
+- Offer disable or delete option for accounts with dependency check
 - Include all position fields in the add/edit position form
 - Fix compilation errors in Positions view after CRUD refactor
 - Move database info panel from Settings to Database Management view
@@ -82,7 +82,7 @@ All notable changes to this project will be documented in this file.
 - Replace Institutions seed data with new dataset
 - Rename cash account names using institution and currency codes
 - Restyled Institutions maintenance window for consistent look and feel
-- Retry account prompt until a custody account is created during position import
+- Retry account prompt until a account is created during position import
 - Fix compile error in Institutions view due to missing empty state component
 - Added Asset Class maintenance screens with create, update and delete
 - Fix compile errors in Asset Class maintenance view on macOS
@@ -94,7 +94,7 @@ All notable changes to this project will be documented in this file.
 - Parse ticker symbol from Valor and build instrument names including institution and currency
 - Default quantity to zero for "Credit-Suisse Call Account USD" when cell is blank
 - Prompt for instrument details when new securities are imported
-- Automatically create Credit-Suisse custody and cash accounts when missing and save position reports
+- Automatically create Credit-Suisse accounts when missing and save position reports
 - Fix unused variable warning when auto-creating Credit-Suisse cash accounts
 - Exclude cash instruments from performance and allocation views
 - Fix missing instrument popup and save newly added instruments
@@ -105,20 +105,20 @@ All notable changes to this project will be documented in this file.
 - Fix compile errors in position review and import views
 - Prompt to delete existing Credit-Suisse positions before importing and show count
 - Parse value date from Credit-Suisse sheets, show import details summary and improve instrument popups
-- Correct custody account number detection from cell B6 and extend new instrument prompt with dropdowns
+- Correct account number detection from cell B6 and extend new instrument prompt with dropdowns
 - Fix compile error in instrument prompt view when selecting subclass or currency
 - Record Credit-Suisse import sessions and link position reports
 - Eliminate QoS warnings by presenting modals synchronously
 - Condense instrument popups and rename review dialog title
 - Show import summary in modern styled popup
 - Condense import details popup row spacing
-- Default custody positions to "Credit-Suisse Custody Account" name
+- Default positions to "Credit-Suisse account" name
 - Fix saving position reports when no import session is created
 - Map Credit-Suisse categories to AssetSubClasses using documented table and treat cash
   rows as accounts instead of instruments
 - Fix sub-class mapping using the defined Credit-Suisse keywords
 - Search existing instruments by ticker symbol before prompting
-- Use single custody account for all parsed positions
+- Use single account for all parsed positions
 - Display a status alert after each position save attempt
 - Allow reimporting the same file by removing unique constraint on file hash
 - Prompt to create new accounts when account number is missing and retry if insertion fails
@@ -126,22 +126,22 @@ All notable changes to this project will be documented in this file.
 - Improve account lookup when importing positions to match numbers with spaces
   and require account name containing "Credit-Suisse" to prevent repeated prompts
 - Append numbers to import session names when duplicates exist
-- Fallback to account lookup by number only to use existing Credit-Suisse Custody Account
+- Fallback to account lookup by number only to use existing Credit-Suisse account
 - Fix account lookup to ignore non-breaking spaces in numbers
 - Retry import session creation when file_hash is unique in older databases
-- Improve custody account search by ignoring hyphens and case
+- Improve account search by ignoring hyphens and case
 - Restrict Credit-Suisse position deletions to accounts linked to the Credit-Suisse institution
 - Add Credit-Suisse institution to seed data script for tests
-- Add debug logs for custody account lookups to help diagnose duplicates
-- Strip all non-alphanumeric characters when searching account numbers so the Credit-Suisse custody account is detected
+- Add debug logs for account lookups to help diagnose duplicates
+- Strip all non-alphanumeric characters when searching account numbers so the Credit-Suisse account is detected
 - Clarify that `Instruments.isin` is optional rather than mandatory
-- Add Credit-Suisse Custody Test Account with sample position reports to seed data
+- Add Credit-Suisse Test Account with sample position reports to seed data
 - Look up instruments by ISIN ignoring spaces and case so existing records are detected
 - Store institution_id from the linked account when saving PositionReports and prompt before removing existing Credit-Suisse positions
 - Track purchase and current price in PositionReports when importing Credit-Suisse files
 - Display institution name in Positions view
 - Fix Positions view table headers for quantity and price columns
-- Remove OLD-BANK-007 from seed data and rename Credit-Suisse Custody test account
+- Remove OLD-BANK-007 from seed data and rename Credit-Suisse test account
 - Populate purchase and current price in seed position reports
 - Fix argument order when constructing PositionReportData to resolve compile error
 - Enlarge the import details popup so all information is visible
@@ -178,4 +178,5 @@ All notable changes to this project will be documented in this file.
 - Fix duplicate reference restore function to resolve compilation error
 - Fix missing SQLITE_TRANSIENT constant in reference data backup
 
+- Replace "Custody Accounts" wording with "Accounts" across the app and docs
 - Fix nested transaction error during reference data restore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Add dedicated reference data backup and restore with grouped buttons
+- Fix compile error from missing `rowCounts` helper
 - Backup reference data separately via new UI button and CLI flag
 - Restore reference data from SQL or JSON with dedicated button
 - Export reference tables as SQL with CREATE and INSERT statements

--- a/DragonShield/BackupService.swift
+++ b/DragonShield/BackupService.swift
@@ -203,12 +203,9 @@ class BackupService: ObservableObject {
         lastReferenceBackup = Date()
         UserDefaults.standard.set(lastReferenceBackup, forKey: UserDefaultsKeys.lastReferenceBackupTimestamp)
 
-        var counts = [String]()
-        for tbl in referenceTables {
-            if let n = try? dbManager.rowCount(table: tbl) { counts.append("\(tbl): \(n)") }
-        }
         DispatchQueue.main.async {
-            self.logMessages.append("✅ Backed up Reference data — " + counts.joined(separator: ", "))
+            let summary = counts.map { "\($0.0): \($0.1)" }.joined(separator: ", ")
+            self.logMessages.append("✅ Backed up Reference data — " + summary)
             self.appendLog(action: "RefBackup", file: destination.lastPathComponent, success: true)
         }
 
@@ -278,12 +275,9 @@ class BackupService: ObservableObject {
         let counts = rowCounts(db: db, tables: referenceTables)
         lastReferenceBackup = Date()
         UserDefaults.standard.set(lastReferenceBackup, forKey: UserDefaultsKeys.lastReferenceBackupTimestamp)
-        var counts = [String]()
-        for tbl in referenceTables {
-            if let n = try? dbManager.rowCount(table: tbl) { counts.append("\(tbl): \(n)") }
-        }
         DispatchQueue.main.async {
-            self.logMessages.append("✅ Restored Reference data — " + counts.joined(separator: ", "))
+            let summary = counts.map { "\($0.0): \($0.1)" }.joined(separator: ", ")
+            self.logMessages.append("✅ Restored Reference data — " + summary)
             self.appendLog(action: "RefRestore", file: url.lastPathComponent, success: true)
         }
 

--- a/DragonShield/CreditSuissePositionParser.swift
+++ b/DragonShield/CreditSuissePositionParser.swift
@@ -84,7 +84,7 @@ struct CreditSuissePositionParser {
             let accountName = isCash ? Self.renameCashAccount(description: descr,
                                                              currency: currency,
                                                              institution: "Credit-Suisse")
-                                      : "Credit-Suisse Custody Account"
+                                     : "Credit-Suisse Account"
             let record = ParsedPositionRecord(accountNumber: accountNumber,
                                                accountName: accountName,
                                                instrumentName: instrumentName,

--- a/DragonShield/DatabaseManager+OtherData.swift
+++ b/DragonShield/DatabaseManager+OtherData.swift
@@ -27,8 +27,8 @@ extension DatabaseManager {
         print("ℹ️ fetchPositions() called - returning sample data.")
         let formatter = ISO8601DateFormatter()
         return [
-            PositionData(id: 1, portfolioName: "Main", accountName: "Sample Custody", instrumentName: "Apple Inc.", quantity: 10, valueChf: 2500.0, uploadedAt: formatter.date(from: "2025-06-01T10:00:00Z")!, reportDate: formatter.date(from: "2025-05-31T00:00:00Z")!),
-            PositionData(id: 2, portfolioName: "Main", accountName: "Sample Custody", instrumentName: "iShares MSCI World ETF", quantity: 20, valueChf: 1500.0, uploadedAt: formatter.date(from: "2025-06-01T10:00:00Z")!, reportDate: formatter.date(from: "2025-05-31T00:00:00Z")!),
+            PositionData(id: 1, portfolioName: "Main", accountName: "Sample Account", instrumentName: "Apple Inc.", quantity: 10, valueChf: 2500.0, uploadedAt: formatter.date(from: "2025-06-01T10:00:00Z")!, reportDate: formatter.date(from: "2025-05-31T00:00:00Z")!),
+            PositionData(id: 2, portfolioName: "Main", accountName: "Sample Account", instrumentName: "iShares MSCI World ETF", quantity: 20, valueChf: 1500.0, uploadedAt: formatter.date(from: "2025-06-01T10:00:00Z")!, reportDate: formatter.date(from: "2025-05-31T00:00:00Z")!),
             PositionData(id: 3, portfolioName: "Crypto", accountName: "Ledger", instrumentName: "Bitcoin", quantity: 0.5, valueChf: 14000.0, uploadedAt: formatter.date(from: "2025-06-02T11:00:00Z")!, reportDate: formatter.date(from: "2025-06-01T00:00:00Z")!)
         ]
     }

--- a/DragonShield/ImportManager.swift
+++ b/DragonShield/ImportManager.swift
@@ -90,7 +90,7 @@ class ImportManager {
         var result: AccountPromptResult = .cancel
         let instId = dbManager.findInstitutionId(name: "Credit-Suisse") ?? 1
         let typeId = dbManager.findAccountTypeId(code: accountTypeCode) ?? 1
-        let defaultName = accountTypeCode == "CASH" ? "Credit-Suisse Cash Account" : "Credit-Suisse Custody Account"
+        let defaultName = accountTypeCode == "CASH" ? "Credit-Suisse Cash Account" : "Credit-Suisse Account"
         let view = AccountPromptView(accountName: defaultName,
                                      accountNumber: number,
                                      institutionId: instId,
@@ -292,7 +292,7 @@ class ImportManager {
                     } else {
                         let instId = self.dbManager.findInstitutionId(name: "Credit-Suisse") ?? 1
                         let typeId = self.dbManager.findAccountTypeId(code: "CUSTODY") ?? 1
-                        _ = self.dbManager.addAccount(accountName: "Credit-Suisse Custody Account",
+                        _ = self.dbManager.addAccount(accountName: "Credit-Suisse Account",
                                                        institutionId: instId,
                                                        accountNumber: custodyNumber,
                                                        accountTypeId: typeId,

--- a/DragonShield/Views/AccountTypesView.swift
+++ b/DragonShield/Views/AccountTypesView.swift
@@ -110,7 +110,7 @@ struct AccountTypesView: View {
                         .font(.system(size: 32, weight: .bold, design: .rounded))
                         .foregroundStyle(LinearGradient(colors: [.black, .gray], startPoint: .top, endPoint: .bottom))
                 }
-                Text("Manage types for your custody and bank accounts")
+                Text("Manage types for your accounts")
                     .font(.subheadline).foregroundColor(.gray)
             }
             Spacer()

--- a/DragonShield/Views/AccountsView.swift
+++ b/DragonShield/Views/AccountsView.swift
@@ -1,18 +1,18 @@
-// DragonShield/Views/CustodyAccountsView.swift
+// DragonShield/Views/AccountsView.swift
 // MARK: - Version 1.6
 // MARK: - History
 // - 1.4 -> 1.5: Accounts now reference Institutions. Added picker fields.
 // - 1.5 -> 1.6: Added institution picker to Edit view to resolve compile error.
 // - 1.3 -> 1.4: Updated deprecated onChange modifiers to new syntax for macOS 14.0+.
 // - 1.2 -> 1.3: Updated Add/Edit views to use Picker for AccountType based on normalized schema.
-// - 1.2 (Corrected - Full): Ensured all helper views like accountsContent, emptyStateView, accountsTable are fully defined within CustodyAccountsView. Provided full implementations for helper functions in Add/Edit views and fixed animation function signatures.
+// - 1.2 (Corrected - Full): Ensured all helper views like accountsContent, emptyStateView, accountsTable are fully defined within AccountsView. Provided full implementations for helper functions in Add/Edit views and fixed animation function signatures.
 // - 1.1 -> 1.2: Updated Add/Edit views to include institutionBic, optional openingDate, and optional closingDate.
-// - 1.0 -> 1.1: Fixed EditCustodyAccountView initializer access level and incorrect String.trim() calls. Corrected onChange usage in text fields.
+// - 1.0 -> 1.1: Fixed EditAccountView initializer access level and incorrect String.trim() calls. Corrected onChange usage in text fields.
 
 import SwiftUI
 
-// Main View for Custody Accounts
-struct CustodyAccountsView: View {
+// Main View for Accounts
+struct AccountsView: View {
     @EnvironmentObject var dbManager: DatabaseManager
 
     @State private var accounts: [DatabaseManager.AccountData] = []
@@ -59,17 +59,17 @@ struct CustodyAccountsView: View {
             loadAccounts()
             animateEntrance()
         }
-        .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("RefreshCustodyAccounts"))) { _ in
+        .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("RefreshAccounts"))) { _ in
             loadAccounts()
         }
         .onChange(of: dbManager.tableRowSpacing) { _, _ in }
         .onChange(of: dbManager.tableRowPadding) { _, _ in }
         .sheet(isPresented: $showAddAccountSheet) {
-            AddCustodyAccountView().environmentObject(dbManager)
+            AddAccountView().environmentObject(dbManager)
         }
         .sheet(isPresented: $showEditAccountSheet) {
             if let account = selectedAccount {
-                EditCustodyAccountView(accountId: account.id).environmentObject(dbManager)
+                EditAccountView(accountId: account.id).environmentObject(dbManager)
             }
         }
         .confirmationDialog("Account Action", isPresented: $showingDeleteAlert, titleVisibility: .visible) {
@@ -92,7 +92,7 @@ struct CustodyAccountsView: View {
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 12) {
                     Image(systemName: "building.columns.fill").font(.system(size: 32)).foregroundColor(.blue)
-                    Text("Custody Accounts").font(.system(size: 32, weight: .bold, design: .rounded)).foregroundStyle(LinearGradient(colors: [.black, .gray], startPoint: .top, endPoint: .bottom))
+                    Text("Accounts").font(.system(size: 32, weight: .bold, design: .rounded)).foregroundStyle(LinearGradient(colors: [.black, .gray], startPoint: .top, endPoint: .bottom))
                 }
                 Text("Manage your brokerage, bank, and exchange accounts").font(.subheadline).foregroundColor(.gray)
             }
@@ -141,9 +141,9 @@ struct CustodyAccountsView: View {
                     .font(.system(size: 64))
                     .foregroundStyle(LinearGradient(colors: [.gray.opacity(0.5), .gray.opacity(0.3)], startPoint: .top, endPoint: .bottom))
                 VStack(spacing: 8) {
-                    Text(searchText.isEmpty && accounts.isEmpty ? "No custody accounts yet" : "No matching accounts")
+                    Text(searchText.isEmpty && accounts.isEmpty ? "No accounts yet" : "No matching accounts")
                         .font(.title2).fontWeight(.semibold).foregroundColor(.gray)
-                    Text(searchText.isEmpty && accounts.isEmpty ? "Add your first custody account to get started." : "Try adjusting your search terms.")
+                    Text(searchText.isEmpty && accounts.isEmpty ? "Add your first account to get started." : "Try adjusting your search terms.")
                         .font(.body).foregroundColor(.gray).multilineTextAlignment(.center)
                 }
                 if searchText.isEmpty && accounts.isEmpty {
@@ -168,7 +168,7 @@ struct CustodyAccountsView: View {
             ScrollView {
                 LazyVStack(spacing: CGFloat(dbManager.tableRowSpacing)) {
                     ForEach(filteredAccounts) { account in
-                        ModernCustodyAccountRowView(
+                        ModernAccountRowView(
                             account: account,
                             isSelected: selectedAccount?.id == account.id,
                             rowPadding: CGFloat(dbManager.tableRowPadding),
@@ -280,7 +280,7 @@ struct CustodyAccountsView: View {
     }
 }
 
-struct ModernCustodyAccountRowView: View {
+struct ModernAccountRowView: View {
     let account: DatabaseManager.AccountData // No change needed here as accountType is already the name
     let isSelected: Bool
     let rowPadding: CGFloat
@@ -320,8 +320,8 @@ struct ModernCustodyAccountRowView: View {
     }
 }
 
-// Add Custody Account View - MODIFIED
-struct AddCustodyAccountView: View {
+// Add Account View - MODIFIED
+struct AddAccountView: View {
     @Environment(\.presentationMode) private var presentationMode
     @EnvironmentObject var dbManager: DatabaseManager
     
@@ -370,7 +370,7 @@ struct AddCustodyAccountView: View {
     private var addModernHeader: some View {
         HStack {
             Button { animateAddExit() } label: { Image(systemName: "xmark").modifier(ModernSubtleButton()) }; Spacer()
-            HStack(spacing: 12) { Image(systemName: "plus.circle.fill").font(.system(size: 24)).foregroundColor(.blue); Text("Add Custody Account").font(.system(size: 24, weight: .bold, design: .rounded)).foregroundStyle(LinearGradient(colors: [.black, .gray], startPoint: .top, endPoint: .bottom)) }; Spacer()
+            HStack(spacing: 12) { Image(systemName: "plus.circle.fill").font(.system(size: 24)).foregroundColor(.blue); Text("Add Account").font(.system(size: 24, weight: .bold, design: .rounded)).foregroundStyle(LinearGradient(colors: [.black, .gray], startPoint: .top, endPoint: .bottom)) }; Spacer()
             Button { saveAccount() } label: { HStack(spacing: 8) { if isLoading { ProgressView().progressViewStyle(.circular).tint(.white).scaleEffect(0.8) } else { Image(systemName: "checkmark").font(.system(size: 14, weight: .bold)) }; Text(isLoading ? "Saving..." : "Save") .font(.system(size: 14, weight: .semibold)) }.modifier(ModernPrimaryButton(color: .blue, isDisabled: isLoading || !isValid)) }
         }.padding(.horizontal, 24).padding(.vertical, 20).opacity(headerOpacity)
     }
@@ -552,14 +552,14 @@ private var accountTypePickerField: some View {
             notes: notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : notes.trimmingCharacters(in: .whitespacesAndNewlines)
         )
         isLoading = false
-        if success { alertMessage = "✅ Account '\(accountName)' added successfully!"; NotificationCenter.default.post(name: NSNotification.Name("RefreshCustodyAccounts"), object: nil);
+        if success { alertMessage = "✅ Account '\(accountName)' added successfully!"; NotificationCenter.default.post(name: NSNotification.Name("RefreshAccounts"), object: nil);
         } else { alertMessage = "❌ Failed to add account. Please try again."; if alertMessage.contains("UNIQUE constraint failed: Accounts.account_number") { alertMessage = "❌ Failed to add account: Account Number must be unique."} }
         showingAlert = true
     }
 }
 
-// Edit Custody Account View - MODIFIED
-struct EditCustodyAccountView: View {
+// Edit Account View - MODIFIED
+struct EditAccountView: View {
     @Environment(\.presentationMode) private var presentationMode
     @EnvironmentObject var dbManager: DatabaseManager
     let accountId: Int
@@ -622,7 +622,7 @@ struct EditCustodyAccountView: View {
     private var editModernHeader: some View {
         HStack {
             Button { if hasChanges { showUnsavedChangesAlert() } else { animateEditExit() } } label: { Image(systemName: "xmark").modifier(ModernSubtleButton()) }; Spacer()
-            HStack(spacing: 12) { Image(systemName: "pencil.line").font(.system(size: 24)).foregroundColor(.orange); Text("Edit Custody Account").font(.system(size: 24, weight: .bold, design: .rounded)).foregroundStyle(LinearGradient(colors: [.black, .gray], startPoint: .top, endPoint: .bottom)) }; Spacer()
+            HStack(spacing: 12) { Image(systemName: "pencil.line").font(.system(size: 24)).foregroundColor(.orange); Text("Edit Account").font(.system(size: 24, weight: .bold, design: .rounded)).foregroundStyle(LinearGradient(colors: [.black, .gray], startPoint: .top, endPoint: .bottom)) }; Spacer()
             Button { saveAccountChanges() } label: { HStack(spacing: 8) { if isLoading { ProgressView().progressViewStyle(.circular).tint(.white).scaleEffect(0.8) } else { Image(systemName: hasChanges ? "checkmark.circle.fill" : "checkmark").font(.system(size: 14, weight: .bold)) }; Text(isLoading ? "Saving..." : "Save Changes").font(.system(size: 14, weight: .semibold)) }.modifier(ModernPrimaryButton(color: .orange, isDisabled: isLoading || !isValid || !hasChanges)) }
         }.padding(.horizontal, 24).padding(.vertical, 20).opacity(headerOpacity)
     }
@@ -830,7 +830,7 @@ struct EditCustodyAccountView: View {
                 if let cDate = currentDetails.closingDate { originalClosingDateInput = cDate; originalSetClosingDate = true } else { originalSetClosingDate = false }
             }
             detectChanges() // Re-evaluate hasChanges, should be false now
-            NotificationCenter.default.post(name: NSNotification.Name("RefreshCustodyAccounts"), object: nil)
+            NotificationCenter.default.post(name: NSNotification.Name("RefreshAccounts"), object: nil)
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { animateEditExit() }
         } else { alertMessage = "❌ Failed to update account. Please try again."; if alertMessage.contains("UNIQUE constraint failed: Accounts.account_number") { alertMessage = "❌ Failed to update account: Account Number must be unique."}; showingAlert = true }
     }

--- a/DragonShield/Views/AddAccountTypeView.swift
+++ b/DragonShield/Views/AddAccountTypeView.swift
@@ -114,7 +114,7 @@ struct AddAccountTypeView: View {
             sectionHeader(title: "Type Details", icon: "doc.text.image.fill", color: .indigo)
             
             VStack(spacing: 16) {
-                modernTextField(title: "Type Name*", text: $typeName, placeholder: "e.g., Custody Account", icon: "textformat.abc", isRequired: true)
+                modernTextField(title: "Type Name*", text: $typeName, placeholder: "e.g., Account", icon: "textformat.abc", isRequired: true)
                 modernTextField(title: "Type Code*", text: $typeCode, placeholder: "e.g., CUSTODY (all caps, no spaces)", icon: "number.square", isRequired: true, autoUppercase: true)
                 
                 VStack(alignment: .leading, spacing: 8) {

--- a/DragonShield/Views/EditAccountTypeView.swift
+++ b/DragonShield/Views/EditAccountTypeView.swift
@@ -131,7 +131,7 @@ struct EditAccountTypeView: View {
             sectionHeader(title: "Type Details", icon: "doc.text.image.fill", color: .orange)
             
             VStack(spacing: 16) {
-                modernTextField(title: "Type Name*", text: $typeName, placeholder: "e.g., Custody Account", icon: "textformat.abc", isRequired: true)
+                modernTextField(title: "Type Name*", text: $typeName, placeholder: "e.g., Account", icon: "textformat.abc", isRequired: true)
                 modernTextField(title: "Type Code*", text: $typeCode, placeholder: "e.g., CUSTODY (all caps, no spaces)", icon: "number.square", isRequired: true, autoUppercase: true)
                 
                 VStack(alignment: .leading, spacing: 8) {

--- a/DragonShield/Views/ImportStatementView.swift
+++ b/DragonShield/Views/ImportStatementView.swift
@@ -116,7 +116,7 @@ struct ImportStatementView: View {
                         .font(.system(size: 32, weight: .bold, design: .rounded))
                         .foregroundStyle(LinearGradient(colors: [.black, .gray], startPoint: .top, endPoint: .bottom))
                 }
-                Text("Upload bank or custody account statements (CSV, XLSX, PDF)")
+                Text("Upload bank or account statements (CSV, XLSX, PDF)")
                     .font(.subheadline)
                     .foregroundColor(.gray)
             }

--- a/DragonShield/Views/ImportSummaryView.swift
+++ b/DragonShield/Views/ImportSummaryView.swift
@@ -40,7 +40,7 @@ struct ImportSummaryView: View {
                     Section {
                         infoRow(title: "File", value: fileName, icon: "doc")
                         if let account = accountNumber {
-                            infoRow(title: "Custody Account", value: account, icon: "number")
+                            infoRow(title: "Account", value: account, icon: "number")
                         }
                         if let date = valueDate {
                             infoRow(title: "Value Date", value: DateFormatter.swissDate.string(from: date), icon: "calendar")

--- a/DragonShield/Views/SidebarView.swift
+++ b/DragonShield/Views/SidebarView.swift
@@ -90,8 +90,8 @@ struct SidebarView: View {
                     Label("Edit Instruments", systemImage: "pencil.and.list.clipboard")
                 }
                 
-                NavigationLink(destination: CustodyAccountsView()) {
-                    Label("Edit Custody Accounts", systemImage: "building.columns.fill")
+                NavigationLink(destination: AccountsView()) {
+                    Label("Edit Accounts", systemImage: "building.columns.fill")
                 }
             }
             

--- a/DragonShield/database/schema.sql
+++ b/DragonShield/database/schema.sql
@@ -197,7 +197,7 @@ CREATE INDEX idx_portfolio_instruments_instrument ON PortfolioInstruments(instru
 CREATE TABLE AccountTypes (
     account_type_id INTEGER PRIMARY KEY AUTOINCREMENT,
     type_code TEXT NOT NULL UNIQUE, -- e.g., 'BANK', 'CUSTODY'
-    type_name TEXT NOT NULL,        -- e.g., 'Bank Account', 'Custody Account'
+    type_name TEXT NOT NULL,        -- e.g., 'Bank Account', 'Account'
     type_description TEXT,
     is_active BOOLEAN DEFAULT 1,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,

--- a/DragonShield/docs/AssetClassDefinitionConcept.md
+++ b/DragonShield/docs/AssetClassDefinitionConcept.md
@@ -131,7 +131,7 @@ Each instrument record includes:
 
 Below is a concrete illustration of how a Credit-Suisse setup would look in your unified model. We show three tables—​Accounts, Instruments, and Positions—​with sample data for:
 	•	Two cash accounts at Credit-Suisse (CHF and USD)
-	•	One Credit-Suisse custody account
+	•	One Credit-Suisse account
 	•	Cash instruments & two equities
 
 # Credit-Suisse Example in DragonShield Model
@@ -142,7 +142,7 @@ Below is a concrete illustration of how a Credit-Suisse setup would look in your
 |-----------:|--------------------------|--------------|------|
 | 101        | Credit-Suisse CHF Cash Account     | CASH         | Credit-Suisse  |
 | 102        | Credit-Suisse USD Cash Account     | CASH         | Credit-Suisse  |
-| 201        | Credit-Suisse Custody Account      | CUSTODY      | Credit-Suisse  |
+| 201        | Credit-Suisse Account      | CUSTODY      | Credit-Suisse  |
 
 ## 2. Instruments
 
@@ -159,10 +159,10 @@ Below is a concrete illustration of how a Credit-Suisse setup would look in your
 |-----------:|--------------:|---------:|----------------------------------------|
 | 101        | 1             | 50 000   | CHF cash in CHF Cash Account           |
 | 102        | 2             | 30 000   | USD cash in USD Cash Account           |
-| 201        | 10            | 100      | Apple shares in Custody Account        |
-| 201        | 20            | 50       | Nestlé shares in Custody Account       |
-| 201        | 1             | 10 000   | CHF cash _within_ Custody Account      |
-| 201        | 2             | 5 000    | USD cash _within_ Custody Account      |
+| 201        | 10            | 100      | Apple shares in Account        |
+| 201        | 20            | 50       | Nestlé shares in Account       |
+| 201        | 1             | 10 000   | CHF cash _within_ Account      |
+| 201        | 2             | 5 000    | USD cash _within_ Account      |
 
 ---
 
@@ -172,7 +172,7 @@ Below is a concrete illustration of how a Credit-Suisse setup would look in your
   - Each is its own “CASH” account.  
   - Only holds its corresponding cash instrument.
 
-- **Custody Account (201)**  
+- **Account (201)**  
   - Holds both securities (AAPL_US, NESN_SW) and cash instruments (CHF_CASH, USD_CASH).  
 
 - **Unified Treatment**  

--- a/DragonShield/docs/Parsing_documents/Credit-Suisse_Parser_Mapping.md
+++ b/DragonShield/docs/Parsing_documents/Credit-Suisse_Parser_Mapping.md
@@ -7,7 +7,7 @@ This document outlines the mapping logic for parsing the Zürcher Kantonalbank (
 | Source | Credit-Suisse XLS Data Example | Dragon Shield Database Target | Transformation / Logic / Notes |
 | :--- | :--- | :--- | :--- |
 | **File Name** | `Position List Mar 26 2025` | `Transactions.transaction_date` | The date ("2025-03-26") is parsed from the filename and used as the "as-of" date for all imported positions. |
-| **Line 6 Content** | "Portfolio-Nr. S 398424-05" | `Accounts.account_number` | The number ("S 398424-05") is extracted. This is used to find or create the main **Custody Account** that holds all security positions. |
+| **Line 6 Content** | "Portfolio-Nr. S 398424-05" | `Accounts.account_number` | The number ("S 398424-05") is extracted. This is used to find or create the main **Account** that holds all security positions. |
 
 ---
 

--- a/DragonShield/docs/dragon_shield_db_documentation.md
+++ b/DragonShield/docs/dragon_shield_db_documentation.md
@@ -62,7 +62,7 @@ The Dragon Shield database schema is designed to support comprehensive personal 
 - Support for ISIN, ticker symbols, and exchanges
 
 #### 5. Account Management ✅
-**Requirement**: Track multiple accounts (banks, custody, crypto, pension)
+**Requirement**: Track multiple accounts (bank, crypto, pension)
 **Implementation**:
 - `Accounts` table with comprehensive account types
 - Institution metadata and BIC codes
@@ -122,7 +122,7 @@ Asset Management Layer
 └── PortfolioInstruments (portfolio assignments)
 
 Account & Transaction Layer
-├── Accounts (bank/custody accounts)
+├── Accounts (bank accounts)
 ├── TransactionTypes (transaction categories)
 ├── Transactions (core transaction data)
 ├── PositionReports (uploaded positions)
@@ -276,7 +276,7 @@ Analysis Layer
 
 **Account Types**:
 - BANK: Regular bank account
-- CUSTODY: Securities custody account
+- CUSTODY: Securities account
 - CRYPTO: Cryptocurrency wallet
 - PENSION: Retirement account
 - CASH: Cash management account

--- a/DragonShield/python_scripts/credit_suisse_parser.py
+++ b/DragonShield/python_scripts/credit_suisse_parser.py
@@ -189,7 +189,7 @@ def process_file(filepath: str, sheet_name_or_index: Optional[Any] = None) -> in
                 parsed_data["main_custody_account_nr"] = main_custody_account_nr_internal
                 break
         if not main_custody_account_nr_internal:
-            print(f"Warning: Could not parse Custody Account Nr from Line {LINE_6_PORTFOLIO_NR_LINE_NUMBER}.\n")
+            print(f"Warning: Could not parse Account Nr from Line {LINE_6_PORTFOLIO_NR_LINE_NUMBER}.\n")
 
 
         if sheet is None:

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ This is a personal passion project, but issues and PRs are welcome. Please keep 
 - 2.11: Improved Institutions maintenance UI with edit and delete actions.
 - 2.10: Institutions screen now supports add, edit and delete with dependency checks.
 - 2.9: Added Hashable conformance for InstitutionData.
-- 2.8: Fixed compile issue in CustodyAccountsView.
+- 2.8: Fixed compile issue in AccountsView.
 - 2.7: Added Institutions table and management view.
 - 2.6: Updated default database path to container directory.
 - 2.5: Settings view shows database info and added `db_tool.py` utility.


### PR DESCRIPTION
## Summary
- rename Custody Accounts view and related strings to Accounts
- update documentation to drop custody account wording
- change default account labels in Import tools
- adjust sample data names and parser messages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6872988b86cc8323bc1f173c12d5a790