### PR TITLE
feat(ui): add notes tooltip and sortable values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,3 +243,4 @@ All notable changes to this project will be documented in this file.
 - Show note tooltips and sortable value columns in Positions view
 - Remove unused variables in exchange rate fetching to resolve build warnings
 - Fix compile errors in Positions view by restructuring table code and handling CHF optionals
+- Break out positions table columns into helper views to aid compiler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,3 +245,4 @@ All notable changes to this project will be documented in this file.
 - Fix compile errors in Positions view by restructuring table code and handling CHF optionals
 - Remove invalid TableBuilder attribute to restore builds
 - Break out positions table columns into helper views to aid compiler
+- Simplify column helper signatures to avoid generics compile error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -247,3 +247,4 @@ All notable changes to this project will be documented in this file.
 - Break out positions table columns into helper views to aid compiler
 - Simplify column helper signatures to avoid generics compile error
 - Inline positions table columns again to satisfy SwiftUI TableColumn constraints
+- Group positions table columns into helper functions to avoid type-check timeout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,3 +242,4 @@ All notable changes to this project will be documented in this file.
 - Add Portfolio by Currency dashboard tile with CHF-based exposure
 - Show note tooltips and sortable value columns in Positions view
 - Remove unused variables in exchange rate fetching to resolve build warnings
+- Fix compile errors in Positions view by restructuring table code and handling CHF optionals

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,4 +243,5 @@ All notable changes to this project will be documented in this file.
 - Show note tooltips and sortable value columns in Positions view
 - Remove unused variables in exchange rate fetching to resolve build warnings
 - Fix compile errors in Positions view by restructuring table code and handling CHF optionals
+- Remove invalid TableBuilder attribute to restore builds
 - Break out positions table columns into helper views to aid compiler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,3 +241,4 @@ All notable changes to this project will be documented in this file.
 - Show Top 10 Positions by Asset Value (CHF) on Dashboard
 - Add Portfolio by Currency dashboard tile with CHF-based exposure
 - Show note tooltips and sortable value columns in Positions view
+- Remove unused variables in exchange rate fetching to resolve build warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,3 +240,4 @@ All notable changes to this project will be documented in this file.
 - Display position value columns in original currency and CHF on Positions screen
 - Show Top 10 Positions by Asset Value (CHF) on Dashboard
 - Add Portfolio by Currency dashboard tile with CHF-based exposure
+- Show note tooltips and sortable value columns in Positions view

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,3 +246,4 @@ All notable changes to this project will be documented in this file.
 - Remove invalid TableBuilder attribute to restore builds
 - Break out positions table columns into helper views to aid compiler
 - Simplify column helper signatures to avoid generics compile error
+- Inline positions table columns again to satisfy SwiftUI TableColumn constraints

--- a/DragonShield/DatabaseManager+ExchangeRates.swift
+++ b/DragonShield/DatabaseManager+ExchangeRates.swift
@@ -23,10 +23,10 @@ extension DatabaseManager {
             query += " WHERE"
         }
         var conditions: [String] = []
