### PR TITLE
Refine asset allocation bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -264,3 +264,4 @@ All notable changes to this project will be documented in this file.
 - Resolve compile warnings in PositionsView and ExchangeRates helpers
 - Rename "Instrument Updated" label to "Last Update" in Position form
 - Remove obsolete Value Date field from Position form
+- Refine Asset Allocation rows with uniform bars and vibrant deviation colors

--- a/DragonShield/Views/AssetAllocationView.swift
+++ b/DragonShield/Views/AssetAllocationView.swift
@@ -36,35 +36,32 @@ private struct AllocationRow: View {
     var portfolioValue: Double
 
     @State private var target: Double = 0
+    private let barWidth: CGFloat = 250
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack {
-                Text(item.assetClassName)
-                Spacer()
-            }
-            .font(.subheadline)
+        HStack(alignment: .center, spacing: 8) {
+            Text(item.assetClassName)
+            Text(variationText())
+                .font(.caption)
+            Spacer()
             SliderWithMarkers(current: item.currentPercent,
                               target: $target,
                               deviationColor: deviationColor)
-                .frame(height: 24)
+                .frame(width: barWidth, height: 24)
                 .onChange(of: target) { newValue in
                     targetChanged(newValue)
                 }
-            HStack {
-                Text(labelText(prefix: "T", pct: target, value: portfolioValue * target / 100))
-                    .font(.caption)
-                Spacer()
-                Text(labelText(prefix: "A", pct: item.currentPercent, value: item.currentValueCHF))
-                    .font(.caption)
-            }
         }
+        .font(.subheadline)
         .onAppear { target = item.targetPercent }
     }
 
-    private func labelText(prefix: String, pct: Double, value: Double) -> String {
-        let valueString = currencyFormatter.string(from: NSNumber(value: value)) ?? ""
-        return String(format: "%@: %.0f%% / %@", prefix, pct, valueString)
+    private func variationText() -> String {
+        let pctDiff = item.currentPercent - item.targetPercent
+        let valueDiff = item.currentValueCHF - (portfolioValue * item.targetPercent / 100)
+        let pctString = String(format: "%+.1f%%", pctDiff)
+        let valString = String(format: "%+.1f kCHF", valueDiff / 1000)
+        return "\(pctString) / \(valString)"
     }
 }
 
@@ -73,29 +70,37 @@ private struct SliderWithMarkers: View {
     @Binding var target: Double
     var deviationColor: Color
 
+    private let trackHeight: CGFloat = 6
+    private let markerSize: CGFloat = 16
+
     var body: some View {
         GeometryReader { geo in
             let width = geo.size.width
+            let trackTop = (geo.size.height - trackHeight) / 2
             ZStack(alignment: .leading) {
-                Capsule().fill(Color.gray.opacity(0.2)).frame(height: 6)
                 Capsule()
-                    .fill(deviationColor.opacity(0.4))
-                    .frame(width: width * CGFloat(abs(current - target) / 100), height: 6)
-                    .offset(x: width * CGFloat(min(current, target) / 100))
+                    .fill(Color.gray.opacity(0.2))
+                    .frame(height: trackHeight)
+                    .offset(y: trackTop)
                 Capsule()
                     .fill(Color.gray.opacity(0.5))
-                    .frame(width: width * CGFloat(current / 100), height: 6)
+                    .frame(width: width * CGFloat(current / 100), height: trackHeight)
+                    .offset(y: trackTop)
+                Capsule()
+                    .fill(deviationColor)
+                    .frame(width: width * CGFloat(abs(current - target) / 100), height: trackHeight)
+                    .offset(x: width * CGFloat(min(current, target) / 100), y: trackTop)
                 Triangle()
                     .fill(Color.blue)
-                    .frame(width: 10, height: 6)
-                    .offset(x: width * CGFloat(target / 100) - 5, y: -4)
+                    .frame(width: markerSize, height: markerSize)
+                    .offset(x: width * CGFloat(target / 100) - markerSize / 2, y: trackTop - markerSize)
                 Triangle()
                     .rotation(Angle(degrees: 180))
                     .fill(Color.gray)
-                    .frame(width: 10, height: 6)
-                    .offset(x: width * CGFloat(current / 100) - 5, y: 6)
+                    .frame(width: markerSize, height: markerSize)
+                    .offset(x: width * CGFloat(current / 100) - markerSize / 2, y: trackTop + trackHeight)
             }
-            .frame(height: 6)
+            .contentShape(Rectangle())
             .gesture(DragGesture(minimumDistance: 0).onChanged { value in
                 let pct = min(max(0, value.location.x / width * 100), 100)
                 target = pct

--- a/DragonShield/helpers/Color+Palette.swift
+++ b/DragonShield/helpers/Color+Palette.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 extension Color {
-    static let success = Color(red: 30/255, green: 142/255, blue: 62/255)
-    static let warning = Color(red: 224/255, green: 168/255, blue: 0/255)
-    static let error = Color(red: 211/255, green: 47/255, blue: 47/255)
+    static let success = Color(red: 40/255, green: 199/255, blue: 111/255)
+    static let warning = Color(red: 255/255, green: 159/255, blue: 67/255)
+    static let error = Color(red: 234/255, green: 84/255, blue: 85/255)
 }


### PR DESCRIPTION
## Summary
- redesign allocation row layout with uniform bar widths and variation text
- enlarge triangle markers and show vibrant deviation colors
- adjust palette colors for success, warning, error
- document UI improvement in changelog

## Testing
- `pytest -q` *(fails: Could not find required packages)*

------
https://chatgpt.com/codex/tasks/task_e_687884356c288323ba34188f420647da