### PR TITLE
Add ZKB CSV parsing support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project will be documented in this file.
 - Document Data Import/Export screen spec with Statement Loading Log and wireframe
 - Redesign Data Import/Export view with import cards, summary bar and persistent log
 - Display import progress and update log when importing Credit-Suisse statements
+- Parse ZKB CSV depot statements via new `zkb_parser` and auto-dispatch in `import_tool`
 - Assign report date to instrument updated timestamp for Credit-Suisse imports
 - Simplify Data Import/Export layout with separate status bar and persistent log
 - Fix Data Import/Export layout so Select File button and log panel are visible

--- a/DragonShield/python_scripts/zkb_parser.py
+++ b/DragonShield/python_scripts/zkb_parser.py
@@ -1,0 +1,108 @@
+import csv
+import json
+import re
+import sys
+from typing import Any, Dict, Optional
+
+
+def parse_statement_date_from_filename(filename: str) -> Optional[str]:
+    match_mon_dd_yyyy = re.search(
+        r"(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*[\s.-]+(\d{1,2})[\s.,-]+(\d{4})",
+        filename,
+        re.IGNORECASE,
+    )
+    if match_mon_dd_yyyy:
+        month_str, day, year = match_mon_dd_yyyy.groups()
+        month_map = {name: num for num, name in enumerate([
+            "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+            "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"], 1)}
+        month = month_map.get(month_str[:3].capitalize())
+        if month:
+            return f"{int(year):04d}-{int(month):02d}-{int(day):02d}"
+    return None
+
+
+def parse_number(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    text = str(value).strip()
+    if not text:
+        return None
+    cleaned = text.replace("'", "").replace(" ", "")
+    cleaned = cleaned.replace(".", "").replace(",", ".")
+    try:
+        return float(cleaned)
+    except ValueError:
+        return None
+
+
+def process_file(filepath: str) -> int:
+    parsed: Dict[str, Any] = {
+        "institution_name": "ZKB",
+        "parsed_statement_date": parse_statement_date_from_filename(filepath.split('/')[-1]),
+        "summary": {
+            "processed_file": filepath,
+            "total_data_rows_attempted": 0,
+            "data_rows_successfully_parsed": 0,
+            "cash_account_records": 0,
+            "security_holding_records": 0,
+        },
+        "records": [],
+    }
+    try:
+        with open(filepath, newline='', encoding='utf-8-sig') as f:
+            reader = csv.DictReader(f, delimiter=';')
+            for row in reader:
+                parsed["summary"]["total_data_rows_attempted"] += 1
+                category = (row.get("Anlagekategorie") or "").strip()
+                quantity = parse_number(row.get("Anz./Nom."))
+                price = parse_number(row.get("Kurs"))
+                currency = (row.get("Währung") or "").strip()
+                name = (row.get("Bezeichnung") or "").strip()
+                isin_match = re.search(r"[A-Z]{2}[A-Z0-9]{10}", name)
+                valor_match = re.search(r"\b\d{6,}\b", name)
+                record: Dict[str, Any]
+                if category == "Konten":
+                    parsed["summary"]["cash_account_records"] += 1
+                    record = {
+                        "record_type": "cash_account",
+                        "currency": currency,
+                        "balance": quantity,
+                    }
+                else:
+                    parsed["summary"]["security_holding_records"] += 1
+                    record = {
+                        "record_type": "security_holding",
+                        "instrument_name_from_file": name,
+                        "isin": isin_match.group(0) if isin_match else None,
+                        "valor": valor_match.group(0) if valor_match else None,
+                        "quantity_nominal": quantity,
+                        "current_price": price,
+                        "currency": currency,
+                        "original_anlagekategorie": category,
+                    }
+                parsed["records"].append(record)
+                parsed["summary"]["data_rows_successfully_parsed"] += 1
+    except FileNotFoundError:
+        parsed["summary"]["error"] = f"File not found at {filepath}"
+        print(json.dumps(parsed, ensure_ascii=False))
+        return 1
+    except Exception as e:  # pragma: no cover - generic error path
+        parsed["summary"]["error"] = f"An error occurred: {e}"
+        print(json.dumps(parsed, ensure_ascii=False))
+        return 3
+
+    print(json.dumps(parsed, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI usage
+    if len(sys.argv) > 1:
+        sys.exit(process_file(sys.argv[1]))
+    print(json.dumps({
+        "error": "Please provide the CSV file path as an argument.",
+        "usage": "python zkb_parser.py <path_to_file.csv>",
+    }))
+    sys.exit(1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,87 @@
+import sys
+import types
+
+class FakeSeries(list):
+    def __sub__(self, other):
+        if isinstance(other, (int, float)):
+            return FakeSeries([x - other for x in self])
+        if isinstance(other, FakeSeries):
+            return FakeSeries([a - b for a, b in zip(self, other)])
+        return NotImplemented
+
+    def __truediv__(self, other):
+        if isinstance(other, (int, float)):
+            return FakeSeries([x / other for x in self])
+        if isinstance(other, FakeSeries):
+            return FakeSeries([a / b for a, b in zip(self, other)])
+        return NotImplemented
+
+    def mean(self):
+        return sum(self) / len(self) if self else 0.0
+
+    def std(self):
+        m = self.mean()
+        return (sum((x - m) ** 2 for x in self) / len(self)) ** 0.5 if self else 0.0
+
+    def cumprod(self):
+        out = []
+        acc = 1.0
+        for x in self:
+            acc *= (1 + x)
+            out.append(acc)
+        return FakeSeries(out)
+
+    def cummax(self):
+        out = []
+        current = float('-inf')
+        for x in self:
+            current = x if x > current else current
+            out.append(current)
+        return FakeSeries(out)
+
+    def quantile(self, q):
+        if not self:
+            return 0.0
+        arr = sorted(self)
+        idx = int((len(arr) - 1) * q)
+        return arr[idx]
+
+    def min(self):
+        return min(x for x in self) if self else 0.0
+
+    def astype(self, _type):
+        if _type is float:
+            return FakeSeries([float(x) for x in self])
+        return self
+
+    def __getitem__(self, key):
+        if isinstance(key, FakeSeries):
+            return FakeSeries([x for x, flag in zip(self, key) if flag])
+        return FakeSeries(super().__getitem__(key)) if isinstance(key, slice) else super().__getitem__(key)
+
+    def __lt__(self, other):
+        if isinstance(other, (int, float)):
+            return FakeSeries([x < other for x in self])
+        if isinstance(other, FakeSeries):
+            return FakeSeries([a < b for a, b in zip(self, other)])
+        return NotImplemented
+
+    def __radd__(self, other):
+        if isinstance(other, (int, float)):
+            return FakeSeries([other + x for x in self])
+        return NotImplemented
+
+
+def Series(data):
+    return FakeSeries(list(data))
+
+fake_pandas = types.ModuleType('pandas')
+fake_pandas.Series = Series
+fake_pandas.read_csv = lambda *a, **k: None
+
+sys.modules.setdefault('pandas', fake_pandas)
+
+import math
+fake_numpy = types.ModuleType('numpy')
+fake_numpy.sqrt = math.sqrt
+sys.modules.setdefault('numpy', fake_numpy)

--- a/tests/test_import_tool.py
+++ b/tests/test_import_tool.py
@@ -113,3 +113,18 @@ def test_parse_file(monkeypatch, tmp_path):
     data = import_tool.parse_file(str(f))
 
     assert data == sample
+
+
+def test_parse_file_zkb(monkeypatch, tmp_path):
+    sample = {'records': ['a'], 'summary': {}}
+
+    def fake_process_file(path):
+        print(json.dumps(sample))
+
+    monkeypatch.setattr(import_tool, 'zkb_parser', type('M', (), {'process_file': fake_process_file}))
+
+    f = tmp_path / 'dep.csv'
+    f.write_text('x')
+    data = import_tool.parse_file(str(f), institution='ZKB')
+
+    assert data == sample

--- a/tests/test_zkb_parser.py
+++ b/tests/test_zkb_parser.py
@@ -1,0 +1,29 @@
+import json
+from pathlib import Path
+import sys
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / 'DragonShield' / 'python_scripts'
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import zkb_parser
+
+
+def test_process_file(tmp_path, capsys):
+    csv_content = (
+        "Anlagekategorie;Anz./Nom.;Bezeichnung;Kurs;Währung\n"
+        "Aktien und Ähnliches;10;Sample AG CH12345678901;100;CHF\n"
+        "Konten;1000;Cash;1;CHF\n"
+    )
+    f = tmp_path / 'Depotauszug Mar 26 2025 ZKB.csv'
+    f.write_text(csv_content, encoding='utf-8')
+
+    code = zkb_parser.process_file(str(f))
+    captured = capsys.readouterr().out
+    data = json.loads(captured)
+
+    assert code == 0
+    assert data['summary']['total_data_rows_attempted'] == 2
+    assert data['summary']['cash_account_records'] == 1
+    assert data['summary']['security_holding_records'] == 1
+    assert data['records'][0]['record_type'] == 'security_holding'
+    assert data['records'][1]['record_type'] == 'cash_account'


### PR DESCRIPTION
## Summary
- parse ZKB depot statements via new `zkb_parser`
- dispatch parser in `import_tool` based on institution
- add unit tests and fixtures for the ZKB parser
- stub pandas/numpy for tests
- document change in CHANGELOG

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876b9cbb4b08323a4627a5833d351e6