### PR TITLE
Add Portfolio by Currency dashboard tile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,3 +237,4 @@ All notable changes to this project will be documented in this file.
 - Remove Asset Dashboard view in favor of Portfolio Overview
 - Display position value columns in original currency and CHF on Positions screen
 - Show Top 10 Positions by Asset Value (CHF) on Dashboard
+- Add Portfolio by Currency dashboard tile with CHF-based exposure

--- a/DragonShield/ViewModels/CurrencyExposureViewModel.swift
+++ b/DragonShield/ViewModels/CurrencyExposureViewModel.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+struct CurrencyBreakdown: Identifiable {
+    let id = UUID()
+    let currencyCode: String
+    let percentage: Double
+    let totalCHF: Double
+}
+
+class CurrencyExposureViewModel: ObservableObject {
+    @Published var currencyExposure: [CurrencyBreakdown] = []
+    @Published var loading: Bool = false
+
+    func calculate(db: DatabaseManager) {
+        loading = true
+        DispatchQueue.global().async {
+            let positions = db.fetchPositionReports()
+            var totals: [String: Double] = [:]
+            var rateCache: [String: Double] = [:]
+            var total: Double = 0
+            for p in positions {
+                guard let price = p.currentPrice else { continue }
+                let currency = p.instrumentCurrency.uppercased()
+                var value = p.quantity * price
+                if currency != "CHF" {
+                    if rateCache[currency] == nil {
+                        let rates = db.fetchExchangeRates(currencyCode: currency, upTo: nil)
+                        if let rate = rates.first?.rateToChf {
+                            rateCache[currency] = rate
+                        } else {
+                            continue
+                        }
+                    }
+                    if let rate = rateCache[currency] { value *= rate }
+                }
+                totals[currency, default: 0] += value
+                total += value
+            }
+            var breakdown = totals.map { CurrencyBreakdown(currencyCode: $0.key, percentage: 0, totalCHF: $0.value) }
+            breakdown.sort { $0.totalCHF > $1.totalCHF }
+            var result: [CurrencyBreakdown] = []
+            var otherValue: Double = 0
+            for (index, item) in breakdown.enumerated() {
+                if index < 6 {
+                    result.append(item)
+                } else {
+                    otherValue += item.totalCHF
+                }
+            }
+            if otherValue > 0 {
+                result.append(CurrencyBreakdown(currencyCode: "Other", percentage: 0, totalCHF: otherValue))
+            }
+            result = result.map { br in
+                CurrencyBreakdown(currencyCode: br.currencyCode, percentage: total > 0 ? br.totalCHF / total * 100 : 0, totalCHF: br.totalCHF)
+            }
+            DispatchQueue.main.async {
+                self.currencyExposure = result
+                self.loading = false
+            }
+        }
+    }
+}

