### PR TITLE
fix: avoid self usage before init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Use modern `allowedContentTypes` API for file pickers
 - Fix build error resolving bookmark URLs by passing an inout staleness flag
 - Fix compile error when initializing DatabaseManager due to referencing `dbMode` before all properties were set
+- Resolve compile error computing initial DB path by avoiding `self` before initialization
 - Replace instrument seed data with Consolidated_Instruments_V8.xlsx for updated test dataset
 - Expand seed dataset with full production reference data
 - Expand PositionReports with diverse sample entries for testing

--- a/DragonShield/DatabaseManager.swift
+++ b/DragonShield/DatabaseManager.swift
@@ -48,19 +48,25 @@ class DatabaseManager: ObservableObject {
 
     init() {
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        self.appDir = appSupport.appendingPathComponent("DragonShield")
+        let appDir = appSupport.appendingPathComponent("DragonShield")
 
         try? FileManager.default.createDirectory(at: appDir, withIntermediateDirectories: true)
 
         // Start in production mode and load database paths from config.json if present
-        self.dbMode = .production
+        let initialMode: DatabaseMode = .production
 
         let paths = DatabaseManager.loadPathsFromConfig()
-        self.defaultProdPath = paths.prod ?? appDir.appendingPathComponent(DatabaseManager.fileName(for: .production)).path
-        self.defaultTestPath = paths.test ?? appDir.appendingPathComponent(DatabaseManager.fileName(for: .test)).path
+        let prodPath = paths.prod ?? appDir.appendingPathComponent(DatabaseManager.fileName(for: .production)).path
+        let testPath = paths.test ?? appDir.appendingPathComponent(DatabaseManager.fileName(for: .test)).path
 
         // Determine initial database path based on the selected mode
-        self.dbPath = dbMode == .production ? defaultProdPath : defaultTestPath
+        let initialPath = initialMode == .production ? prodPath : testPath
+
+        self.appDir = appDir
+        self.defaultProdPath = prodPath
+        self.defaultTestPath = testPath
+        self.dbMode = initialMode
+        self.dbPath = initialPath
 
         // Open default database first to read configuration paths
 


### PR DESCRIPTION
## Summary
- resolve compile error in DatabaseManager initializer by avoiding `self` before all properties are set
- update changelog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6874b75f200c8323b0a8a7867cc800c6