### PR TITLE
feat(db): track instrument update timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Track last instrument update timestamp on PositionReports
 - Track earliest instrument update timestamp on Accounts
 - Display instrument updated date in Positions view and form
+- Display earliest instrument updated date in Accounts view and forms
 - Replace Load Documents with Data Import/Export view and statement log
 - Enable file picker and drag-and-drop on Data Import/Export screen
 - Unify drag-and-drop and file picker handling in Data Import/Export view

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 - Replace instrument seed data with Consolidated_Instruments_V8.xlsx for updated test dataset
 - Expand seed dataset with full production reference data
 - Fix unicode bullet escape in Data Import/Export status message causing build error
+- Track last instrument update timestamp on PositionReports
+- Track earliest instrument update timestamp on Accounts
 - Replace Load Documents with Data Import/Export view and statement log
 - Enable file picker and drag-and-drop on Data Import/Export screen
 - Unify drag-and-drop and file picker handling in Data Import/Export view

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Fix unicode bullet escape in Data Import/Export status message causing build error
 - Track last instrument update timestamp on PositionReports
 - Track earliest instrument update timestamp on Accounts
+- Display instrument updated date in Positions view and form
 - Replace Load Documents with Data Import/Export view and statement log
 - Enable file picker and drag-and-drop on Data Import/Export screen
 - Unify drag-and-drop and file picker handling in Data Import/Export view

