### PR TITLE
Improve Position form layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Expand PositionReports with diverse sample entries for testing
 - Add risk concentration dashboard tile showing top 5 groups by value
 - Support asset class grouping and display CHF values in Risk Buckets tile
+- Improve Position form with labeled numeric fields and aligned date pickers
 - Fix unicode bullet escape in Data Import/Export status message causing build error
 - Track last instrument update timestamp on PositionReports
 - Track earliest instrument update timestamp on Accounts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Add risk concentration dashboard tile showing top 5 groups by value
 - Support asset class grouping and display CHF values in Risk Buckets tile
 - Improve Position form with labeled numeric fields and aligned date pickers
+- Refine Position form typography and enforce minimum sheet size
 - Fix unicode bullet escape in Data Import/Export status message causing build error
 - Track last instrument update timestamp on PositionReports
 - Track earliest instrument update timestamp on Accounts

--- a/DragonShield/Views/PositionFormView.swift
+++ b/DragonShield/Views/PositionFormView.swift
@@ -51,15 +51,16 @@ struct PositionFormView: View {
             }
         }
         .padding(24)
-        .frame(width: 400)
+        .frame(width: 480)
         .onAppear { loadData(); populate() }
     }
 
     private var formFields: some View {
-        Group {
-            TextField("Session", text: $sessionId)
-                .textFieldStyle(.roundedBorder)
-                .accessibilityLabel("Import Session")
+        Form {
+            Section {
+                TextField("Session", text: $sessionId)
+                    .textFieldStyle(.roundedBorder)
+                    .accessibilityLabel("Import Session")
 
             Picker("Account", selection: $accountId) {
                 Text("Select Account").tag(Optional<Int>(nil))
@@ -92,35 +93,63 @@ struct PositionFormView: View {
                 }
             }
             .accessibilityLabel("Currency")
+            }
 
-            TextField("Quantity", text: $quantity)
+            Section("Prices") {
+                numericField(label: "Quantity", text: $quantity)
+                numericField(label: "Purchase Price", text: $purchasePrice)
+                numericField(label: "Current Price", text: $currentPrice)
+            }
+
+            Section("Dates") {
+                datesGrid
+            }
+
+            Section("Notes") {
+                TextEditor(text: $notes)
+                    .frame(height: 60)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 4)
+                            .stroke(Color.gray.opacity(0.3))
+                    )
+                    .accessibilityLabel("Notes")
+            }
+        }
+    }
+
+    private func numericField(label: String, text: Binding<String>) -> some View {
+        HStack {
+            Text(label)
+            Spacer()
+            TextField("", text: text)
+                .multilineTextAlignment(.trailing)
                 .textFieldStyle(.roundedBorder)
+                .frame(width: 120)
+                .accessibilityLabel(label)
+        }
+    }
 
-            TextField("Purchase Price", text: $purchasePrice)
-                .textFieldStyle(.roundedBorder)
+    private var datesGrid: some View {
+        Grid(horizontalSpacing: 16, verticalSpacing: 8) {
+            GridRow {
+                dateField(label: "Instrument Updated", date: $instrumentUpdatedAt)
+                dateField(label: "Value Date", date: $valueDate)
+            }
+            GridRow {
+                dateField(label: "Uploaded At", date: $uploadedAt)
+                dateField(label: "Report Date", date: $reportDate)
+            }
+        }
+    }
 
-            TextField("Current Price", text: $currentPrice)
-                .textFieldStyle(.roundedBorder)
-
-            DatePicker("Instrument Updated", selection: $instrumentUpdatedAt, displayedComponents: .date)
+    private func dateField(label: String, date: Binding<Date>) -> some View {
+        HStack {
+            Text(label)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            DatePicker("", selection: date, displayedComponents: .date)
+                .labelsHidden()
                 .datePickerStyle(.field)
-
-            DatePicker("Value Date", selection: $valueDate, displayedComponents: .date)
-                .datePickerStyle(.field)
-
-            DatePicker("Uploaded At", selection: $uploadedAt, displayedComponents: .date)
-                .datePickerStyle(.field)
-
-            DatePicker("Report Date", selection: $reportDate, displayedComponents: .date)
-                .datePickerStyle(.field)
-
-            TextEditor(text: $notes)
-                .frame(height: 60)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 4)
-                        .stroke(Color.gray.opacity(0.3))
-                )
-                .accessibilityLabel("Notes")
+                .frame(maxWidth: .infinity, alignment: .trailing)
         }
     }
 

--- a/DragonShield/Views/PositionFormView.swift
+++ b/DragonShield/Views/PositionFormView.swift
@@ -51,7 +51,7 @@ struct PositionFormView: View {
             }
         }
         .padding(24)
-        .frame(width: 480)
+        .frame(minWidth: 520, minHeight: 620)
         .onAppear { loadData(); populate() }
     }
 
@@ -115,17 +115,20 @@ struct PositionFormView: View {
                     .accessibilityLabel("Notes")
             }
         }
+        .formStyle(.grouped)
     }
 
     private func numericField(label: String, text: Binding<String>) -> some View {
         HStack {
             Text(label)
+                .font(.headline)
             Spacer()
             TextField("", text: text)
                 .multilineTextAlignment(.trailing)
                 .textFieldStyle(.roundedBorder)
                 .frame(width: 120)
                 .accessibilityLabel(label)
+                .font(.body)
         }
     }
 
@@ -146,10 +149,12 @@ struct PositionFormView: View {
         HStack {
             Text(label)
                 .frame(maxWidth: .infinity, alignment: .leading)
+                .font(.headline)
             DatePicker("", selection: date, displayedComponents: .date)
                 .labelsHidden()
                 .datePickerStyle(.field)
                 .frame(maxWidth: .infinity, alignment: .trailing)
+                .font(.body)
         }
     }
 


### PR DESCRIPTION
## Summary
- add labels for quantity, purchase price and current price
- align date fields in a grid
- switch PositionFormView to `Form` sections

## Testing
- `pytest tests/test_refresh_button.py -q`
- `pytest -q` *(fails: ModuleNotFoundError for pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68768547de24832384936945f66cfc5d