### PR TITLE
feat(ui): enlarge tile picker window with OK button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,3 +219,4 @@ All notable changes to this project will be documented in this file.
 - Fix dashboard compilation errors by renaming MetricTile and using `any` keyword
 - Fix build warnings for dashboard onChange and unused variable
 - Resolve Swift compiler crash in TilePickerView by refactoring TileRegistry
+- Enlarge dashboard tile picker window and add "OK" button to close

--- a/DragonShield/Views/TilePickerView.swift
+++ b/DragonShield/Views/TilePickerView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct TilePickerView: View {
     @Binding var tileIDs: [String]
+    @Environment(\.dismiss) private var dismiss
 
     var body: some View {
         NavigationView {
@@ -13,9 +14,14 @@ struct TilePickerView: View {
                 }
             }
             .navigationTitle("Configure Dashboard")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("OK") { dismiss() }
+                }
+            }
             .padding()
         }
-        .frame(minWidth: 250)
+        .frame(minWidth: 400, minHeight: 400)
     }
 
     private func binding(for id: String) -> Binding<Bool> {


### PR DESCRIPTION
## Summary
- increase tile picker window size so all options are visible
- add an 'OK' button to close the configuration window

## Testing
- `pytest -q` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6874df1564e08323b3fdac4f6d536ea4