### PR TITLE
Restore environment switch in DB management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - Fix Data Import/Export layout so Select File button and log panel are visible
 - Fix file importer losing selected statement type so imports run after choosing a file
 - Fix Data Import/Export file picker not starting import after choosing a file
+- Restore Switch Mode button in Database Management view to toggle environment
 - Fix Select File button to start import by retaining chosen statement type until completion
 - Restyle Statement Loading Log with padded white frame and remove extra spacer
 - Add dedicated reference data backup and restore with grouped buttons

--- a/DragonShield/Views/DatabaseManagementView.swift
+++ b/DragonShield/Views/DatabaseManagementView.swift
@@ -130,6 +130,18 @@ struct DatabaseManagementView: View {
                         }
                 }
             }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Environment")
+                    .font(.system(size: 14, weight: .medium))
+                HStack(spacing: 12) {
+                    Button("Switch to \(dbManager.dbMode == .production ? "Test" : "Production")") {
+                        confirmSwitchMode()
+                    }
+                    .buttonStyle(SecondaryButtonStyle())
+                    .disabled(processing)
+                }
+            }
         }
         .padding(24)
         .background(Theme.surface)
@@ -391,6 +403,18 @@ struct DatabaseManagementView: View {
                     errorMessage = error.localizedDescription
                 }
             }
+        }
+    }
+
+    private func confirmSwitchMode() {
+        let newMode = dbManager.dbMode == .production ? "TEST" : "PRODUCTION"
+        let alert = NSAlert()
+        alert.messageText = "Switch to \(newMode) mode? Unsaved data may be lost."
+        alert.addButton(withTitle: "Switch")
+        alert.addButton(withTitle: "Cancel")
+        alert.alertStyle = .warning
+        if alert.runModal() == .alertFirstButtonReturn {
+            dbManager.switchMode()
         }
     }
 


### PR DESCRIPTION
## Summary
- restore missing environment switch in Database Management view
- document the fix in the changelog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6873ecc722088323a2edaea5f7fc0459