--- a/DragonShield/DatabaseManager+Accounts.swift
+++ b/DragonShield/DatabaseManager+Accounts.swift
@@ -28,6 +28,7 @@ extension DatabaseManager {
         var currencyCode: String
         var openingDate: Date?
         var closingDate: Date?
+        var earliestInstrumentLastUpdatedAt: Date?
         var includeInPortfolio: Bool
         var isActive: Bool
         var notes: String?
@@ -40,7 +41,8 @@ extension DatabaseManager {
             SELECT a.account_id, a.account_name,
                    i.institution_name, i.bic,
                    a.account_number, at.type_name AS account_type_name, a.currency_code,
-                   a.opening_date, a.closing_date, a.include_in_portfolio, a.is_active, a.notes,
+                   a.opening_date, a.closing_date, a.earliest_instrument_last_updated_at,
+                   a.include_in_portfolio, a.is_active, a.notes,
                    a.account_type_id, a.institution_id
             FROM Accounts a
             JOIN AccountTypes at ON a.account_type_id = at.account_type_id
@@ -63,12 +65,13 @@ extension DatabaseManager {
 
                 let openingDate: Date? = sqlite3_column_text(statement, 7).map { String(cString: $0) }.flatMap { DateFormatter.iso8601DateOnly.date(from: $0) }
                 let closingDate: Date? = sqlite3_column_text(statement, 8).map { String(cString: $0) }.flatMap { DateFormatter.iso8601DateOnly.date(from: $0) }
+                let earliestDate: Date? = sqlite3_column_text(statement, 9).map { String(cString: $0) }.flatMap { DateFormatter.iso8601DateOnly.date(from: $0) }
 
-                let includeInPortfolio = sqlite3_column_int(statement, 9) == 1
-                let isActive = sqlite3_column_int(statement, 10) == 1
-                let notes: String? = sqlite3_column_text(statement, 11).map { String(cString: $0) }
-                let accountTypeId = Int(sqlite3_column_int(statement, 12))
-                let institutionId = Int(sqlite3_column_int(statement, 13))
+                let includeInPortfolio = sqlite3_column_int(statement, 10) == 1
+                let isActive = sqlite3_column_int(statement, 11) == 1
+                let notes: String? = sqlite3_column_text(statement, 12).map { String(cString: $0) }
+                let accountTypeId = Int(sqlite3_column_int(statement, 13))
+                let institutionId = Int(sqlite3_column_int(statement, 14))
                 
                 accounts.append(AccountData(
                     id: id,
@@ -82,6 +85,7 @@ extension DatabaseManager {
                     currencyCode: currencyCode,
                     openingDate: openingDate,
                     closingDate: closingDate,
+                    earliestInstrumentLastUpdatedAt: earliestDate,
                     includeInPortfolio: includeInPortfolio,
                     isActive: isActive,
                     notes: notes
@@ -100,7 +104,8 @@ extension DatabaseManager {
             SELECT a.account_id, a.account_name,
                    i.institution_name, i.bic,
                    a.account_number, at.type_name AS account_type_name, a.currency_code,
-                   a.opening_date, a.closing_date, a.include_in_portfolio, a.is_active, a.notes,
+                   a.opening_date, a.closing_date, a.earliest_instrument_last_updated_at,
+                   a.include_in_portfolio, a.is_active, a.notes,
                    a.account_type_id, a.institution_id
             FROM Accounts a
             JOIN AccountTypes at ON a.account_type_id = at.account_type_id
@@ -122,11 +127,12 @@ extension DatabaseManager {
                 let currencyCode = String(cString: sqlite3_column_text(statement, 6))
                 let openingDate: Date? = sqlite3_column_text(statement, 7).map { String(cString: $0) }.flatMap { DateFormatter.iso8601DateOnly.date(from: $0) }
                 let closingDate: Date? = sqlite3_column_text(statement, 8).map { String(cString: $0) }.flatMap { DateFormatter.iso8601DateOnly.date(from: $0) }
-                let includeInPortfolio = sqlite3_column_int(statement, 9) == 1
-                let isActive = sqlite3_column_int(statement, 10) == 1
-                let notes: String? = sqlite3_column_text(statement, 11).map { String(cString: $0) }
-                let accountTypeId = Int(sqlite3_column_int(statement, 12))
-                let institutionId = Int(sqlite3_column_int(statement, 13))
+                let earliestDate: Date? = sqlite3_column_text(statement, 9).map { String(cString: $0) }.flatMap { DateFormatter.iso8601DateOnly.date(from: $0) }
+                let includeInPortfolio = sqlite3_column_int(statement, 10) == 1
+                let isActive = sqlite3_column_int(statement, 11) == 1
+                let notes: String? = sqlite3_column_text(statement, 12).map { String(cString: $0) }
+                let accountTypeId = Int(sqlite3_column_int(statement, 13))
+                let institutionId = Int(sqlite3_column_int(statement, 14))
 
                 sqlite3_finalize(statement)
                 return AccountData(
@@ -134,7 +140,8 @@ extension DatabaseManager {
                     institutionName: institutionName, institutionBic: institutionBic,
                     accountNumber: accountNumber, accountType: accountTypeName,
                     accountTypeId: accountTypeId, currencyCode: currencyCode, openingDate: openingDate,
-                    closingDate: closingDate, includeInPortfolio: includeInPortfolio, isActive: isActive, notes: notes
+                    closingDate: closingDate, earliestInstrumentLastUpdatedAt: earliestDate,
+                    includeInPortfolio: includeInPortfolio, isActive: isActive, notes: notes
                 )
             } else {
                 print("ℹ️ No account details found for ID: \(id)")

--- a/DragonShield/DatabaseManager+PositionReports.swift
+++ b/DragonShield/DatabaseManager+PositionReports.swift
@@ -17,6 +17,7 @@ struct PositionReportData: Identifiable {
         var quantity: Double
         var purchasePrice: Double?
         var currentPrice: Double?
+        var instrumentUpdatedAt: Date?
         var notes: String?
         var reportDate: Date
         var uploadedAt: Date
@@ -30,6 +31,7 @@ extension DatabaseManager {
             SELECT pr.position_id, pr.import_session_id, a.account_name,
                    ins.institution_name, i.instrument_name, i.currency,
                    pr.quantity, pr.purchase_price, pr.current_price,
+                   pr.instrument_updated_at,
                    pr.notes,
                    pr.report_date, pr.uploaded_at
             FROM PositionReports pr
@@ -61,9 +63,14 @@ extension DatabaseManager {
                 if sqlite3_column_type(statement, 8) != SQLITE_NULL {
                     currentPrice = sqlite3_column_double(statement, 8)
                 }
-                let notes: String? = sqlite3_column_text(statement, 9).map { String(cString: $0) }
-                let reportDateStr = String(cString: sqlite3_column_text(statement, 10))
-                let uploadedAtStr = String(cString: sqlite3_column_text(statement, 11))
+                var instrumentUpdatedAt: Date?
+                if sqlite3_column_type(statement, 9) != SQLITE_NULL {
+                    let str = String(cString: sqlite3_column_text(statement, 9))
+                    instrumentUpdatedAt = DateFormatter.iso8601DateOnly.date(from: str)
+                }
+                let notes: String? = sqlite3_column_text(statement, 10).map { String(cString: $0) }
+                let reportDateStr = String(cString: sqlite3_column_text(statement, 11))
+                let uploadedAtStr = String(cString: sqlite3_column_text(statement, 12))
                 let reportDate = DateFormatter.iso8601DateOnly.date(from: reportDateStr) ?? Date()
                 let uploadedAt = DateFormatter.iso8601DateTime.date(from: uploadedAtStr) ?? Date()
                 reports.append(PositionReportData(
@@ -76,6 +83,7 @@ extension DatabaseManager {
                     quantity: quantity,
                     purchasePrice: purchasePrice,
                     currentPrice: currentPrice,
+                    instrumentUpdatedAt: instrumentUpdatedAt,
                     notes: notes,
                     reportDate: reportDate,
                     uploadedAt: uploadedAt
@@ -166,8 +174,8 @@ extension DatabaseManager {
 
     // MARK: - Single Position CRUD
 
-    func addPositionReport(importSessionId: Int?, accountId: Int, institutionId: Int, instrumentId: Int, quantity: Double, purchasePrice: Double?, currentPrice: Double?, notes: String?, reportDate: Date) -> Int? {
-        let sql = "INSERT INTO PositionReports (import_session_id, account_id, institution_id, instrument_id, quantity, purchase_price, current_price, notes, report_date) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);"
+    func addPositionReport(importSessionId: Int?, accountId: Int, institutionId: Int, instrumentId: Int, quantity: Double, purchasePrice: Double?, currentPrice: Double?, instrumentUpdatedAt: Date?, notes: String?, reportDate: Date) -> Int? {
+        let sql = "INSERT INTO PositionReports (import_session_id, account_id, institution_id, instrument_id, quantity, purchase_price, current_price, instrument_updated_at, notes, report_date) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);"
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
             print("❌ Failed to prepare insert position: \(String(cString: sqlite3_errmsg(db)))")
@@ -182,8 +190,9 @@ extension DatabaseManager {
         sqlite3_bind_double(stmt, 5, quantity)
         if let p = purchasePrice { sqlite3_bind_double(stmt, 6, p) } else { sqlite3_bind_null(stmt, 6) }
         if let c = currentPrice { sqlite3_bind_double(stmt, 7, c) } else { sqlite3_bind_null(stmt, 7) }
-        if let n = notes { sqlite3_bind_text(stmt, 8, n, -1, SQLITE_TRANSIENT) } else { sqlite3_bind_null(stmt, 8) }
-        sqlite3_bind_text(stmt, 9, DateFormatter.iso8601DateOnly.string(from: reportDate), -1, SQLITE_TRANSIENT)
+        if let iu = instrumentUpdatedAt { sqlite3_bind_text(stmt, 8, DateFormatter.iso8601DateOnly.string(from: iu), -1, SQLITE_TRANSIENT) } else { sqlite3_bind_null(stmt, 8) }
+        if let n = notes { sqlite3_bind_text(stmt, 9, n, -1, SQLITE_TRANSIENT) } else { sqlite3_bind_null(stmt, 9) }
+        sqlite3_bind_text(stmt, 10, DateFormatter.iso8601DateOnly.string(from: reportDate), -1, SQLITE_TRANSIENT)
         guard sqlite3_step(stmt) == SQLITE_DONE else {
             print("❌ Insert position failed: \(String(cString: sqlite3_errmsg(db)))")
             return nil
@@ -191,8 +200,8 @@ extension DatabaseManager {
         return Int(sqlite3_last_insert_rowid(db))
     }
 
-    func updatePositionReport(id: Int, importSessionId: Int?, accountId: Int, institutionId: Int, instrumentId: Int, quantity: Double, purchasePrice: Double?, currentPrice: Double?, notes: String?, reportDate: Date) -> Bool {
-        let sql = "UPDATE PositionReports SET import_session_id = ?, account_id = ?, institution_id = ?, instrument_id = ?, quantity = ?, purchase_price = ?, current_price = ?, notes = ?, report_date = ?, uploaded_at = CURRENT_TIMESTAMP WHERE position_id = ?;"
+    func updatePositionReport(id: Int, importSessionId: Int?, accountId: Int, institutionId: Int, instrumentId: Int, quantity: Double, purchasePrice: Double?, currentPrice: Double?, instrumentUpdatedAt: Date?, notes: String?, reportDate: Date) -> Bool {
+        let sql = "UPDATE PositionReports SET import_session_id = ?, account_id = ?, institution_id = ?, instrument_id = ?, quantity = ?, purchase_price = ?, current_price = ?, instrument_updated_at = ?, notes = ?, report_date = ?, uploaded_at = CURRENT_TIMESTAMP WHERE position_id = ?;"
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
             print("❌ Failed to prepare update position: \(String(cString: sqlite3_errmsg(db)))")
@@ -207,9 +216,10 @@ extension DatabaseManager {
         sqlite3_bind_double(stmt, 5, quantity)
         if let p = purchasePrice { sqlite3_bind_double(stmt, 6, p) } else { sqlite3_bind_null(stmt, 6) }
         if let c = currentPrice { sqlite3_bind_double(stmt, 7, c) } else { sqlite3_bind_null(stmt, 7) }
-        if let n = notes { sqlite3_bind_text(stmt, 8, n, -1, SQLITE_TRANSIENT) } else { sqlite3_bind_null(stmt, 8) }
-        sqlite3_bind_text(stmt, 9, DateFormatter.iso8601DateOnly.string(from: reportDate), -1, SQLITE_TRANSIENT)
-        sqlite3_bind_int(stmt, 10, Int32(id))
+        if let iu = instrumentUpdatedAt { sqlite3_bind_text(stmt, 8, DateFormatter.iso8601DateOnly.string(from: iu), -1, SQLITE_TRANSIENT) } else { sqlite3_bind_null(stmt, 8) }
+        if let n = notes { sqlite3_bind_text(stmt, 9, n, -1, SQLITE_TRANSIENT) } else { sqlite3_bind_null(stmt, 9) }
+        sqlite3_bind_text(stmt, 10, DateFormatter.iso8601DateOnly.string(from: reportDate), -1, SQLITE_TRANSIENT)
+        sqlite3_bind_int(stmt, 11, Int32(id))
         let result = sqlite3_step(stmt) == SQLITE_DONE
         if !result { print("❌ Update position failed: \(String(cString: sqlite3_errmsg(db)))") }
         return result

--- a/DragonShield/Views/PositionFormView.swift
+++ b/DragonShield/Views/PositionFormView.swift
@@ -20,6 +20,7 @@ struct PositionFormView: View {
     @State private var quantity = ""
     @State private var purchasePrice = ""
     @State private var currentPrice = ""
+    @State private var instrumentUpdatedAt = Date()
     @State private var valueDate = Date()
     @State private var uploadedAt = Date()
     @State private var reportDate = Date()
@@ -101,6 +102,9 @@ struct PositionFormView: View {
             TextField("Current Price", text: $currentPrice)
                 .textFieldStyle(.roundedBorder)
 
+            DatePicker("Instrument Updated", selection: $instrumentUpdatedAt, displayedComponents: .date)
+                .datePickerStyle(.field)
+
             DatePicker("Value Date", selection: $valueDate, displayedComponents: .date)
                 .datePickerStyle(.field)
 
@@ -145,6 +149,7 @@ struct PositionFormView: View {
         quantity = String(p.quantity)
         if let pp = p.purchasePrice { purchasePrice = String(pp) }
         if let cp = p.currentPrice { currentPrice = String(cp) }
+        if let iu = p.instrumentUpdatedAt { instrumentUpdatedAt = iu }
         valueDate = p.reportDate
         uploadedAt = p.uploadedAt
         reportDate = p.reportDate
@@ -174,6 +179,7 @@ struct PositionFormView: View {
                 quantity: qty,
                 purchasePrice: price,
                 currentPrice: currPrice,
+                instrumentUpdatedAt: instrumentUpdatedAt,
                 notes: notes.isEmpty ? nil : notes,
                 reportDate: reportDate
             )
@@ -186,6 +192,7 @@ struct PositionFormView: View {
                 quantity: qty,
                 purchasePrice: price,
                 currentPrice: currPrice,
+                instrumentUpdatedAt: instrumentUpdatedAt,
                 notes: notes.isEmpty ? nil : notes,
                 reportDate: reportDate
             )

--- a/DragonShield/Views/PositionsView.swift
+++ b/DragonShield/Views/PositionsView.swift
@@ -249,8 +249,11 @@ struct PositionsView: View {
             Group {
                 TableColumn("Dates", sortUsing: KeyPathComparator(\PositionReportData.uploadedAt)) { (position: PositionReportData) in
                     VStack {
-                        Text(position.uploadedAt, formatter: DateFormatter.iso8601DateTime)
+                        if let iu = position.instrumentUpdatedAt {
+                            Text(iu, formatter: DateFormatter.iso8601DateOnly)
+                        }
                         Text(position.reportDate, formatter: DateFormatter.iso8601DateOnly)
+                        Text(position.uploadedAt, formatter: DateFormatter.iso8601DateTime)
                     }
                     .font(.system(size: 12))
                     .foregroundColor(.secondary)

--- a/DragonShield/database/schema.sql
+++ b/DragonShield/database/schema.sql
@@ -1,8 +1,8 @@
 -- DragonShield/docs/schema.sql
 -- Dragon Shield Database Creation Script
--- Version 4.12 - PositionReports support notes field
+-- Version 4.13 - Track instrument last updated timestamps
 -- Created: 2025-05-24
--- Updated: 2025-06-19
+-- Updated: 2025-07-13
 --
 -- RECENT HISTORY:
 -- - v4.7 -> v4.8: Added Institutions table and linked Accounts to it.
@@ -234,6 +234,7 @@ CREATE TABLE Accounts (
     include_in_portfolio BOOLEAN DEFAULT 1,
     opening_date DATE,
     closing_date DATE,
+    earliest_instrument_last_updated_at DATE,
     notes TEXT,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
@@ -337,6 +338,7 @@ CREATE TABLE PositionReports (
     quantity REAL NOT NULL,
     purchase_price REAL,
     current_price REAL,
+    instrument_updated_at DATE,
     notes TEXT,
     report_date DATE NOT NULL,
     uploaded_at DATETIME DEFAULT CURRENT_TIMESTAMP,

--- a/DragonShield/database/schema.txt
+++ b/DragonShield/database/schema.txt
@@ -11,6 +11,7 @@
 -- - v4.8 -> v4.9: Introduced AssetClasses and AssetSubClasses
 -- - v4.10 -> v4.11: Added extended institution details
 -- - v4.11 -> v4.12: Added notes column to PositionReports table
+-- - v4.12 -> v4.13: Track instrument last updated timestamps
 -- - v4.7 -> v4.7.1: Removed duplicate db_version row causing UNIQUE constraint failure
 -- - v4.4 -> v4.5: Added PositionReports table, renamed CurrentHoldings view to Positions, updated PortfolioSummary and AccountSummary views.
 -- - v4.3 -> v4.4: Normalized AccountTypes into a separate table. Updated Accounts table and AccountSummary view.
@@ -26,7 +27,7 @@ INSERT INTO Configuration VALUES ('7', 'default_timezone', 'Europe/Zurich', 'str
 INSERT INTO Configuration VALUES ('8', 'table_row_spacing', '1.0', 'number', 'Spacing between table rows in points', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('9', 'table_row_padding', '12.0', 'number', 'Vertical padding inside table rows in points', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('10', 'table_font_size', '14.0', 'number', 'Font size for text in data table rows (in points)', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
-INSERT INTO Configuration VALUES ('12', 'db_version', '4.12', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
+INSERT INTO Configuration VALUES ('12', 'db_version', '4.13', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('CHF', 'Swiss Franc', 'CHF', '1', '0', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('EUR', 'Euro', '€', '1', '1', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('USD', 'US Dollar', '$', '1', '1', '2025-07-13 09:04:29', '2025-07-13 09:04:29');

--- a/migrations/001_add_instrument_updated_at.sql
+++ b/migrations/001_add_instrument_updated_at.sql
@@ -1,0 +1,2 @@
+ALTER TABLE PositionReports
+  ADD COLUMN instrument_updated_at DATE NULL;

--- a/migrations/002_add_earliest_instrument_last_updated_at.sql
+++ b/migrations/002_add_earliest_instrument_last_updated_at.sql
@@ -1,0 +1,2 @@
+ALTER TABLE Accounts
+  ADD COLUMN earliest_instrument_last_updated_at DATE NULL;


### PR DESCRIPTION
## Summary
- add `instrument_updated_at` to PositionReports
- add `earliest_instrument_last_updated_at` to Accounts
- bump database schema to 4.13
- document changes in CHANGELOG

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_6873cbe58f108323a81d1664993964d5