### PR TITLE
Update config paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Define production and test database paths in `config.json`
 - Persist selected database paths in the `Configuration` table and reopen the correct file on startup
 - Remove outdated config file storage for database paths
 - Use modern `allowedContentTypes` API for file pickers

--- a/config.json
+++ b/config.json
@@ -1,0 +1,4 @@
+{
+  "production_db_path": "/Users/renekeller/Library/Mobile Documents/com~apple~CloudDocs/010 🔥Open Cases/210 🐉🛡️Dragon Shield /100_Dragonshield_Production_Data/dragonshield.sqlite",
+  "test_db_path": "/Users/renekeller/Library/Mobile Documents/com~apple~CloudDocs/010 🔥Open Cases/210 🐉🛡️Dragon Shield /101_Dragonshield_Test_Data/dragonshield_test.sqlite"
+}


### PR DESCRIPTION
## Summary
- add a `config.json` for database paths
- document config paths in changelog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6874a33b670c832389a3432bb4934923