### PR TITLE
Add adjustable font size for positions table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,4 +244,5 @@ All notable changes to this project will be documented in this file.
 - Show Top 10 Positions by Asset Value (CHF) on Dashboard
 - Add Portfolio by Currency dashboard tile with CHF-based exposure
 - Allow hiding and showing columns in Positions table with persistent settings
+- Add adjustable font size (7-14pt) for Positions table in column settings
 - Resolve compile warnings in PositionsView and ExchangeRates helpers

--- a/DragonShield/helpers/UserDefaultsKeys.swift
+++ b/DragonShield/helpers/UserDefaultsKeys.swift
@@ -18,4 +18,5 @@ struct UserDefaultsKeys {
     static let backupDirectoryURL = "backupDirectoryURL"
     static let backupDirectoryBookmark = "backupDirectoryBookmark"
     static let positionsVisibleColumns = "positionsVisibleColumns"
+    static let positionsFontSize = "positionsFontSize"
 }


### PR DESCRIPTION
## Summary
- allow saving preferred font size via new `positionsFontSize` key
- integrate column visibility and font size controls in a popover
- apply font size across all table cells
- document the new setting in the changelog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6876a6d373ac8323953604754875a8f4