### PR TITLE
Add Top Positions dashboard tile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Add dashboard tile showing Top 10 Positions by Asset Value in CHF
 - Replace instrument seed data with Consolidated_Instruments_V8.xlsx for updated test dataset
 - Expand seed dataset with full production reference data
 - Expand PositionReports with diverse sample entries for testing

--- a/DragonShield/ViewModels/PositionsViewModel.swift
+++ b/DragonShield/ViewModels/PositionsViewModel.swift
@@ -1,0 +1,42 @@
+import Foundation
+import SwiftUI
+
+class PositionsViewModel: ObservableObject {
+    struct TopPositionCHF: Identifiable, Equatable {
+        let id: Int
+        let instrumentName: String
+        let valueChf: Double
+        let currency: String
+    }
+
+    @Published var top10PositionsCHF: [TopPositionCHF] = []
+
+    private let db: DatabaseManager
+
+    init(db: DatabaseManager = DatabaseManager()) {
+        self.db = db
+    }
+
+    func loadTopPositions() {
+        let reports = db.fetchPositionReports()
+        var rates: [String: Double] = ["CHF": 1.0]
+        for report in reports {
+            let code = report.instrumentCurrency
+            if rates[code] == nil && code != "CHF" {
+                let rate = db.fetchExchangeRates(currencyCode: code).first?.rateToChf ?? 1.0
+                rates[code] = rate
+            }
+        }
+        let items = reports.compactMap { report -> TopPositionCHF? in
+            guard let price = report.currentPrice else { return nil }
+            let rate = rates[report.instrumentCurrency] ?? 1.0
+            let value = report.quantity * price * rate
+            return TopPositionCHF(id: report.id,
+                                  instrumentName: report.instrumentName,
+                                  valueChf: value,
+                                  currency: report.instrumentCurrency)
+        }
+        .sorted { $0.valueChf > $1.valueChf }
+        top10PositionsCHF = Array(items.prefix(10))
+    }
+}

--- a/DragonShield/Views/DashboardTiles/DashboardTiles.swift
+++ b/DragonShield/Views/DashboardTiles/DashboardTiles.swift
@@ -150,7 +150,8 @@ enum TileRegistry {
         TileInfo(id: MetricTile.tileID, name: MetricTile.tileName, icon: MetricTile.iconName) { AnyView(MetricTile()) },
         TileInfo(id: TextTile.tileID, name: TextTile.tileName, icon: TextTile.iconName) { AnyView(TextTile()) },
         TileInfo(id: ImageTile.tileID, name: ImageTile.tileName, icon: ImageTile.iconName) { AnyView(ImageTile()) },
-        TileInfo(id: MapTile.tileID, name: MapTile.tileName, icon: MapTile.iconName) { AnyView(MapTile()) }
+        TileInfo(id: MapTile.tileID, name: MapTile.tileName, icon: MapTile.iconName) { AnyView(MapTile()) },
+        TileInfo(id: TopPositionsTile.tileID, name: TopPositionsTile.tileName, icon: TopPositionsTile.iconName) { AnyView(TopPositionsTile()) }
     ]
 
     static func view(for id: String) -> AnyView? {

--- a/DragonShield/Views/DashboardTiles/TopPositionsTile.swift
+++ b/DragonShield/Views/DashboardTiles/TopPositionsTile.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+struct TopPositionsTile: DashboardTile {
+    init() {}
+    static let tileID = "top_positions_chf"
+    static let tileName = "Top 10 Positions by Asset Value (CHF)"
+    static let iconName = "list.number"
+
+    @StateObject private var vm = PositionsViewModel()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(Self.tileName)
+                .font(.headline)
+                .padding(.bottom, 8)
+            header
+            ScrollView {
+                VStack(spacing: 0) {
+                    ForEach(vm.top10PositionsCHF.indices, id: \..self) { idx in
+                        let item = vm.top10PositionsCHF[idx]
+                        row(item: item, highlight: idx == 0)
+                    }
+                }
+            }
+            .frame(maxHeight: vm.top10PositionsCHF.count > 6 ? 240 : .none)
+        }
+        .padding(16)
+        .background(Color(red: 216/255, green: 236/255, blue: 248/255))
+        .cornerRadius(12)
+        .onAppear { vm.loadTopPositions() }
+    }
+
+    private var header: some View {
+        HStack {
+            Text("Instrument")
+                .font(.footnote.weight(.medium))
+            Spacer()
+            Text("Value (CHF)")
+                .font(.footnote.weight(.medium))
+            Text("Curr")
+                .font(.footnote.weight(.medium))
+                .frame(width: 40, alignment: .trailing)
+        }
+        .foregroundColor(Color(red: 107/255, green: 114/255, blue: 128/255))
+        .padding(.bottom, 4)
+        Rectangle()
+            .fill(Color(red: 229/255, green: 231/255, blue: 235/255))
+            .frame(height: 1)
+    }
+
+    private func row(item: PositionsViewModel.TopPositionCHF, highlight: Bool) -> some View {
+        HStack {
+            Text(item.instrumentName)
+                .font(.body.weight(.semibold))
+                .lineLimit(1)
+                .truncationMode(.tail)
+            Spacer()
+            Text(String(format: "%.2f CHF", item.valueChf))
+                .font(.body.weight(.medium))
+                .foregroundColor(Color(red: 30/255, green: 58/255, blue: 138/255))
+            Text(item.currency)
+                .font(.caption)
+                .frame(width: 40, alignment: .trailing)
+                .foregroundColor(.secondary)
+        }
+        .padding(.vertical, 8)
+        .padding(.horizontal, 12)
+        .background(highlight ? Color(red: 191/255, green: 219/255, blue: 254/255) : Color.clear)
+        .cornerRadius(6)
+    }
+}

--- a/tests/test_top_positions.py
+++ b/tests/test_top_positions.py
@@ -1,0 +1,25 @@
+import math
+
+
+def compute_top_positions(positions, rates):
+    result = []
+    for p in positions:
+        rate = rates.get(p['currency'], 1.0)
+        value = p['quantity'] * p['price'] * rate
+        result.append((p['name'], value, p['currency']))
+    result.sort(key=lambda x: x[1], reverse=True)
+    return result[:10]
+
+
+def test_top_positions_sorting():
+    positions = [
+        {'name': 'A', 'quantity': 10, 'price': 100, 'currency': 'CHF'},
+        {'name': 'B', 'quantity': 5, 'price': 50, 'currency': 'USD'},
+        {'name': 'C', 'quantity': 20, 'price': 10, 'currency': 'EUR'},
+    ]
+    rates = {'USD': 0.9, 'EUR': 1.2, 'CHF': 1.0}
+    top = compute_top_positions(positions, rates)
+    assert math.isclose(top[0][1], 2400.0, rel_tol=1e-9)
+    assert top[0][0] == 'C'
+    assert top[1][0] == 'B'
+    assert top[2][0] == 'A'


### PR DESCRIPTION
## Summary
- show Top 10 Positions by Asset Value in CHF
- compute the ranking in new `PositionsViewModel`
- register new tile type and implement the SwiftUI layout
- test conversion logic and ranking
- document change in CHANGELOG

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68755d53ad1483239e6e8ad6539d8e4e