--- a/DragonShield/Views/DashboardTiles/CurrencyExposureTile.swift
+++ b/DragonShield/Views/DashboardTiles/CurrencyExposureTile.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+import Charts
+
+struct CurrencyExposureTile: DashboardTile {
+    init() {}
+    static let tileID = "currency_exposure"
+    static let tileName = "Portfolio by Currency"
+    static let iconName = "dollarsign.circle"
+
+    @EnvironmentObject var dbManager: DatabaseManager
+    @StateObject private var viewModel = CurrencyExposureViewModel()
+
+    private func color(for code: String) -> Color {
+        Theme.currencyColors[code] ?? .gray
+    }
+
+    var body: some View {
+        DashboardCard(title: Self.tileName) {
+            if viewModel.loading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, alignment: .center)
+            } else {
+                HStack(alignment: .top) {
+                    Chart(viewModel.currencyExposure, id: \.currencyCode) { item in
+                        SectorMark(
+                            angle: .value("Share", item.percentage),
+                            innerRadius: .ratio(0.6)
+                        )
+                        .foregroundStyle(color(for: item.currencyCode))
+                    }
+                    .chartLegend(.hidden)
+                    .frame(width: 100, height: 100)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        ForEach(viewModel.currencyExposure) { item in
+                            HStack {
+                                Text(item.currencyCode)
+                                    .frame(width: 40, alignment: .leading)
+                                Text(String(format: "%.0f%%", item.percentage))
+                                    .frame(width: 50, alignment: .trailing)
+                                Text(String(format: "%.0f CHF", item.totalCHF))
+                                    .frame(alignment: .trailing)
+                            }
+                            .foregroundColor(item.percentage > 50 ? .orange : .primary)
+                        }
+                    }
+                    .font(.caption)
+                    Spacer()
+                }
+            }
+        }
+        .onAppear { viewModel.calculate(db: dbManager) }
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/DragonShield/Views/DashboardTiles/DashboardTiles.swift
+++ b/DragonShield/Views/DashboardTiles/DashboardTiles.swift
@@ -259,6 +259,7 @@ enum TileRegistry {
         TileInfo(id: MetricTile.tileID, name: MetricTile.tileName, icon: MetricTile.iconName) { AnyView(MetricTile()) },
         TileInfo(id: TotalValueTile.tileID, name: TotalValueTile.tileName, icon: TotalValueTile.iconName) { AnyView(TotalValueTile()) },
         TileInfo(id: TopPositionsTile.tileID, name: TopPositionsTile.tileName, icon: TopPositionsTile.iconName) { AnyView(TopPositionsTile()) },
+        TileInfo(id: CurrencyExposureTile.tileID, name: CurrencyExposureTile.tileName, icon: CurrencyExposureTile.iconName) { AnyView(CurrencyExposureTile()) },
         TileInfo(id: TextTile.tileID, name: TextTile.tileName, icon: TextTile.iconName) { AnyView(TextTile()) },
         TileInfo(id: ImageTile.tileID, name: ImageTile.tileName, icon: ImageTile.iconName) { AnyView(ImageTile()) },
         TileInfo(id: MapTile.tileID, name: MapTile.tileName, icon: MapTile.iconName) { AnyView(MapTile()) },

--- a/DragonShield/helpers/Theme.swift
+++ b/DragonShield/helpers/Theme.swift
@@ -26,6 +26,13 @@ extension Theme {
         .derivatives: .teal,
         .other: .gray
     ]
+
+    static let currencyColors: [String: Color] = [
+        "CHF": .blue,
+        "USD": .green,
+        "EUR": .purple,
+        "BTC": .orange
+    ]
 }
 
 struct PrimaryButtonStyle: ButtonStyle {

--- a/DragonShield/python_scripts/currency_exposure.py
+++ b/DragonShield/python_scripts/currency_exposure.py
@@ -1,0 +1,55 @@
+"""Utility to compute currency exposure of a portfolio."""
+
+from typing import Iterable, Mapping, List, Dict
+
+
+def currency_exposure(
+    positions: Iterable[Mapping], rates: Mapping[str, float], top_n: int = 6
+) -> List[Dict[str, float]]:
+    """Return breakdown of position values by currency.
+
+    Each position mapping must provide ``quantity``, ``current_price`` and
+    ``currency`` keys. ``rates`` maps currency codes to ``rate_to_chf``.
+    Raises ``KeyError`` if a non-CHF currency is missing from ``rates``.
+    """
+    totals: Dict[str, float] = {}
+    total_chf = 0.0
+    for pos in positions:
+        qty = pos.get("quantity", 0)
+        price = pos.get("current_price")
+        if price is None:
+            continue
+        value = qty * price
+        currency = str(pos.get("currency", "CHF")).upper()
+        if currency != "CHF":
+            if currency not in rates:
+                raise KeyError(currency)
+            value *= rates[currency]
+        totals[currency] = totals.get(currency, 0.0) + value
+        total_chf += value
+
+    breakdown = [
+        {
+            "currency": code,
+            "percentage": (val / total_chf * 100) if total_chf else 0.0,
+            "value_chf": val,
+        }
+        for code, val in sorted(totals.items(), key=lambda x: x[1], reverse=True)
+    ]
+
+    if len(breakdown) > top_n:
+        other = breakdown[top_n:]
+        other_value = sum(item["value_chf"] for item in other)
+        breakdown = breakdown[:top_n]
+        breakdown.append(
+            {
+                "currency": "Other",
+                "percentage": (other_value / total_chf * 100) if total_chf else 0.0,
+                "value_chf": other_value,
+            }
+        )
+
+    return breakdown
+
+
+__all__ = ["currency_exposure"]

--- a/tests/test_currency_exposure.py
+++ b/tests/test_currency_exposure.py
@@ -1,0 +1,33 @@
+from DragonShield.python_scripts.currency_exposure import currency_exposure
+
+
+def test_grouping_and_conversion():
+    positions = [
+        {"quantity": 5, "current_price": 100.0, "currency": "USD"},
+        {"quantity": 2, "current_price": 50.0, "currency": "CHF"},
+        {"quantity": 1, "current_price": 200.0, "currency": "EUR"},
+    ]
+    rates = {"USD": 0.9, "EUR": 0.95}
+    result = currency_exposure(positions, rates, top_n=6)
+    by_currency = {r["currency"]: r for r in result}
+    assert "USD" in by_currency and "EUR" in by_currency and "CHF" in by_currency
+    usd_value = 5 * 100.0 * 0.9
+    eur_value = 1 * 200.0 * 0.95
+    chf_value = 2 * 50.0
+    total = usd_value + eur_value + chf_value
+    assert abs(by_currency["USD"]["value_chf"] - usd_value) < 1e-6
+    assert abs(by_currency["EUR"]["value_chf"] - eur_value) < 1e-6
+    assert abs(by_currency["CHF"]["value_chf"] - chf_value) < 1e-6
+    percent_sum = sum(r["percentage"] for r in result)
+    assert abs(percent_sum - 100.0) < 1e-6
+
+
+def test_other_triggered_only_if_more_than_six():
+    positions = []
+    currencies = ["CHF", "USD", "EUR", "GBP", "JPY", "AUD", "CAD"]
+    for idx, cur in enumerate(currencies):
+        positions.append({"quantity": 1, "current_price": 10.0 + idx, "currency": cur})
+    rates = {cur: 1.0 for cur in currencies if cur != "CHF"}
+    result = currency_exposure(positions, rates, top_n=6)
+    assert any(r["currency"] == "Other" for r in result)
+    assert len(result) == 7  # 6 + Other


### PR DESCRIPTION
## Summary
- implement `currency_exposure` helper and unit tests
- add `CurrencyExposureViewModel` and `CurrencyExposureTile`
- register new tile and currency colours
- document addition in CHANGELOG

## Testing
- `PYTHONPATH=. pytest -q tests/test_currency_exposure.py`

------
https://chatgpt.com/codex/tasks/task_e_687576b4ee188323805b0a2f5caf2618