### PR TITLE
Add asset class grouping to Risk Buckets tile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Expand seed dataset with full production reference data
 - Expand PositionReports with diverse sample entries for testing
 - Add risk concentration dashboard tile showing top 5 groups by value
+- Support asset class grouping and display CHF values in Risk Buckets tile
 - Fix unicode bullet escape in Data Import/Export status message causing build error
 - Track last instrument update timestamp on PositionReports
 - Track earliest instrument update timestamp on Accounts

--- a/DragonShield/ViewModels/RiskBucketsViewModel.swift
+++ b/DragonShield/ViewModels/RiskBucketsViewModel.swift
@@ -5,6 +5,7 @@ enum RiskGroupingDimension: String, CaseIterable, Identifiable {
     case issuer
     case currency
     case country
+    case assetClass
 
     var id: String { rawValue }
 }
@@ -62,6 +63,8 @@ final class RiskBucketsViewModel: ObservableObject {
                 key = currency
             case .country:
                 key = p.instrumentCountry ?? "Unknown"
+            case .assetClass:
+                key = p.assetClass ?? "Unknown"
             }
             groups[key, default: 0] += value
         }

--- a/DragonShield/Views/DashboardTiles/RiskBucketsTile.swift
+++ b/DragonShield/Views/DashboardTiles/RiskBucketsTile.swift
@@ -27,23 +27,32 @@ struct RiskBucketsTile: DashboardTile {
                 Text("No data to display")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
-                Chart(viewModel.topRiskBuckets) { bucket in
-                    SectorMark(
-                        angle: .value("Value", bucket.exposurePct)
-                    )
-                    .foregroundStyle(bucket.isOverconcentrated ? Color.error : Theme.primaryAccent)
-                    .annotation(position: .overlay) {
-                        VStack {
-                            Text(bucket.label)
-                                .font(.caption2)
-                            Text(String(format: "%.1f%%", bucket.exposurePct * 100))
-                                .font(.caption2)
-                        }
-                        .foregroundColor(.white)
+                HStack(alignment: .top) {
+                    Chart(viewModel.topRiskBuckets) { bucket in
+                        SectorMark(
+                            angle: .value("Share", bucket.exposurePct),
+                            innerRadius: .ratio(0.6)
+                        )
+                        .foregroundStyle(bucket.isOverconcentrated ? Color.warning : Theme.primaryAccent)
                     }
+                    .chartLegend(.hidden)
+                    .frame(width: 100, height: 100)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        ForEach(viewModel.topRiskBuckets) { bucket in
+                            HStack {
+                                Text(bucket.label)
+                                    .frame(width: 80, alignment: .leading)
+                                Text(String(format: "%.1f%%", bucket.exposurePct * 100))
+                                    .frame(width: 50, alignment: .trailing)
+                                Text(String(format: "%.0f CHF", bucket.valueCHF))
+                            }
+                            .foregroundColor(bucket.isOverconcentrated ? .orange : .primary)
+                        }
+                    }
+                    .font(.caption)
+                    Spacer()
                 }
-                .chartLegend(.hidden)
-                .frame(height: 180)
             }
         }
         .padding(16)

--- a/tests/test_risk_buckets.py
+++ b/tests/test_risk_buckets.py
@@ -17,3 +17,19 @@ def test_risk_buckets_grouping_and_highlight():
     assert abs(buckets[0]["value_chf"] - health_value) < 1e-6
     assert abs(buckets[0]["exposure_pct"] - health_value/total) < 1e-6
     assert buckets[0]["is_overconcentrated"] is True
+
+
+def test_risk_buckets_asset_class_dimension():
+    positions = [
+        {"quantity": 1, "current_price": 100.0, "currency": "CHF", "asset_class": "Equity"},
+        {"quantity": 2, "current_price": 50.0, "currency": "CHF", "asset_class": "Bond"},
+        {"quantity": 3, "current_price": 30.0, "currency": "CHF", "asset_class": "Equity"},
+    ]
+    rates = {}
+
+    buckets = top_risk_buckets(positions, rates, dimension="asset_class", top_n=2)
+    assert buckets[0]["label"] == "Equity"
+    total = 1*100.0 + 2*50.0 + 3*30.0
+    eq_value = 1*100.0 + 3*30.0
+    assert abs(buckets[0]["value_chf"] - eq_value) < 1e-6
+    assert abs(buckets[0]["exposure_pct"] - eq_value/total) < 1e-6


### PR DESCRIPTION
## Summary
- extend `RiskGroupingDimension` with `assetClass`
- include asset class in `PositionReportData` and database query
- show CHF values in `RiskBucketsTile` and allow grouping by asset class
- test the new grouping logic
- document the enhancement in the changelog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6875e4aaccd883238bd9822c013f406e