### PR TITLE
Add statement loading log to import screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Disable foreign key checks during reference restore to avoid constraint failures
 - Include Instruments and Accounts in reference data backup/restore
 - Sync full reference SQL dump for tests and clarify restore instructions
+- Add Statement Loading Log panel to Data Import/Export view
 - Fix permission error when restoring reference data by using security-scoped access
 - Replace deprecated allowedFileTypes API in Database Management view
 - Fix compile error on macOS by using `.navigation` toolbar placement

--- a/DragonShield/ImportLogService.swift
+++ b/DragonShield/ImportLogService.swift
@@ -1,0 +1,29 @@
+// DragonShield/ImportLogService.swift
+// MARK: - Version 1.0
+// MARK: - History
+// - 1.0: Initial service to persist statement import log entries.
+
+import Foundation
+import SwiftUI
+
+class ImportLogService: ObservableObject {
+    static let shared = ImportLogService()
+
+    @Published var logMessages: [String]
+    private let isoFormatter = ISO8601DateFormatter()
+
+    private init() {
+        logMessages = UserDefaults.standard.stringArray(forKey: UserDefaultsKeys.statementLog) ?? []
+    }
+
+    func appendLog(fileName: String, success: Bool, details: String? = nil) {
+        var entry = "[\(isoFormatter.string(from: Date()))] \(fileName) \u{2192} "
+        entry += success ? "Success" : "Failed"
+        if let details = details { entry += ": \(details)" }
+        DispatchQueue.main.async {
+            self.logMessages.insert(entry, at: 0)
+            if self.logMessages.count > 10 { self.logMessages = Array(self.logMessages.prefix(10)) }
+            UserDefaults.standard.set(self.logMessages, forKey: UserDefaultsKeys.statementLog)
+        }
+    }
+}

--- a/DragonShield/ImportManager.swift
+++ b/DragonShield/ImportManager.swift
@@ -192,12 +192,18 @@ class ImportManager {
                 DispatchQueue.main.async {
                     completion(.success(json))
                 }
+                ImportLogService.shared.appendLog(fileName: url.lastPathComponent,
+                                                  success: true,
+                                                  details: "\(records.count) records.")
                 LoggingService.shared.log("Import complete for \(url.lastPathComponent)", type: .info, logger: .parser)
             } catch {
                 LoggingService.shared.log("Import failed: \(error.localizedDescription)", type: .error, logger: .parser)
                 DispatchQueue.main.async {
                     completion(.failure(error))
                 }
+                ImportLogService.shared.appendLog(fileName: url.lastPathComponent,
+                                                  success: false,
+                                                  details: error.localizedDescription)
             }
         }
     }
@@ -468,12 +474,18 @@ class ImportManager {
                 DispatchQueue.main.async {
                     completion(.success(summary))
                 }
+                ImportLogService.shared.appendLog(fileName: url.lastPathComponent,
+                                                  success: true,
+                                                  details: "\(summary.parsedRows) records.")
                 LoggingService.shared.log("Position import complete", type: .info, logger: .parser)
             } catch {
                 LoggingService.shared.log("Position import failed: \(error.localizedDescription)", type: .error, logger: .parser)
                 DispatchQueue.main.async {
                     completion(.failure(error))
                 }
+                ImportLogService.shared.appendLog(fileName: url.lastPathComponent,
+                                                  success: false,
+                                                  details: error.localizedDescription)
             }
         }
     }

--- a/DragonShield/Views/ImportStatementView.swift
+++ b/DragonShield/Views/ImportStatementView.swift
@@ -17,6 +17,7 @@ struct ImportStatementView: View {
     @State private var showingFileImporter = false
     @State private var errorMessage: String?
     @State private var logMessages: [String] = []
+    @StateObject private var importLog = ImportLogService.shared
     @State private var importSummary: PositionImportSummary?
     @State private var showSummaryPanel = false
 
@@ -85,6 +86,8 @@ struct ImportStatementView: View {
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .padding(.horizontal)
+
+                statementLogView
             }
         }
         .fileImporter(
@@ -258,6 +261,29 @@ struct ImportStatementView: View {
                 .padding(.top, 10)
             }
         }
+    }
+
+    private var statementLogView: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Statement Loading Log")
+                .font(.headline)
+            ScrollView {
+                VStack(alignment: .leading, spacing: 2) {
+                    ForEach(importLog.logMessages, id: \.self) { entry in
+                        Text(entry)
+                            .font(.system(.caption2, design: .monospaced))
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+            }
+            .frame(maxHeight: 160)
+            .padding(4)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .stroke(Color.gray.opacity(0.2))
+            )
+        }
+        .padding(.top, 24)
     }
 
     // MARK: - Logic Handlers

--- a/DragonShield/helpers/UserDefaultsKeys.swift
+++ b/DragonShield/helpers/UserDefaultsKeys.swift
@@ -11,6 +11,7 @@ struct UserDefaultsKeys {
     static let automaticBackupsEnabled = "automaticBackupsEnabled"
     static let automaticBackupTime = "automaticBackupTime"
     static let backupLog = "backupLog"
+    static let statementLog = "statementLog"
     static let lastBackupTimestamp = "lastBackupTimestamp"
     static let lastReferenceBackupTimestamp = "lastReferenceBackupTimestamp"
     static let databaseMode = "databaseMode"


### PR DESCRIPTION
## Summary
- track statement import attempts via `ImportLogService`
- display log entries in `ImportStatementView`
- expose new `statementLog` UserDefaults key
- log import success and failure from `ImportManager`
- document the new feature in the changelog

## Testing
- `swiftc -parse DragonShield/ImportLogService.swift DragonShield/ImportManager.swift DragonShield/Views/ImportStatementView.swift`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_6872aaf0f974832390584cf6f2db4c39