### PR TITLE
Implement allocation slider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Display actual vs target asset allocation on a single slider in new AssetAllocationView
 - Fix seed data to include valor numbers in Instruments table
 - Replace instrument seed data with Consolidated_Instruments_V8.xlsx for updated test dataset
 - Expand seed dataset with full production reference data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 - Display actual vs target asset allocation on a single slider in new AssetClassAllocationView
 - Link Asset Allocation view from the sidebar navigation
+- Fix layout of Asset Allocation slider to match design
 - Fix seed data to include valor numbers in Instruments table
 - Replace instrument seed data with Consolidated_Instruments_V8.xlsx for updated test dataset
 - Expand seed dataset with full production reference data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Display actual vs target asset allocation on a single slider in new AssetClassAllocationView
+- Link Asset Allocation view from the sidebar navigation
 - Fix seed data to include valor numbers in Instruments table
 - Replace instrument seed data with Consolidated_Instruments_V8.xlsx for updated test dataset
 - Expand seed dataset with full production reference data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
-- Display actual vs target asset allocation on a single slider in new AssetAllocationView
+- Display actual vs target asset allocation on a single slider in new AssetClassAllocationView
 - Fix seed data to include valor numbers in Instruments table
 - Replace instrument seed data with Consolidated_Instruments_V8.xlsx for updated test dataset
 - Expand seed dataset with full production reference data

--- a/DragonShield/Views/AssetAllocationView.swift
+++ b/DragonShield/Views/AssetAllocationView.swift
@@ -1,0 +1,109 @@
+// DragonShield/Views/AssetAllocationView.swift
+// MARK: - Version 1.0
+// MARK: - History
+// - 1.0: Display actual vs target allocation on single slider.
+
+import SwiftUI
+
+struct AllocationMarker: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.move(to: CGPoint(x: rect.midX, y: rect.minY))
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
+        path.closeSubpath()
+        return path
+    }
+}
+
+struct AllocationRow: View {
+    let item: AssetAllocationVarianceItem
+    let portfolioValue: Double
+
+    private var deviation: Double { abs(item.currentPercent - item.targetPercent) }
+
+    private var deviationColor: Color {
+        switch deviation {
+        case ..<5: return .success
+        case 5..<15: return .warning
+        default: return .error
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(item.assetClassName)
+                .font(.headline)
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(Color.gray.opacity(0.2))
+                        .frame(height: 8)
+                    Capsule()
+                        .fill(Color.blue.opacity(0.4))
+                        .frame(width: geo.size.width * CGFloat(item.targetPercent/100), height: 8)
+                    Capsule()
+                        .fill(Color.gray.opacity(0.6))
+                        .frame(width: geo.size.width * CGFloat(item.currentPercent/100), height: 8)
+                    if deviation > 0 {
+                        let start = min(item.currentPercent, item.targetPercent)
+                        let width = abs(item.currentPercent - item.targetPercent)
+                        Capsule()
+                            .fill(deviationColor.opacity(0.5))
+                            .frame(width: geo.size.width * CGFloat(width/100), height: 8)
+                            .offset(x: geo.size.width * CGFloat(start/100))
+                    }
+                    AllocationMarker()
+                        .fill(Color.blue)
+                        .frame(width: 8, height: 8)
+                        .offset(x: geo.size.width * CGFloat(item.targetPercent/100) - 4, y: -4)
+                    AllocationMarker()
+                        .fill(Color.gray)
+                        .frame(width: 8, height: 8)
+                        .offset(x: geo.size.width * CGFloat(item.currentPercent/100) - 4, y: 4)
+                }
+            }
+            .frame(height: 16)
+            HStack {
+                Text(String(format: "T: %.0f%% / %.1f kCHF", item.targetPercent, item.targetPercent/100 * portfolioValue / 1000))
+                Spacer()
+                Text(String(format: "A: %.0f%% / %.1f kCHF", item.currentPercent, item.currentValue / 1000))
+            }
+            .font(.caption)
+            .foregroundColor(deviationColor)
+        }
+        .padding(.vertical, 8)
+    }
+}
+
+struct AssetAllocationView: View {
+    @EnvironmentObject var dbManager: DatabaseManager
+    @State private var items: [AssetAllocationVarianceItem] = []
+    @State private var portfolioValue: Double = 0
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            ForEach(items) { item in
+                AllocationRow(item: item, portfolioValue: portfolioValue)
+            }
+        }
+        .padding()
+        .onAppear(perform: loadData)
+    }
+
+    private func loadData() {
+        let result = dbManager.fetchAssetAllocationVariance()
+        items = result.items
+        portfolioValue = result.portfolioValue
+    }
+}
+
+#if DEBUG
+struct AssetAllocationView_Previews: PreviewProvider {
+    static var previews: some View {
+        AssetAllocationView()
+            .environmentObject(DatabaseManager())
+    }
+}
+#endif
+

--- a/DragonShield/Views/AssetClassAllocationView.swift
+++ b/DragonShield/Views/AssetClassAllocationView.swift
@@ -1,4 +1,4 @@
-// DragonShield/Views/AssetAllocationView.swift
+// DragonShield/Views/AssetClassAllocationView.swift
 // MARK: - Version 1.0
 // MARK: - History
 // - 1.0: Display actual vs target allocation on single slider.
