### PR TITLE
Enable CHF mode for allocation targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Add risk concentration dashboard tile showing top 5 groups by value
 - Support asset class grouping and display CHF values in Risk Buckets tile
 - Add valor number field to instruments with database and UI support
+- Allow editing allocation targets in CHF or percent with per-row mode toggle
 - Enforce minimum column widths in Positions table to prevent overlap
 - Improve Position form with labeled numeric fields and aligned date pickers
 - Add Allocation Targets table view with hierarchical editing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Support asset class grouping and display CHF values in Risk Buckets tile
 - Add valor number field to instruments with database and UI support
 - Allow editing allocation targets in CHF or percent with per-row mode toggle
+- Split Allocation Targets table into Target %/CHF columns with totals row warning
 - Enforce minimum column widths in Positions table to prevent overlap
 - Improve Position form with labeled numeric fields and aligned date pickers
 - Add Allocation Targets table view with hierarchical editing

--- a/DragonShield/DatabaseManager+PositionReports.swift
+++ b/DragonShield/DatabaseManager+PositionReports.swift
@@ -17,6 +17,7 @@ struct PositionReportData: Identifiable {
         var instrumentCountry: String?
         var instrumentSector: String?
         var assetClass: String?
+        var assetSubClass: String?
         var quantity: Double
         var purchasePrice: Double?
         var currentPrice: Double?
@@ -33,7 +34,7 @@ extension DatabaseManager {
         let query = """
             SELECT pr.position_id, pr.import_session_id, a.account_name,
                    ins.institution_name, i.instrument_name, i.currency,
-                   i.country_code, i.sector, ac.class_name,
+                   i.country_code, i.sector, ac.class_name, asc.sub_class_name,
                    pr.quantity, pr.purchase_price, pr.current_price,
                    pr.instrument_updated_at,
                    pr.notes,
@@ -63,23 +64,24 @@ extension DatabaseManager {
                 let instrumentCountry = sqlite3_column_text(statement, 6).map { String(cString: $0) }
                 let instrumentSector = sqlite3_column_text(statement, 7).map { String(cString: $0) }
                 let assetClass = sqlite3_column_text(statement, 8).map { String(cString: $0) }
-                let quantity = sqlite3_column_double(statement, 9)
+                let assetSubClass = sqlite3_column_text(statement, 9).map { String(cString: $0) }
+                let quantity = sqlite3_column_double(statement, 10)
                 var purchasePrice: Double?
-                if sqlite3_column_type(statement, 10) != SQLITE_NULL {
-                    purchasePrice = sqlite3_column_double(statement, 10)
+                if sqlite3_column_type(statement, 11) != SQLITE_NULL {
+                    purchasePrice = sqlite3_column_double(statement, 11)
                 }
                 var currentPrice: Double?
-                if sqlite3_column_type(statement, 11) != SQLITE_NULL {
-                    currentPrice = sqlite3_column_double(statement, 11)
+                if sqlite3_column_type(statement, 12) != SQLITE_NULL {
+                    currentPrice = sqlite3_column_double(statement, 12)
                 }
                 var instrumentUpdatedAt: Date?
-                if sqlite3_column_type(statement, 12) != SQLITE_NULL {
-                    let str = String(cString: sqlite3_column_text(statement, 12))
+                if sqlite3_column_type(statement, 13) != SQLITE_NULL {
+                    let str = String(cString: sqlite3_column_text(statement, 13))
                     instrumentUpdatedAt = DateFormatter.iso8601DateOnly.date(from: str)
                 }
-                let notes: String? = sqlite3_column_text(statement, 13).map { String(cString: $0) }
-                let reportDateStr = String(cString: sqlite3_column_text(statement, 14))
-                let uploadedAtStr = String(cString: sqlite3_column_text(statement, 15))
+                let notes: String? = sqlite3_column_text(statement, 14).map { String(cString: $0) }
+                let reportDateStr = String(cString: sqlite3_column_text(statement, 15))
+                let uploadedAtStr = String(cString: sqlite3_column_text(statement, 16))
                 let reportDate = DateFormatter.iso8601DateOnly.date(from: reportDateStr) ?? Date()
                 let uploadedAt = DateFormatter.iso8601DateTime.date(from: uploadedAtStr) ?? Date()
                 reports.append(PositionReportData(
@@ -92,6 +94,7 @@ extension DatabaseManager {
                     instrumentCountry: instrumentCountry,
                     instrumentSector: instrumentSector,
                     assetClass: assetClass,
+                    assetSubClass: assetSubClass,
                     quantity: quantity,
                     purchasePrice: purchasePrice,
                     currentPrice: currentPrice,


### PR DESCRIPTION
## Summary
- allow editing allocation targets in CHF or percent
- persist mode choice per row in UserDefaults
- store CHF amounts in TargetAllocation table
- expose subclass name in `fetchPositionReports`
- compute actual CHF totals from positions

## Testing
- `swiftc -o /tmp/test DragonShield/Views/AllocationTargetsTableView.swift` *(fails: no such module 'SwiftUI')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'DragonShield')*

------
https://chatgpt.com/codex/tasks/task_e_6879085602588323a0de7b8057e994b5