### PR TITLE
Fix empty maintenance views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,3 +224,4 @@ All notable changes to this project will be documented in this file.
 - Fix compile error in Database Management view due to missing `value:` label
 - Add manual Refresh Instrument Timestamps button to recalculate earliest instrument dates
 - Fix compile error when loading config paths from config.json
+- Restore data display in Transaction Types and Instruments views with reload controls

--- a/DragonShield/Views/PortfolioView.swift
+++ b/DragonShield/Views/PortfolioView.swift
@@ -77,6 +77,11 @@ struct PortfolioView: View {
                     }
             }
         }
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button("Reload") { assetManager.loadAssets() }
+            }
+        }
         .alert("Delete Instrument", isPresented: $showingDeleteAlert) {
             Button("Cancel", role: .cancel) { }
             Button("Delete", role: .destructive) {
@@ -645,9 +650,7 @@ struct InstrumentParticle {
 // Note: ScaleButtonStyle is defined in AddInstrumentView.swift
 
 // MARK: - Preview
-struct PortfolioView_Previews: PreviewProvider {
-    static var previews: some View {
-        PortfolioView()
-            .environmentObject(AssetManager())
-    }
+#Preview {
+    PortfolioView()
+        .environmentObject(AssetManager())
 }

--- a/DragonShield/Views/TransactionTypesView.swift
+++ b/DragonShield/Views/TransactionTypesView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 // MARK: - History: Initial creation - transaction types management with CRUD operations
 
 struct TransactionTypesView: View {
+    @EnvironmentObject var dbManager: DatabaseManager
     @State private var transactionTypes: [(id: Int, code: String, name: String, description: String, affectsPosition: Bool, affectsCash: Bool, isIncome: Bool, sortOrder: Int)] = []
     @State private var showAddTypeSheet = false
     @State private var showEditTypeSheet = false
@@ -67,6 +68,11 @@ struct TransactionTypesView: View {
         .sheet(isPresented: $showEditTypeSheet) {
             if let type = selectedType {
                 EditTransactionTypeView(typeId: type.id)
+            }
+        }
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button("Reload") { loadTransactionTypes() }
             }
         }
         .alert("Delete Transaction Type", isPresented: $showingDeleteAlert) {
@@ -483,8 +489,11 @@ struct TransactionTypesView: View {
     
     // MARK: - Functions
     func loadTransactionTypes() {
-        let dbManager = DatabaseManager()
-        transactionTypes = dbManager.fetchTransactionTypes()
+        let rows = dbManager.fetchTransactionTypes()
+        print("🔄 Loaded \(rows.count) transaction types")
+        DispatchQueue.main.async {
+            self.transactionTypes = rows
+        }
     }
     
     func confirmDelete(_ type: (id: Int, code: String, name: String, description: String, affectsPosition: Bool, affectsCash: Bool, isIncome: Bool, sortOrder: Int)) {
@@ -1931,4 +1940,9 @@ struct TransactionTypesParticle {
     var position: CGPoint
     var size: CGFloat
     var opacity: Double
+}
+
+#Preview {
+    TransactionTypesView()
+        .environmentObject(DatabaseManager())
 }

--- a/tests/test_fetch_records.py
+++ b/tests/test_fetch_records.py
@@ -1,0 +1,27 @@
+import sqlite3
+from pathlib import Path
+
+DB_ROOT = Path(__file__).resolve().parents[1] / 'DragonShield' / 'database'
+SCHEMA = DB_ROOT / 'schema.sql'
+SEED = DB_ROOT / 'schema.txt'
+
+
+def load_db():
+    conn = sqlite3.connect(':memory:')
+    conn.executescript(SCHEMA.read_text(encoding='utf-8'))
+    conn.executescript(SEED.read_text(encoding='utf-8'))
+    return conn
+
+
+def test_fetch_transaction_types():
+    conn = load_db()
+    count = conn.execute('SELECT COUNT(*) FROM TransactionTypes').fetchone()[0]
+    assert count == 10
+    conn.close()
+
+
+def test_fetch_instruments():
+    conn = load_db()
+    count = conn.execute('SELECT COUNT(*) FROM Instruments WHERE is_active = 1').fetchone()[0]
+    assert count == 50
+    conn.close()

--- a/tests/test_view_previews.py
+++ b/tests/test_view_previews.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1] / 'DragonShield' / 'Views'
+
+
+def test_transaction_types_preview_exists():
+    text = (ROOT / 'TransactionTypesView.swift').read_text(encoding='utf-8')
+    assert '#Preview {' in text
+    assert 'TransactionTypesView()' in text
+
+
+def test_portfolio_view_preview_exists():
+    text = (ROOT / 'PortfolioView.swift').read_text(encoding='utf-8')
+    assert '#Preview {' in text
+    assert 'PortfolioView()' in text


### PR DESCRIPTION
## Summary
- reload Transaction Types and Instruments views using existing database manager
- log fetch counts and update UI on main thread
- add Reload toolbar buttons
- provide SwiftUI previews for the views
- test that TransactionTypes and Instruments tables contain seed data
- test that previews exist for the views

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6874bbd58220832383f93c8fe1f480b3