@@ -76,7 +76,7 @@ struct AllocationRow: View {
     }
 }
 
-struct AssetAllocationView: View {
+struct AssetClassAllocationView: View {
     @EnvironmentObject var dbManager: DatabaseManager
     @State private var items: [AssetAllocationVarianceItem] = []
     @State private var portfolioValue: Double = 0
@@ -99,9 +99,9 @@ struct AssetAllocationView: View {
 }
 
 #if DEBUG
-struct AssetAllocationView_Previews: PreviewProvider {
+struct AssetClassAllocationView_Previews: PreviewProvider {
     static var previews: some View {
-        AssetAllocationView()
+        AssetClassAllocationView()
             .environmentObject(DatabaseManager())
     }
 }

--- a/DragonShield/Views/AssetClassAllocationView.swift
+++ b/DragonShield/Views/AssetClassAllocationView.swift
@@ -30,47 +30,72 @@ struct AllocationRow: View {
         }
     }
 
+    private var targetValue: Double { (item.targetPercent / 100) * portfolioValue }
+    private var targetLabel: String {
+        String(format: "T: %.0f%% / %.1f kCHF", item.targetPercent, targetValue / 1000)
+    }
+    private var actualLabel: String {
+        String(format: "A: %.0f%% / %.1f kCHF", item.currentPercent, item.currentValue / 1000)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             Text(item.assetClassName)
                 .font(.headline)
             GeometryReader { geo in
+                let width = geo.size.width
+                let targetX = width * CGFloat(item.targetPercent / 100)
+                let actualX = width * CGFloat(item.currentPercent / 100)
+                let startX = min(targetX, actualX)
+                let overlayWidth = abs(targetX - actualX)
+
                 ZStack(alignment: .leading) {
                     Capsule()
                         .fill(Color.gray.opacity(0.2))
                         .frame(height: 8)
+
                     Capsule()
                         .fill(Color.blue.opacity(0.4))
-                        .frame(width: geo.size.width * CGFloat(item.targetPercent/100), height: 8)
+                        .frame(width: targetX, height: 8)
+
                     Capsule()
                         .fill(Color.gray.opacity(0.6))
-                        .frame(width: geo.size.width * CGFloat(item.currentPercent/100), height: 8)
-                    if deviation > 0 {
-                        let start = min(item.currentPercent, item.targetPercent)
-                        let width = abs(item.currentPercent - item.targetPercent)
+                        .frame(width: actualX, height: 8)
+
+                    if overlayWidth > 0 {
                         Capsule()
                             .fill(deviationColor.opacity(0.5))
-                            .frame(width: geo.size.width * CGFloat(width/100), height: 8)
-                            .offset(x: geo.size.width * CGFloat(start/100))
+                            .frame(width: overlayWidth, height: 8)
+                            .offset(x: startX)
+                            .zIndex(1)
                     }
+
                     AllocationMarker()
                         .fill(Color.blue)
-                        .frame(width: 8, height: 8)
-                        .offset(x: geo.size.width * CGFloat(item.targetPercent/100) - 4, y: -4)
+                        .frame(width: 10, height: 10)
+                        .offset(x: targetX - 5, y: -6)
+                        .zIndex(2)
+
                     AllocationMarker()
                         .fill(Color.gray)
-                        .frame(width: 8, height: 8)
-                        .offset(x: geo.size.width * CGFloat(item.currentPercent/100) - 4, y: 4)
+                        .frame(width: 10, height: 10)
+                        .offset(x: actualX - 5, y: 6)
+                        .zIndex(2)
+
+                    Text(targetLabel)
+                        .font(.caption2)
+                        .foregroundColor(.primary)
+                        .offset(x: targetX + 6, y: -14)
+                        .zIndex(2)
+
+                    Text(actualLabel)
+                        .font(.caption2)
+                        .foregroundColor(.primary)
+                        .offset(x: actualX + 6, y: 10)
+                        .zIndex(2)
                 }
             }
-            .frame(height: 16)
-            HStack {
-                Text(String(format: "T: %.0f%% / %.1f kCHF", item.targetPercent, item.targetPercent/100 * portfolioValue / 1000))
-                Spacer()
-                Text(String(format: "A: %.0f%% / %.1f kCHF", item.currentPercent, item.currentValue / 1000))
-            }
-            .font(.caption)
-            .foregroundColor(deviationColor)
+            .frame(height: 24)
         }
         .padding(.vertical, 8)
     }

--- a/DragonShield/Views/SidebarView.swift
+++ b/DragonShield/Views/SidebarView.swift
@@ -31,6 +31,9 @@ struct SidebarView: View {
                 NavigationLink(destination: PositionsView()) {
                     Label("Positions", systemImage: "tablecells")
                 }
+                NavigationLink(destination: AssetClassAllocationView()) {
+                    Label("Asset Allocation", systemImage: "slider.horizontal.3")
+                }
             }
             
             // MARK: - Maintenance Functions Section


### PR DESCRIPTION
## Summary
- add AssetAllocationView to show target vs actual on one slider
- log the new feature in the changelog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'DragonShield')*

------
https://chatgpt.com/codex/tasks/task_e_6877ceb8dcb48323b5d6532b026e4870