### PR TITLE
Add Accounts Needing Update dashboard tile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Add ExchangeRates maintenance view for CRUD FX rate management
 - Fix SQLITE_TRANSIENT compile error in ExchangeRates database helpers
 - Fix compile error mapping active currencies in ExchangeRates view model
+- Add "Accounts Needing Update" dashboard tile showing top 10 stale accounts
 - Display Currency Maintenance and FX History links in sidebar
 - Display instrument updated date in Positions view and form
 - Display earliest instrument updated date in Accounts view and forms

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Fix SQLITE_TRANSIENT compile error in ExchangeRates database helpers
 - Fix compile error mapping active currencies in ExchangeRates view model
 - Add "Accounts Needing Update" dashboard tile showing top 10 stale accounts
+- Fix ambiguous `fetchAccounts` call causing compilation failure in StaleAccountsViewModel
 - Display Currency Maintenance and FX History links in sidebar
 - Display instrument updated date in Positions view and form
 - Display earliest instrument updated date in Accounts view and forms

--- a/DragonShield/DatabaseManager+OtherData.swift
+++ b/DragonShield/DatabaseManager+OtherData.swift
@@ -40,9 +40,4 @@ extension DatabaseManager {
         return []
     }
     
-    // Placeholder, to be implemented
-    func fetchAccounts() -> [(id: Int, name: String, type: String, currency: String)] {
-        print("⚠️ fetchAccounts() - Not yet implemented")
-        return []
-    }
 }

--- a/DragonShield/ViewModels/StaleAccountsViewModel.swift
+++ b/DragonShield/ViewModels/StaleAccountsViewModel.swift
@@ -1,0 +1,33 @@
+import Foundation
+import SwiftUI
+
+class StaleAccountsViewModel: ObservableObject {
+    @Published var staleAccounts: [DatabaseManager.AccountData] = []
+
+    private var dbManager: DatabaseManager?
+
+    init(dbManager: DatabaseManager? = nil) {
+        self.dbManager = dbManager
+        if dbManager != nil {
+            loadStaleAccounts()
+        }
+    }
+
+    func loadStaleAccounts(db: DatabaseManager? = nil) {
+        if let db { self.dbManager = db }
+        guard let dbManager else { return }
+        let accounts = dbManager.fetchAccounts()
+        staleAccounts = accounts
+            .sorted { (a, b) in
+                let lhs = a.earliestInstrumentLastUpdatedAt ?? Date.distantFuture
+                let rhs = b.earliestInstrumentLastUpdatedAt ?? Date.distantFuture
+                return lhs < rhs
+            }
+            .prefix(10)
+            .map { $0 }
+    }
+
+    func daysSince(_ date: Date) -> Int {
+        Calendar.current.dateComponents([.day], from: date, to: Date()).day ?? 0
+    }
+}

--- a/DragonShield/Views/DashboardTiles/AccountsNeedingUpdateTile.swift
+++ b/DragonShield/Views/DashboardTiles/AccountsNeedingUpdateTile.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+struct AccountsNeedingUpdateTile: DashboardTile {
+    init() {}
+    static let tileID = "staleAccounts"
+    static let tileName = "Accounts Needing Update"
+    static let iconName = "exclamationmark.triangle"
+
+    @EnvironmentObject var dbManager: DatabaseManager
+    @StateObject private var viewModel = StaleAccountsViewModel()
+
+    private static let displayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "dd MMM yyyy"
+        return f
+    }()
+
+    private func warningNeeded(for date: Date) -> Bool {
+        viewModel.daysSince(date) > 30
+    }
+
+    var body: some View {
+        DashboardCard(title: Self.tileName) {
+            if viewModel.staleAccounts.isEmpty {
+                Text("All accounts up to date ✅")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            } else {
+                contentList
+            }
+        }
+        .background(Color.blue.opacity(0.1))
+        .cornerRadius(8)
+        .onAppear {
+            viewModel.loadStaleAccounts(db: dbManager)
+        }
+    }
+
+    @ViewBuilder
+    private var contentList: some View {
+        let rows = viewModel.staleAccounts
+        Group {
+            if rows.count > 6 {
+                ScrollView { listBody(rows) }
+            } else {
+                listBody(rows)
+            }
+        }
+    }
+
+    private func listBody(_ rows: [DatabaseManager.AccountData]) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(Array(rows.enumerated()), id: \.element.id) { idx, account in
+                HStack {
+                    Text(account.accountName)
+                    Spacer()
+                    if let date = account.earliestInstrumentLastUpdatedAt {
+                        Text(Self.displayFormatter.string(from: date))
+                            .foregroundColor(.secondary)
+                        if warningNeeded(for: date) {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .foregroundColor(.orange)
+                        }
+                    }
+                }
+                .padding(.vertical, 2)
+                .padding(.horizontal, 4)
+                .background(idx == 0 ? Color.yellow.opacity(0.2) : Color.clear)
+                .cornerRadius(4)
+            }
+        }
+    }
+}

