### PR TITLE
feat(ui): add total asset value dashboard tile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Display earliest instrument updated date in Accounts view and forms
 - Show total asset value in CHF on Positions view with refresh button
 - Show total asset value in CHF on Dashboard via metric tile
+- Display total asset value without decimals on the dashboard tile using Swiss thousands separator
 - Replace Load Documents with Data Import/Export view and statement log
 - Enable file picker and drag-and-drop on Data Import/Export screen
 - Unify drag-and-drop and file picker handling in Data Import/Export view

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - Display instrument updated date in Positions view and form
 - Display earliest instrument updated date in Accounts view and forms
 - Show total asset value in CHF on Positions view with refresh button
+- Show total asset value in CHF on Dashboard via metric tile
 - Replace Load Documents with Data Import/Export view and statement log
 - Enable file picker and drag-and-drop on Data Import/Export screen
 - Unify drag-and-drop and file picker handling in Data Import/Export view

--- a/DragonShield/Views/DashboardTiles/DashboardTiles.swift
+++ b/DragonShield/Views/DashboardTiles/DashboardTiles.swift
@@ -87,6 +87,14 @@ struct TotalValueTile: DashboardTile {
     @State private var total: Double = 0
     @State private var loading = false
 
+    private static let formatter: NumberFormatter = {
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        f.maximumFractionDigits = 0
+        f.groupingSeparator = "'"
+        return f
+    }()
+
     init() {}
     static let tileID = "total_value"
     static let tileName = "Total Asset Value (CHF)"
@@ -98,7 +106,7 @@ struct TotalValueTile: DashboardTile {
                 ProgressView()
                     .frame(maxWidth: .infinity, alignment: .center)
             } else {
-                Text(String(format: "%.2f CHF", total))
+                Text(Self.formatter.string(from: NSNumber(value: total)) ?? "0")
                     .font(.system(size: 48, weight: .bold))
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .foregroundColor(Theme.primaryAccent)


### PR DESCRIPTION
## Summary
- create a metric tile that calculates total portfolio value in CHF
- register the tile in the dashboard tile registry
- document the new tile in the changelog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687561e358a08323a323473af055bacf