### PR TITLE
Add Asset Allocation view with deviation slider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Enforce minimum column widths in Positions table to prevent overlap
 - Improve Position form with labeled numeric fields and aligned date pickers
 - Refine Position form typography and enforce minimum sheet size
+- Add Asset Allocation view showing target vs actual with deviation slider
 - Add toggle for Direct Real Estate with CHF amount and persist settings
 - Persist target allocation percentages to new TargetAllocation table
 - Include FX History table in reference data backups

--- a/DragonShield/ViewModels/AssetAllocationViewModel.swift
+++ b/DragonShield/ViewModels/AssetAllocationViewModel.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+struct AllocationDisplayItem: Identifiable {
+    let id: String
+    let assetClassName: String
+    var targetPercent: Double
+    var currentPercent: Double
+    var currentValueCHF: Double
+}
+
+final class AssetAllocationViewModel: ObservableObject {
+    @Published var items: [AllocationDisplayItem] = []
+    var portfolioValue: Double = 0
+
+    private var db: DatabaseManager?
+    private var classIdMap: [String: Int] = [:]
+
+    let currencyFormatter: NumberFormatter = {
+        let f = NumberFormatter()
+        f.numberStyle = .currency
+        f.currencyCode = "CHF"
+        f.maximumFractionDigits = 0
+        return f
+    }()
+
+    func load(using dbManager: DatabaseManager) {
+        self.db = dbManager
+        let result = dbManager.fetchAssetAllocationVariance()
+        portfolioValue = result.portfolioValue
+        items = result.items.map { AllocationDisplayItem(id: $0.id,
+                                                         assetClassName: $0.assetClassName,
+                                                         targetPercent: $0.targetPercent,
+                                                         currentPercent: $0.currentPercent,
+                                                         currentValueCHF: $0.currentValue) }
+        classIdMap = Dictionary(uniqueKeysWithValues: dbManager.fetchAssetClassesDetailed().map { ($0.name, $0.id) })
+    }
+
+    func updateTarget(for item: AllocationDisplayItem, to newValue: Double) {
+        guard let db, let id = classIdMap[item.assetClassName] else { return }
+        if let index = items.firstIndex(where: { $0.id == item.id }) {
+            items[index].targetPercent = newValue
+        }
+        db.upsertClassTarget(portfolioId: 1, classId: id, percent: newValue)
+    }
+
+    func deviationColor(for item: AllocationDisplayItem) -> Color {
+        let diff = abs(item.currentPercent - item.targetPercent)
+        switch diff {
+        case 0..<5: return .success
+        case 5..<15: return .warning
+        default: return .error
+        }
+    }
+}
+

--- a/DragonShield/Views/AssetAllocationView.swift
+++ b/DragonShield/Views/AssetAllocationView.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+
+struct AssetAllocationView: View {
+    @EnvironmentObject var dbManager: DatabaseManager
+    @StateObject private var viewModel = AssetAllocationViewModel()
+
+    var body: some View {
+        List {
+            ForEach(viewModel.items) { item in
+                AllocationRow(item: item,
+                              targetChanged: { newValue in
+                                  viewModel.updateTarget(for: item, to: newValue)
+                              },
+                              currencyFormatter: viewModel.currencyFormatter,
+                              deviationColor: viewModel.deviationColor(for: item),
+                              portfolioValue: viewModel.portfolioValue)
+            }
+        }
+        .listStyle(.plain)
+        .navigationTitle("Asset Allocation")
+        .onAppear { viewModel.load(using: dbManager) }
+    }
+}
+
+private struct AllocationRow: View {
+    var item: AllocationDisplayItem
+    var targetChanged: (Double) -> Void
+    var currencyFormatter: NumberFormatter
+    var deviationColor: Color
+    var portfolioValue: Double
+
+    @State private var target: Double = 0
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(item.assetClassName)
+                Spacer()
+            }
+            .font(.subheadline)
+            SliderWithMarkers(current: item.currentPercent,
+                              target: $target,
+                              deviationColor: deviationColor)
+                .frame(height: 24)
+                .onChange(of: target) { newValue in
+                    targetChanged(newValue)
+                }
+            HStack {
+                Text(labelText(prefix: "T", pct: target, value: portfolioValue * target / 100))
+                    .font(.caption)
+                Spacer()
+                Text(labelText(prefix: "A", pct: item.currentPercent, value: item.currentValueCHF))
+                    .font(.caption)
+            }
+        }
+        .onAppear { target = item.targetPercent }
+    }
+
+    private func labelText(prefix: String, pct: Double, value: Double) -> String {
+        let valueString = currencyFormatter.string(from: NSNumber(value: value)) ?? ""
+        return String(format: "%@: %.0f%% / %@", prefix, pct, valueString)
+    }
+}
+
+private struct SliderWithMarkers: View {
+    var current: Double
+    @Binding var target: Double
+    var deviationColor: Color
+
+    var body: some View {
+        GeometryReader { geo in
+            let width = geo.size.width
+            ZStack(alignment: .leading) {
+                Capsule().fill(Color.gray.opacity(0.2)).frame(height: 6)
+                Capsule()
+                    .fill(deviationColor.opacity(0.4))
+                    .frame(width: width * CGFloat(abs(current - target) / 100), height: 6)
+                    .offset(x: width * CGFloat(min(current, target) / 100))
+                Capsule()
+                    .fill(Color.gray.opacity(0.5))
+                    .frame(width: width * CGFloat(current / 100), height: 6)
+                Triangle()
+                    .fill(Color.blue)
+                    .frame(width: 10, height: 6)
+                    .offset(x: width * CGFloat(target / 100) - 5, y: -4)
+                Triangle()
+                    .rotation(Angle(degrees: 180))
+                    .fill(Color.gray)
+                    .frame(width: 10, height: 6)
+                    .offset(x: width * CGFloat(current / 100) - 5, y: 6)
+            }
+            .frame(height: 6)
+            .gesture(DragGesture(minimumDistance: 0).onChanged { value in
+                let pct = min(max(0, value.location.x / width * 100), 100)
+                target = pct
+            })
+        }
+    }
+}
+
+private struct Triangle: Shape {
+    func path(in rect: CGRect) -> Path {
+        var p = Path()
+        p.move(to: CGPoint(x: rect.midX, y: rect.minY))
+        p.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+        p.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
+        p.closeSubpath()
+        return p
+    }
+}
+
+struct AssetAllocationView_Previews: PreviewProvider {
+    static var previews: some View {
+        AssetAllocationView()
+            .environmentObject(DatabaseManager())
+    }
+}
+

--- a/DragonShield/Views/SidebarView.swift
+++ b/DragonShield/Views/SidebarView.swift
@@ -31,6 +31,10 @@ struct SidebarView: View {
                 NavigationLink(destination: PositionsView()) {
                     Label("Positions", systemImage: "tablecells")
                 }
+
+                NavigationLink(destination: AssetAllocationView()) {
+                    Label("Asset Allocation", systemImage: "slider.horizontal.3")
+                }
             }
             
             // MARK: - Maintenance Functions Section


### PR DESCRIPTION
## Summary
- create `AssetAllocationView` showing target vs actual values
- implement `AssetAllocationViewModel` to load allocation data and persist target changes
- link new view from sidebar
- document the feature in the changelog

## Testing
- `pytest -q` *(fails: pysqlcipher3 and pandas unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6877ff3b59c88323b57b03c506ffa41a