### PR TITLE
Fix rounding for total asset value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - Show total asset value in CHF on Dashboard via metric tile
 - Display total asset value without decimals on the dashboard tile using Swiss thousands separator
 - Format total asset value in Positions view using Swiss thousands separator
+- Truncate decimals when displaying total asset value in Positions view
 - Replace Load Documents with Data Import/Export view and statement log
 - Enable file picker and drag-and-drop on Data Import/Export screen
 - Unify drag-and-drop and file picker handling in Data Import/Export view

--- a/DragonShield/Views/PositionsView.swift
+++ b/DragonShield/Views/PositionsView.swift
@@ -36,6 +36,8 @@ struct PositionsView: View {
         f.numberStyle = .decimal
         f.maximumFractionDigits = 0
         f.groupingSeparator = "'"
+        f.usesGroupingSeparator = true
+        f.roundingMode = .down
         return f
     }()
 


### PR DESCRIPTION
## Summary
- truncate decimals for total asset value in `PositionsView`
- note change in changelog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6875719bd5e88323b693eb229c4c0f23