### PR TITLE
Add Reference Data info icon

### DIFF
--- a/DragonShield/Views/DatabaseManagementView.swift
+++ b/DragonShield/Views/DatabaseManagementView.swift
@@ -85,10 +85,11 @@ struct DatabaseManagementView: View {
                 HStack(spacing: 4) {
                     Text("Reference Data")
                         .font(.system(size: 14, weight: .medium))
-                    Text("(i)")
+                    Image(systemName: "info.circle")
                         .font(.system(size: 12, weight: .bold))
                         .foregroundColor(.gray)
-                        .help(backupService.referenceTables.joined(separator: ", "))
+                        .help(backupService.referenceTables.map { "\u2022 \($0)" }
+                                .joined(separator: "\n"))
                 }
                 HStack(spacing: 12) {
                     Button(action: backupReferenceNow) {


### PR DESCRIPTION
## Summary
- swap Reference Data `(i)` text for `info.circle` icon
- show list of tables on hover

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'DragonShield')*

------
https://chatgpt.com/codex/tasks/task_e_6877ba9f0c808323a2fc240d23ecd600