--- a/DragonShield/Views/DashboardTiles/DashboardTiles.swift
+++ b/DragonShield/Views/DashboardTiles/DashboardTiles.swift
@@ -150,7 +150,8 @@ enum TileRegistry {
         TileInfo(id: MetricTile.tileID, name: MetricTile.tileName, icon: MetricTile.iconName) { AnyView(MetricTile()) },
         TileInfo(id: TextTile.tileID, name: TextTile.tileName, icon: TextTile.iconName) { AnyView(TextTile()) },
         TileInfo(id: ImageTile.tileID, name: ImageTile.tileName, icon: ImageTile.iconName) { AnyView(ImageTile()) },
-        TileInfo(id: MapTile.tileID, name: MapTile.tileName, icon: MapTile.iconName) { AnyView(MapTile()) }
+        TileInfo(id: MapTile.tileID, name: MapTile.tileName, icon: MapTile.iconName) { AnyView(MapTile()) },
+        TileInfo(id: AccountsNeedingUpdateTile.tileID, name: AccountsNeedingUpdateTile.tileName, icon: AccountsNeedingUpdateTile.iconName) { AnyView(AccountsNeedingUpdateTile()) }
     ]
 
     static func view(for id: String) -> AnyView? {

--- a/DragonShield/python_scripts/stale_accounts.py
+++ b/DragonShield/python_scripts/stale_accounts.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List
+
+@dataclass
+class Account:
+    name: str
+    earliest_instrument_last_updated_at: datetime | None
+
+
+def top_stale_accounts(accounts: List[Account], limit: int = 10) -> List[Account]:
+    def sort_key(a: Account):
+        return a.earliest_instrument_last_updated_at or datetime.max
+
+    return sorted(accounts, key=sort_key)[:limit]

--- a/tests/test_stale_accounts.py
+++ b/tests/test_stale_accounts.py
@@ -1,0 +1,26 @@
+from datetime import datetime, timedelta
+
+from DragonShield.python_scripts.stale_accounts import Account, top_stale_accounts
+
+
+def test_sort_and_limit():
+    today = datetime(2025, 1, 1)
+    accounts = [
+        Account("A", today - timedelta(days=40)),
+        Account("B", today - timedelta(days=10)),
+        Account("C", today - timedelta(days=20)),
+        Account("D", today - timedelta(days=5)),
+        Account("E", today - timedelta(days=60)),
+        Account("F", today - timedelta(days=15)),
+        Account("G", today - timedelta(days=25)),
+        Account("H", today - timedelta(days=35)),
+        Account("I", today - timedelta(days=45)),
+        Account("J", today - timedelta(days=50)),
+        Account("K", today - timedelta(days=55)),
+    ]
+
+    result = top_stale_accounts(accounts)
+
+    assert len(result) == 10
+    dates = [acc.earliest_instrument_last_updated_at for acc in result]
+    assert dates == sorted(dates)


### PR DESCRIPTION
## Summary
- show accounts needing instrument updates
- keep a list of stale accounts in a new view model
- display the list via Accounts Needing Update dashboard tile
- expose helper for sorting stale accounts in Python scripts
- test sorting and limit logic for stale accounts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68755e63eb3483238943f52fd04e09e3