### PR TITLE
fix: remove Value Date field from position form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -247,3 +247,4 @@ All notable changes to this project will be documented in this file.
 - Add adjustable font size (7-14pt) for Positions table in column settings
 - Resolve compile warnings in PositionsView and ExchangeRates helpers
 - Rename "Instrument Updated" label to "Last Update" in Position form
+- Remove obsolete Value Date field from Position form

--- a/DragonShield/Views/PositionFormView.swift
+++ b/DragonShield/Views/PositionFormView.swift
@@ -21,7 +21,6 @@ struct PositionFormView: View {
     @State private var purchasePrice = ""
     @State private var currentPrice = ""
     @State private var instrumentUpdatedAt = Date()
-    @State private var valueDate = Date()
     @State private var uploadedAt = Date()
     @State private var reportDate = Date()
     @State private var notes = ""
@@ -136,10 +135,9 @@ struct PositionFormView: View {
         Grid(horizontalSpacing: 16, verticalSpacing: 8) {
             GridRow {
                 dateField(label: "Last Update", date: $instrumentUpdatedAt)
-                dateField(label: "Value Date", date: $valueDate)
+                dateField(label: "Uploaded At", date: $uploadedAt)
             }
             GridRow {
-                dateField(label: "Uploaded At", date: $uploadedAt)
                 dateField(label: "Report Date", date: $reportDate)
             }
         }
@@ -184,7 +182,6 @@ struct PositionFormView: View {
         if let pp = p.purchasePrice { purchasePrice = String(pp) }
         if let cp = p.currentPrice { currentPrice = String(cp) }
         if let iu = p.instrumentUpdatedAt { instrumentUpdatedAt = iu }
-        valueDate = p.reportDate
         uploadedAt = p.uploadedAt
         reportDate = p.reportDate
         notes = p.notes ?? ""


### PR DESCRIPTION
## Summary
- remove Value Date field from edit position form
- document the form update in the changelog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'DragonShield')*

------
https://chatgpt.com/codex/tasks/task_e_6876ac272968832397d418c951abb689