-        if let code = currencyCode {
+        if currencyCode != nil {
             conditions.append("currency_code = ?")
         }
-        if let d = date {
+        if date != nil {
             conditions.append("rate_date <= ?")
         }
         if !conditions.isEmpty {

--- a/DragonShield/Views/PositionsView.swift
+++ b/DragonShield/Views/PositionsView.swift
@@ -513,11 +513,13 @@ private struct HoverNote: Identifiable {
     let text: String
 }
 
-struct ValueComparator: SortComparator {
-    enum Kind { case original, chf }
+struct ValueComparator: SortComparator, Hashable {
+    enum Kind: Hashable { case original, chf }
+
     var kind: Kind
-    var viewModel: PositionsViewModel
+    unowned var viewModel: PositionsViewModel
     var order: SortOrder = .forward
+
     func compare(_ lhs: PositionReportData, _ rhs: PositionReportData) -> ComparisonResult {
         let l = value(for: lhs)
         let r = value(for: rhs)
@@ -525,6 +527,7 @@ struct ValueComparator: SortComparator {
         let result: ComparisonResult = l < r ? .orderedAscending : .orderedDescending
         return order == .forward ? result : (result == .orderedAscending ? .orderedDescending : .orderedAscending)
     }
+
     private func value(for item: PositionReportData) -> Double {
         switch kind {
         case .original:
@@ -532,6 +535,16 @@ struct ValueComparator: SortComparator {
         case .chf:
             return viewModel.positionValueCHF[item.id] ?? 0
         }
+    }
+
+    static func == (lhs: ValueComparator, rhs: ValueComparator) -> Bool {
+        lhs.kind == rhs.kind && lhs.order == rhs.order && lhs.viewModel === rhs.viewModel
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(kind)
+        hasher.combine(order)
+        hasher.combine(ObjectIdentifier(viewModel))
     }
 }
 

--- a/DragonShield/Views/PositionsView.swift
+++ b/DragonShield/Views/PositionsView.swift
@@ -196,195 +196,223 @@ struct PositionsView: View {
 
     private func buildPositionsTable(data: [PositionReportData]) -> some View {
         Table(data, selection: $selectedRows, sortOrder: $sortOrder) {
-            TableColumn("Note") { (position: PositionReportData) in
-                if let note = position.notes, !note.isEmpty {
-                    Image(systemName: "info.circle.fill")
-                        .foregroundColor(.blue)
-                        .onHover { inside in
-                            hoverTask?.cancel()
-                            if inside {
-                                let item = HoverNote(text: note)
-                                let task = DispatchWorkItem { hoveredNote = item }
-                                hoverTask = task
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: task)
-                            } else {
-                                hoveredNote = nil
-                            }
-                        }
-                        .popover(item: $hoveredNote, arrowEdge: .top) { item in
-                            Text(item.text)
-                                .font(.system(size: 12))
-                                .foregroundColor(.primary)
-                                .padding(8)
-                                .background(Color.gray.opacity(0.1))
-                                .cornerRadius(6)
-                                .frame(maxWidth: 250, alignment: .leading)
-                        }
-                        .frame(width: 20)
-                } else {
-                    Color.clear.frame(width: 20)
-                }
-            }
-
-            Group {
-                TableColumn("Account", sortUsing: KeyPathComparator(\PositionReportData.accountName)) { (position: PositionReportData) in
-                    Text(position.accountName)
-                        .font(.system(size: 13))
-                        .foregroundColor(.secondary)
-                        .lineLimit(2)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(minWidth: 150, idealWidth: 150, maxWidth: .infinity, alignment: .leading)
-                }
-
-                TableColumn("Institution", sortUsing: KeyPathComparator(\PositionReportData.institutionName)) { (position: PositionReportData) in
-                    Text(position.institutionName)
-                        .font(.system(size: 13))
-                        .foregroundColor(.secondary)
-                        .lineLimit(2)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(minWidth: 150, idealWidth: 150, maxWidth: .infinity, alignment: .leading)
-                }
-
-                TableColumn("Instrument", sortUsing: KeyPathComparator(\PositionReportData.instrumentName)) { (position: PositionReportData) in
-                    Text(position.instrumentName)
-                        .font(.system(size: 14))
-                        .foregroundColor(.primary)
-                        .lineLimit(2)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
-
-                TableColumn("Currency", sortUsing: KeyPathComparator(\PositionReportData.instrumentCurrency)) { (position: PositionReportData) in
-                    Text(position.instrumentCurrency)
-                        .font(.system(size: 13, weight: .semibold, design: .monospaced))
-                        .foregroundColor(colorForCurrency(position.instrumentCurrency))
-                        .lineLimit(2)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(minWidth: 60, idealWidth: 60, maxWidth: .infinity, alignment: .center)
-                }
-
-                TableColumn("Qty", sortUsing: KeyPathComparator(\PositionReportData.quantity)) { (position: PositionReportData) in
-                    Text(String(format: "%.2f", position.quantity))
-                        .font(.system(size: 14, design: .monospaced))
-                        .lineLimit(2)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(minWidth: 60, idealWidth: 60, maxWidth: .infinity, alignment: .trailing)
-                }
-
-                TableColumn("Purchase", sortUsing: KeyPathComparator(\PositionReportData.purchasePrice)) { (position: PositionReportData) in
-                    if let p = position.purchasePrice {
-                        Text(String(format: "%.2f", p))
-                            .font(.system(size: 14, design: .monospaced))
-                            .lineLimit(2)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .frame(minWidth: 70, idealWidth: 70, maxWidth: .infinity, alignment: .trailing)
-                    } else {
-                        Text("-")
-                            .font(.system(size: 14, design: .monospaced))
-                            .foregroundColor(.secondary)
-                            .lineLimit(2)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .frame(minWidth: 70, idealWidth: 70, maxWidth: .infinity, alignment: .trailing)
-                    }
-                }
-
-                TableColumn("Current", sortUsing: KeyPathComparator(\PositionReportData.currentPrice)) { (position: PositionReportData) in
-                    if let cp = position.currentPrice {
-                        Text(String(format: "%.2f", cp))
-                            .font(.system(size: 14, design: .monospaced))
-                            .lineLimit(2)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .frame(minWidth: 70, idealWidth: 70, maxWidth: .infinity, alignment: .trailing)
-                    } else {
-                        Text("-")
-                            .font(.system(size: 14, design: .monospaced))
-                            .foregroundColor(.secondary)
-                            .lineLimit(2)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .frame(minWidth: 70, idealWidth: 70, maxWidth: .infinity, alignment: .trailing)
-                    }
-                }
-
-                TableColumn(
-                    "Position Value (Original Currency)",
-                    sortUsing: ValueComparator(kind: .original, viewModel: viewModel)
-                ) { (position: PositionReportData) in
-                    if let value = viewModel.positionValueOriginal[position.id] {
-                        let symbol = viewModel.currencySymbols[position.instrumentCurrency.uppercased()] ?? position.instrumentCurrency
-                        Text(String(format: "%.2f %@", value, symbol))
-                            .font(.system(size: 14, design: .monospaced))
-                            .lineLimit(2)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .frame(minWidth: 110, idealWidth: 110, maxWidth: .infinity, alignment: .trailing)
-                    } else {
-                        Text("-")
-                            .font(.system(size: 14, design: .monospaced))
-                            .foregroundColor(.secondary)
-                            .lineLimit(2)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .frame(minWidth: 110, idealWidth: 110, maxWidth: .infinity, alignment: .trailing)
-                    }
-                }
-
-                TableColumn(
-                    "Position Value (CHF)",
-                    sortUsing: ValueComparator(kind: .chf, viewModel: viewModel)
-                ) { (position: PositionReportData) in
-                    if let opt = viewModel.positionValueCHF[position.id] {
-                        if let value = opt {
-                            Text(String(format: "%.2f CHF", value))
-                                .font(.system(size: 14, design: .monospaced))
-                                .lineLimit(2)
-                                .fixedSize(horizontal: false, vertical: true)
-                                .frame(minWidth: 110, idealWidth: 110, maxWidth: .infinity, alignment: .trailing)
-                        } else {
-                            Text("-")
-                                .font(.system(size: 14, design: .monospaced))
-                                .foregroundColor(.secondary)
-                                .lineLimit(2)
-                                .fixedSize(horizontal: false, vertical: true)
-                                .frame(minWidth: 110, idealWidth: 110, maxWidth: .infinity, alignment: .trailing)
-                        }
-                    } else {
-                        Text("-")
-                            .font(.system(size: 14, design: .monospaced))
-                            .foregroundColor(.secondary)
-                            .lineLimit(2)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .frame(minWidth: 110, idealWidth: 110, maxWidth: .infinity, alignment: .trailing)
-                    }
-                }
-            }
-
-            Group {
-                TableColumn("Dates", sortUsing: KeyPathComparator(\PositionReportData.uploadedAt)) { (position: PositionReportData) in
-                    VStack {
-                        if let iu = position.instrumentUpdatedAt {
-                            Text(iu, formatter: DateFormatter.iso8601DateOnly)
-                        }
-                        Text(position.reportDate, formatter: DateFormatter.iso8601DateOnly)
-                        Text(position.uploadedAt, formatter: DateFormatter.iso8601DateTime)
-                    }
-                    .font(.system(size: 12))
-                    .foregroundColor(.secondary)
-                    .frame(minWidth: 110, idealWidth: 110, maxWidth: .infinity, alignment: .center)
-                }
-
-                TableColumn("Actions") { (position: PositionReportData) in
-                    HStack(spacing: 8) {
-                        Button(action: { positionToEdit = position }) { Image(systemName: "pencil") }
-                            .buttonStyle(PlainButtonStyle())
-                        Button(action: { positionToDelete = position; showDeleteSingleAlert = true }) { Image(systemName: "trash") }
-                            .buttonStyle(PlainButtonStyle())
-                    }
-                    .frame(width: 50)
-                }
-            }
+            noteColumn()
+            basicInfoColumns()
+            valueColumns()
+            dateAndActionColumns()
         }
         .tableStyle(.inset(alternatesRowBackgrounds: true))
         .padding(24)
         .background(Theme.surface)
         .cornerRadius(8)
+    }
+
+    @TableBuilder
+    private func noteColumn() -> some View {
+        TableColumn("Note") { (position: PositionReportData) in
+            noteCell(note: position.notes)
+        }
+    }
+
+    @TableBuilder
+    private func basicInfoColumns() -> some View {
+        TableColumn("Account", sortUsing: KeyPathComparator(\PositionReportData.accountName)) { (position: PositionReportData) in
+            Text(position.accountName)
+                .font(.system(size: 13))
+                .foregroundColor(.secondary)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(minWidth: 150, idealWidth: 150, maxWidth: .infinity, alignment: .leading)
+        }
+
+        TableColumn("Institution", sortUsing: KeyPathComparator(\PositionReportData.institutionName)) { (position: PositionReportData) in
+            Text(position.institutionName)
+                .font(.system(size: 13))
+                .foregroundColor(.secondary)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(minWidth: 150, idealWidth: 150, maxWidth: .infinity, alignment: .leading)
+        }
+
+        TableColumn("Instrument", sortUsing: KeyPathComparator(\PositionReportData.instrumentName)) { (position: PositionReportData) in
+            Text(position.instrumentName)
+                .font(.system(size: 14))
+                .foregroundColor(.primary)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+
+        TableColumn("Currency", sortUsing: KeyPathComparator(\PositionReportData.instrumentCurrency)) { (position: PositionReportData) in
+            Text(position.instrumentCurrency)
+                .font(.system(size: 13, weight: .semibold, design: .monospaced))
+                .foregroundColor(colorForCurrency(position.instrumentCurrency))
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(minWidth: 60, idealWidth: 60, maxWidth: .infinity, alignment: .center)
+        }
+
+        TableColumn("Qty", sortUsing: KeyPathComparator(\PositionReportData.quantity)) { (position: PositionReportData) in
+            Text(String(format: "%.2f", position.quantity))
+                .font(.system(size: 14, design: .monospaced))
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(minWidth: 60, idealWidth: 60, maxWidth: .infinity, alignment: .trailing)
+        }
+
+        TableColumn("Purchase", sortUsing: KeyPathComparator(\PositionReportData.purchasePrice)) { (position: PositionReportData) in
+            if let p = position.purchasePrice {
+                Text(String(format: "%.2f", p))
+                    .font(.system(size: 14, design: .monospaced))
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(minWidth: 70, idealWidth: 70, maxWidth: .infinity, alignment: .trailing)
+            } else {
+                Text("-")
+                    .font(.system(size: 14, design: .monospaced))
+                    .foregroundColor(.secondary)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(minWidth: 70, idealWidth: 70, maxWidth: .infinity, alignment: .trailing)
+            }
+        }
+
+        TableColumn("Current", sortUsing: KeyPathComparator(\PositionReportData.currentPrice)) { (position: PositionReportData) in
+            if let cp = position.currentPrice {
+                Text(String(format: "%.2f", cp))
+                    .font(.system(size: 14, design: .monospaced))
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(minWidth: 70, idealWidth: 70, maxWidth: .infinity, alignment: .trailing)
+            } else {
+                Text("-")
+                    .font(.system(size: 14, design: .monospaced))
+                    .foregroundColor(.secondary)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(minWidth: 70, idealWidth: 70, maxWidth: .infinity, alignment: .trailing)
+            }
+        }
+    }
+
+    @TableBuilder
+    private func valueColumns() -> some View {
+        TableColumn(
+            "Position Value (Original Currency)",
+            sortUsing: ValueComparator(kind: .original, viewModel: viewModel)
+        ) { (position: PositionReportData) in
+            originalValueCell(for: position)
+        }
+
+        TableColumn(
+            "Position Value (CHF)",
+            sortUsing: ValueComparator(kind: .chf, viewModel: viewModel)
+        ) { (position: PositionReportData) in
+            chfValueCell(for: position)
+        }
+    }
+
+    @TableBuilder
+    private func dateAndActionColumns() -> some View {
+        TableColumn("Dates", sortUsing: KeyPathComparator(\PositionReportData.uploadedAt)) { (position: PositionReportData) in
+            VStack {
+                if let iu = position.instrumentUpdatedAt {
+                    Text(iu, formatter: DateFormatter.iso8601DateOnly)
+                }
+                Text(position.reportDate, formatter: DateFormatter.iso8601DateOnly)
+                Text(position.uploadedAt, formatter: DateFormatter.iso8601DateTime)
+            }
+            .font(.system(size: 12))
+            .foregroundColor(.secondary)
+            .frame(minWidth: 110, idealWidth: 110, maxWidth: .infinity, alignment: .center)
+        }
+
+        TableColumn("Actions") { (position: PositionReportData) in
+            HStack(spacing: 8) {
+                Button(action: { positionToEdit = position }) { Image(systemName: "pencil") }
+                    .buttonStyle(PlainButtonStyle())
+                Button(action: { positionToDelete = position; showDeleteSingleAlert = true }) { Image(systemName: "trash") }
+                    .buttonStyle(PlainButtonStyle())
+            }
+            .frame(width: 50)
+        }
+    }
+
+    @ViewBuilder
+    private func noteCell(note: String?) -> some View {
+        if let note = note, !note.isEmpty {
+            Image(systemName: "info.circle.fill")
+                .foregroundColor(.blue)
+                .onHover { inside in
+                    hoverTask?.cancel()
+                    if inside {
+                        let item = HoverNote(text: note)
+                        let task = DispatchWorkItem { hoveredNote = item }
+                        hoverTask = task
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: task)
+                    } else {
+                        hoveredNote = nil
+                    }
+                }
+                .popover(item: $hoveredNote, arrowEdge: .top) { item in
+                    Text(item.text)
+                        .font(.system(size: 12))
+                        .foregroundColor(.primary)
+                        .padding(8)
+                        .background(Color.gray.opacity(0.1))
+                        .cornerRadius(6)
+                        .frame(maxWidth: 250, alignment: .leading)
+                }
+                .frame(width: 20)
+        } else {
+            Color.clear.frame(width: 20)
+        }
+    }
+
+    @ViewBuilder
+    private func originalValueCell(for position: PositionReportData) -> some View {
+        if let value = viewModel.positionValueOriginal[position.id] {
+            let symbol = viewModel.currencySymbols[position.instrumentCurrency.uppercased()] ?? position.instrumentCurrency
+            Text(String(format: "%.2f %@", value, symbol))
+                .font(.system(size: 14, design: .monospaced))
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(minWidth: 110, idealWidth: 110, maxWidth: .infinity, alignment: .trailing)
+        } else {
+            Text("-")
+                .font(.system(size: 14, design: .monospaced))
+                .foregroundColor(.secondary)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(minWidth: 110, idealWidth: 110, maxWidth: .infinity, alignment: .trailing)
+        }
+    }
+
+    @ViewBuilder
+    private func chfValueCell(for position: PositionReportData) -> some View {
+        if let opt = viewModel.positionValueCHF[position.id] {
+            if let value = opt {
+                Text(String(format: "%.2f CHF", value))
+                    .font(.system(size: 14, design: .monospaced))
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(minWidth: 110, idealWidth: 110, maxWidth: .infinity, alignment: .trailing)
+            } else {
+                Text("-")
+                    .font(.system(size: 14, design: .monospaced))
+                    .foregroundColor(.secondary)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(minWidth: 110, idealWidth: 110, maxWidth: .infinity, alignment: .trailing)
+            }
+        } else {
+            Text("-")
+                .font(.system(size: 14, design: .monospaced))
+                .foregroundColor(.secondary)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(minWidth: 110, idealWidth: 110, maxWidth: .infinity, alignment: .trailing)
+        }
     }
 
 

--- a/DragonShield/Views/PositionsView.swift
+++ b/DragonShield/Views/PositionsView.swift
@@ -215,13 +215,15 @@ struct PositionsView: View {
         .cornerRadius(8)
     }
 
-    private func noteColumn() -> TableColumn<PositionReportData, some View, Text> {
+    @ViewBuilder
+    private func noteColumn() -> some View {
         TableColumn("Note") { (position: PositionReportData) in
             noteCell(note: position.notes)
         }
     }
 
-    private func accountColumn() -> TableColumn<PositionReportData, some View, Text> {
+    @ViewBuilder
+    private func accountColumn() -> some View {
         TableColumn("Account", sortUsing: KeyPathComparator(\PositionReportData.accountName)) { (position: PositionReportData) in
             Text(position.accountName)
                 .font(.system(size: 13))
@@ -232,7 +234,8 @@ struct PositionsView: View {
         }
     }
 
-    private func institutionColumn() -> TableColumn<PositionReportData, some View, Text> {
+    @ViewBuilder
+    private func institutionColumn() -> some View {
         TableColumn("Institution", sortUsing: KeyPathComparator(\PositionReportData.institutionName)) { (position: PositionReportData) in
             Text(position.institutionName)
                 .font(.system(size: 13))
@@ -243,7 +246,8 @@ struct PositionsView: View {
         }
     }
 
-    private func instrumentColumn() -> TableColumn<PositionReportData, some View, Text> {
+    @ViewBuilder
+    private func instrumentColumn() -> some View {
         TableColumn("Instrument", sortUsing: KeyPathComparator(\PositionReportData.instrumentName)) { (position: PositionReportData) in
             Text(position.instrumentName)
                 .font(.system(size: 14))
@@ -254,7 +258,8 @@ struct PositionsView: View {
         }
     }
 
-    private func currencyColumn() -> TableColumn<PositionReportData, some View, Text> {
+    @ViewBuilder
+    private func currencyColumn() -> some View {
         TableColumn("Currency", sortUsing: KeyPathComparator(\PositionReportData.instrumentCurrency)) { (position: PositionReportData) in
             Text(position.instrumentCurrency)
                 .font(.system(size: 13, weight: .semibold, design: .monospaced))
@@ -265,7 +270,8 @@ struct PositionsView: View {
         }
     }
 
-    private func quantityColumn() -> TableColumn<PositionReportData, some View, Text> {
+    @ViewBuilder
+    private func quantityColumn() -> some View {
         TableColumn("Qty", sortUsing: KeyPathComparator(\PositionReportData.quantity)) { (position: PositionReportData) in
             Text(String(format: "%.2f", position.quantity))
                 .font(.system(size: 14, design: .monospaced))
@@ -275,7 +281,8 @@ struct PositionsView: View {
         }
     }
 
-    private func purchaseColumn() -> TableColumn<PositionReportData, some View, Text> {
+    @ViewBuilder
+    private func purchaseColumn() -> some View {
         TableColumn("Purchase", sortUsing: KeyPathComparator(\PositionReportData.purchasePrice)) { (position: PositionReportData) in
             if let p = position.purchasePrice {
                 Text(String(format: "%.2f", p))
@@ -294,7 +301,8 @@ struct PositionsView: View {
         }
     }
 
-    private func currentColumn() -> TableColumn<PositionReportData, some View, Text> {
+    @ViewBuilder
+    private func currentColumn() -> some View {
         TableColumn("Current", sortUsing: KeyPathComparator(\PositionReportData.currentPrice)) { (position: PositionReportData) in
             if let cp = position.currentPrice {
                 Text(String(format: "%.2f", cp))
@@ -313,7 +321,8 @@ struct PositionsView: View {
         }
     }
 
-    private func originalValueColumn() -> TableColumn<PositionReportData, some View, Text> {
+    @ViewBuilder
+    private func originalValueColumn() -> some View {
         TableColumn(
             "Position Value (Original Currency)",
             sortUsing: ValueComparator(kind: .original, viewModel: viewModel)
@@ -322,7 +331,8 @@ struct PositionsView: View {
         }
     }
 
-    private func chfValueColumn() -> TableColumn<PositionReportData, some View, Text> {
+    @ViewBuilder
+    private func chfValueColumn() -> some View {
         TableColumn(
             "Position Value (CHF)",
             sortUsing: ValueComparator(kind: .chf, viewModel: viewModel)
@@ -331,7 +341,8 @@ struct PositionsView: View {
         }
     }
 
-    private func datesColumn() -> TableColumn<PositionReportData, some View, Text> {
+    @ViewBuilder
+    private func datesColumn() -> some View {
         TableColumn("Dates", sortUsing: KeyPathComparator(\PositionReportData.uploadedAt)) { (position: PositionReportData) in
             VStack {
                 if let iu = position.instrumentUpdatedAt {
@@ -346,7 +357,8 @@ struct PositionsView: View {
         }
     }
 
-    private func actionsColumn() -> TableColumn<PositionReportData, some View, Text> {
+    @ViewBuilder
+    private func actionsColumn() -> some View {
         TableColumn("Actions") { (position: PositionReportData) in
             HStack(spacing: 8) {
                 Button(action: { positionToEdit = position }) { Image(systemName: "pencil") }

--- a/DragonShield/Views/PositionsView.swift
+++ b/DragonShield/Views/PositionsView.swift
@@ -191,7 +191,11 @@ struct PositionsView: View {
 
     private var positionsContent: some View {
         let data = sortedPositions
-        return Table(data, selection: $selectedRows, sortOrder: $sortOrder) {
+        return buildPositionsTable(data: data)
+    }
+
+    private func buildPositionsTable(data: [PositionReportData]) -> some View {
+        Table(data, selection: $selectedRows, sortOrder: $sortOrder) {
             TableColumn("Note") { (position: PositionReportData) in
                 if let note = position.notes, !note.isEmpty {
                     Image(systemName: "info.circle.fill")
@@ -533,7 +537,11 @@ struct ValueComparator: SortComparator, Hashable {
         case .original:
             return viewModel.positionValueOriginal[item.id] ?? 0
         case .chf:
-            return viewModel.positionValueCHF[item.id] ?? 0
+            if let nested = viewModel.positionValueCHF[item.id], let value = nested {
+                return value
+            } else {
+                return 0
+            }
         }
     }
 

--- a/DragonShield/Views/PositionsView.swift
+++ b/DragonShield/Views/PositionsView.swift
@@ -196,129 +196,138 @@ struct PositionsView: View {
                 noteCell(note: position.notes)
             }
 
-            Group {
-                TableColumn("Account", sortUsing: KeyPathComparator(\PositionReportData.accountName)) { (position: PositionReportData) in
-                    Text(position.accountName)
-                        .font(.system(size: 13))
-                        .foregroundColor(.secondary)
-                        .lineLimit(2)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(minWidth: 150, idealWidth: 150, maxWidth: .infinity, alignment: .leading)
-                }
-
-                TableColumn("Institution", sortUsing: KeyPathComparator(\PositionReportData.institutionName)) { (position: PositionReportData) in
-                    Text(position.institutionName)
-                        .font(.system(size: 13))
-                        .foregroundColor(.secondary)
-                        .lineLimit(2)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(minWidth: 150, idealWidth: 150, maxWidth: .infinity, alignment: .leading)
-                }
-
-                TableColumn("Instrument", sortUsing: KeyPathComparator(\PositionReportData.instrumentName)) { (position: PositionReportData) in
-                    Text(position.instrumentName)
-                        .font(.system(size: 14))
-                        .foregroundColor(.primary)
-                        .lineLimit(2)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
-
-                TableColumn("Currency", sortUsing: KeyPathComparator(\PositionReportData.instrumentCurrency)) { (position: PositionReportData) in
-                    Text(position.instrumentCurrency)
-                        .font(.system(size: 13, weight: .semibold, design: .monospaced))
-                        .foregroundColor(colorForCurrency(position.instrumentCurrency))
-                        .lineLimit(2)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(minWidth: 60, idealWidth: 60, maxWidth: .infinity, alignment: .center)
-                }
-
-                TableColumn("Qty", sortUsing: KeyPathComparator(\PositionReportData.quantity)) { (position: PositionReportData) in
-                    Text(String(format: "%.2f", position.quantity))
-                        .font(.system(size: 14, design: .monospaced))
-                        .lineLimit(2)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(minWidth: 60, idealWidth: 60, maxWidth: .infinity, alignment: .trailing)
-                }
-
-                TableColumn("Purchase", sortUsing: KeyPathComparator(\PositionReportData.purchasePrice)) { (position: PositionReportData) in
-                    if let p = position.purchasePrice {
-                        Text(String(format: "%.2f", p))
-                            .font(.system(size: 14, design: .monospaced))
-                            .lineLimit(2)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .frame(minWidth: 70, idealWidth: 70, maxWidth: .infinity, alignment: .trailing)
-                    } else {
-                        Text("-")
-                            .font(.system(size: 14, design: .monospaced))
-                            .foregroundColor(.secondary)
-                            .lineLimit(2)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .frame(minWidth: 70, idealWidth: 70, maxWidth: .infinity, alignment: .trailing)
-                    }
-                }
-
-                TableColumn("Current", sortUsing: KeyPathComparator(\PositionReportData.currentPrice)) { (position: PositionReportData) in
-                    if let cp = position.currentPrice {
-                        Text(String(format: "%.2f", cp))
-                            .font(.system(size: 14, design: .monospaced))
-                            .lineLimit(2)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .frame(minWidth: 70, idealWidth: 70, maxWidth: .infinity, alignment: .trailing)
-                    } else {
-                        Text("-")
-                            .font(.system(size: 14, design: .monospaced))
-                            .foregroundColor(.secondary)
-                            .lineLimit(2)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .frame(minWidth: 70, idealWidth: 70, maxWidth: .infinity, alignment: .trailing)
-                    }
-                }
-
-                TableColumn(
-                    "Position Value (Original Currency)",
-                    sortUsing: ValueComparator(kind: .original, viewModel: viewModel)
-                ) { (position: PositionReportData) in
-                    originalValueCell(for: position)
-                }
-
-                TableColumn(
-                    "Position Value (CHF)",
-                    sortUsing: ValueComparator(kind: .chf, viewModel: viewModel)
-                ) { (position: PositionReportData) in
-                    chfValueCell(for: position)
-                }
-            }
-
-            Group {
-                TableColumn("Dates", sortUsing: KeyPathComparator(\PositionReportData.uploadedAt)) { (position: PositionReportData) in
-                    VStack {
-                        if let iu = position.instrumentUpdatedAt {
-                            Text(iu, formatter: DateFormatter.iso8601DateOnly)
-                        }
-                        Text(position.reportDate, formatter: DateFormatter.iso8601DateOnly)
-                        Text(position.uploadedAt, formatter: DateFormatter.iso8601DateTime)
-                    }
-                    .font(.system(size: 12))
-                    .foregroundColor(.secondary)
-                    .frame(minWidth: 110, idealWidth: 110, maxWidth: .infinity, alignment: .center)
-                }
-
-                TableColumn("Actions") { (position: PositionReportData) in
-                    HStack(spacing: 8) {
-                        Button(action: { positionToEdit = position }) { Image(systemName: "pencil") }
-                            .buttonStyle(PlainButtonStyle())
-                        Button(action: { positionToDelete = position; showDeleteSingleAlert = true }) { Image(systemName: "trash") }
-                            .buttonStyle(PlainButtonStyle())
-                    }
-                    .frame(width: 50)
-                }
-            }
+            basicInfoColumns()
+            valueColumns()
+            dateAndActionColumns()
         }
         .tableStyle(.inset(alternatesRowBackgrounds: true))
         .padding(24)
         .background(Theme.surface)
         .cornerRadius(8)
+    }
+
+    @ViewBuilder
+    private func basicInfoColumns() -> some View {
+        TableColumn("Account", sortUsing: KeyPathComparator(\PositionReportData.accountName)) { (position: PositionReportData) in
+            Text(position.accountName)
+                .font(.system(size: 13))
+                .foregroundColor(.secondary)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(minWidth: 150, idealWidth: 150, maxWidth: .infinity, alignment: .leading)
+        }
+
+        TableColumn("Institution", sortUsing: KeyPathComparator(\PositionReportData.institutionName)) { (position: PositionReportData) in
+            Text(position.institutionName)
+                .font(.system(size: 13))
+                .foregroundColor(.secondary)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(minWidth: 150, idealWidth: 150, maxWidth: .infinity, alignment: .leading)
+        }
+
+        TableColumn("Instrument", sortUsing: KeyPathComparator(\PositionReportData.instrumentName)) { (position: PositionReportData) in
+            Text(position.instrumentName)
+                .font(.system(size: 14))
+                .foregroundColor(.primary)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+
+        TableColumn("Currency", sortUsing: KeyPathComparator(\PositionReportData.instrumentCurrency)) { (position: PositionReportData) in
+            Text(position.instrumentCurrency)
+                .font(.system(size: 13, weight: .semibold, design: .monospaced))
+                .foregroundColor(colorForCurrency(position.instrumentCurrency))
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(minWidth: 60, idealWidth: 60, maxWidth: .infinity, alignment: .center)
+        }
+
+        TableColumn("Qty", sortUsing: KeyPathComparator(\PositionReportData.quantity)) { (position: PositionReportData) in
+            Text(String(format: "%.2f", position.quantity))
+                .font(.system(size: 14, design: .monospaced))
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(minWidth: 60, idealWidth: 60, maxWidth: .infinity, alignment: .trailing)
+        }
+
+        TableColumn("Purchase", sortUsing: KeyPathComparator(\PositionReportData.purchasePrice)) { (position: PositionReportData) in
+            if let p = position.purchasePrice {
+                Text(String(format: "%.2f", p))
+                    .font(.system(size: 14, design: .monospaced))
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(minWidth: 70, idealWidth: 70, maxWidth: .infinity, alignment: .trailing)
+            } else {
+                Text("-")
+                    .font(.system(size: 14, design: .monospaced))
+                    .foregroundColor(.secondary)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(minWidth: 70, idealWidth: 70, maxWidth: .infinity, alignment: .trailing)
+            }
+        }
+
+        TableColumn("Current", sortUsing: KeyPathComparator(\PositionReportData.currentPrice)) { (position: PositionReportData) in
+            if let cp = position.currentPrice {
+                Text(String(format: "%.2f", cp))
+                    .font(.system(size: 14, design: .monospaced))
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(minWidth: 70, idealWidth: 70, maxWidth: .infinity, alignment: .trailing)
+            } else {
+                Text("-")
+                    .font(.system(size: 14, design: .monospaced))
+                    .foregroundColor(.secondary)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(minWidth: 70, idealWidth: 70, maxWidth: .infinity, alignment: .trailing)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func valueColumns() -> some View {
+        TableColumn(
+            "Position Value (Original Currency)",
+            sortUsing: ValueComparator(kind: .original, viewModel: viewModel)
+        ) { (position: PositionReportData) in
+            originalValueCell(for: position)
+        }
+
+        TableColumn(
+            "Position Value (CHF)",
+            sortUsing: ValueComparator(kind: .chf, viewModel: viewModel)
+        ) { (position: PositionReportData) in
+            chfValueCell(for: position)
+        }
+    }
+
+    @ViewBuilder
+    private func dateAndActionColumns() -> some View {
+        TableColumn("Dates", sortUsing: KeyPathComparator(\PositionReportData.uploadedAt)) { (position: PositionReportData) in
+            VStack {
+                if let iu = position.instrumentUpdatedAt {
+                    Text(iu, formatter: DateFormatter.iso8601DateOnly)
+                }
+                Text(position.reportDate, formatter: DateFormatter.iso8601DateOnly)
+                Text(position.uploadedAt, formatter: DateFormatter.iso8601DateTime)
+            }
+            .font(.system(size: 12))
+            .foregroundColor(.secondary)
+            .frame(minWidth: 110, idealWidth: 110, maxWidth: .infinity, alignment: .center)
+        }
+
+        TableColumn("Actions") { (position: PositionReportData) in
+            HStack(spacing: 8) {
+                Button(action: { positionToEdit = position }) { Image(systemName: "pencil") }
+                    .buttonStyle(PlainButtonStyle())
+                Button(action: { positionToDelete = position; showDeleteSingleAlert = true }) { Image(systemName: "trash") }
+                    .buttonStyle(PlainButtonStyle())
+            }
+            .frame(width: 50)
+        }
     }
 
     @ViewBuilder

--- a/DragonShield/Views/PositionsView.swift
+++ b/DragonShield/Views/PositionsView.swift
@@ -197,9 +197,17 @@ struct PositionsView: View {
     private func buildPositionsTable(data: [PositionReportData]) -> some View {
         Table(data, selection: $selectedRows, sortOrder: $sortOrder) {
             noteColumn()
-            basicInfoColumns()
-            valueColumns()
-            dateAndActionColumns()
+            accountColumn()
+            institutionColumn()
+            instrumentColumn()
+            currencyColumn()
+            quantityColumn()
+            purchaseColumn()
+            currentColumn()
+            originalValueColumn()
+            chfValueColumn()
+            datesColumn()
+            actionsColumn()
         }
         .tableStyle(.inset(alternatesRowBackgrounds: true))
         .padding(24)
@@ -207,15 +215,13 @@ struct PositionsView: View {
         .cornerRadius(8)
     }
 
-    @TableBuilder
-    private func noteColumn() -> some View {
+    private func noteColumn() -> TableColumn<PositionReportData, some View, Text> {
         TableColumn("Note") { (position: PositionReportData) in
             noteCell(note: position.notes)
         }
     }
 
-    @TableBuilder
-    private func basicInfoColumns() -> some View {
+    private func accountColumn() -> TableColumn<PositionReportData, some View, Text> {
         TableColumn("Account", sortUsing: KeyPathComparator(\PositionReportData.accountName)) { (position: PositionReportData) in
             Text(position.accountName)
                 .font(.system(size: 13))
@@ -224,7 +230,9 @@ struct PositionsView: View {
                 .fixedSize(horizontal: false, vertical: true)
                 .frame(minWidth: 150, idealWidth: 150, maxWidth: .infinity, alignment: .leading)
         }
+    }
 
+    private func institutionColumn() -> TableColumn<PositionReportData, some View, Text> {
         TableColumn("Institution", sortUsing: KeyPathComparator(\PositionReportData.institutionName)) { (position: PositionReportData) in
             Text(position.institutionName)
                 .font(.system(size: 13))
@@ -233,7 +241,9 @@ struct PositionsView: View {
                 .fixedSize(horizontal: false, vertical: true)
                 .frame(minWidth: 150, idealWidth: 150, maxWidth: .infinity, alignment: .leading)
         }
+    }
 
+    private func instrumentColumn() -> TableColumn<PositionReportData, some View, Text> {
         TableColumn("Instrument", sortUsing: KeyPathComparator(\PositionReportData.instrumentName)) { (position: PositionReportData) in
             Text(position.instrumentName)
                 .font(.system(size: 14))
@@ -242,7 +252,9 @@ struct PositionsView: View {
                 .fixedSize(horizontal: false, vertical: true)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
+    }
 
+    private func currencyColumn() -> TableColumn<PositionReportData, some View, Text> {
         TableColumn("Currency", sortUsing: KeyPathComparator(\PositionReportData.instrumentCurrency)) { (position: PositionReportData) in
             Text(position.instrumentCurrency)
                 .font(.system(size: 13, weight: .semibold, design: .monospaced))
@@ -251,7 +263,9 @@ struct PositionsView: View {
                 .fixedSize(horizontal: false, vertical: true)
                 .frame(minWidth: 60, idealWidth: 60, maxWidth: .infinity, alignment: .center)
         }
+    }
 
+    private func quantityColumn() -> TableColumn<PositionReportData, some View, Text> {
         TableColumn("Qty", sortUsing: KeyPathComparator(\PositionReportData.quantity)) { (position: PositionReportData) in
             Text(String(format: "%.2f", position.quantity))
                 .font(.system(size: 14, design: .monospaced))
@@ -259,7 +273,9 @@ struct PositionsView: View {
                 .fixedSize(horizontal: false, vertical: true)
                 .frame(minWidth: 60, idealWidth: 60, maxWidth: .infinity, alignment: .trailing)
         }
+    }
 
+    private func purchaseColumn() -> TableColumn<PositionReportData, some View, Text> {
         TableColumn("Purchase", sortUsing: KeyPathComparator(\PositionReportData.purchasePrice)) { (position: PositionReportData) in
             if let p = position.purchasePrice {
                 Text(String(format: "%.2f", p))
@@ -276,7 +292,9 @@ struct PositionsView: View {
                     .frame(minWidth: 70, idealWidth: 70, maxWidth: .infinity, alignment: .trailing)
             }
         }
+    }
 
+    private func currentColumn() -> TableColumn<PositionReportData, some View, Text> {
         TableColumn("Current", sortUsing: KeyPathComparator(\PositionReportData.currentPrice)) { (position: PositionReportData) in
             if let cp = position.currentPrice {
                 Text(String(format: "%.2f", cp))
@@ -295,15 +313,16 @@ struct PositionsView: View {
         }
     }
 
-    @TableBuilder
-    private func valueColumns() -> some View {
+    private func originalValueColumn() -> TableColumn<PositionReportData, some View, Text> {
         TableColumn(
             "Position Value (Original Currency)",
             sortUsing: ValueComparator(kind: .original, viewModel: viewModel)
         ) { (position: PositionReportData) in
             originalValueCell(for: position)
         }
+    }
 
+    private func chfValueColumn() -> TableColumn<PositionReportData, some View, Text> {
         TableColumn(
             "Position Value (CHF)",
             sortUsing: ValueComparator(kind: .chf, viewModel: viewModel)
@@ -312,8 +331,7 @@ struct PositionsView: View {
         }
     }
 
-    @TableBuilder
-    private func dateAndActionColumns() -> some View {
+    private func datesColumn() -> TableColumn<PositionReportData, some View, Text> {
         TableColumn("Dates", sortUsing: KeyPathComparator(\PositionReportData.uploadedAt)) { (position: PositionReportData) in
             VStack {
                 if let iu = position.instrumentUpdatedAt {
@@ -326,7 +344,9 @@ struct PositionsView: View {
             .foregroundColor(.secondary)
             .frame(minWidth: 110, idealWidth: 110, maxWidth: .infinity, alignment: .center)
         }
+    }
 
+    private func actionsColumn() -> TableColumn<PositionReportData, some View, Text> {
         TableColumn("Actions") { (position: PositionReportData) in
             HStack(spacing: 8) {
                 Button(action: { positionToEdit = position }) { Image(systemName: "pencil") }

--- a/Model/Position.swift
+++ b/Model/Position.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct Position: Identifiable {
+    let id: Int
+    var note: String?
+}


### PR DESCRIPTION
## Summary
- show tooltip for position notes on hover
- enable sorting for value columns
- track note text in `Position` model

## Testing
- `pytest tests/test_currency_exposure.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6875ecf2a9ec8323b9c7fa2568ed0d9f