### PR TITLE
Load DB paths from config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Define production and test database paths in `config.json`
+- Load database paths from `config.json` at startup and default to production mode
 - Persist selected database paths in the `Configuration` table and reopen the correct file on startup
 - Remove outdated config file storage for database paths
 - Use modern `allowedContentTypes` API for file pickers


### PR DESCRIPTION
## Summary
- read production and test database paths from `config.json`
- start `DatabaseManager` in production mode by default
- document new startup behaviour in changelog

## Testing
- `swiftc -parse DragonShield/DatabaseManager.swift`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `xcodebuild -version` *(fails: command not found)*
- `open DragonShield.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874a61816e88323979a340f7ccaeca5