### PR TITLE
Add spec for AllocationTargetsTableView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,3 +277,4 @@ All notable changes to this project will be documented in this file.
 - Increase slider marker size and align allocation bars to the right edge
 - Resolve onChange deprecation warning in AllocationTargetsTableView
 - Document requirements for Allocation Targets table sorting indicators and zero allocation grouping
+- Document Delta % column sorting and revised zero allocation criteria in Allocation Targets spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - Refine AllocationTargetsTableView formatting and persistence
 - Refine AllocationTargetsTableView editing and ordering behaviour
 - Add sortable Target % and Actual % columns with default Actual % ordering in AllocationTargetsTableView
+- Always show sort arrows and group zero-allocation rows at reduced opacity in AllocationTargetsTableView
 - Add Asset Allocation view showing target vs actual with deviation slider and summary table
 - Compute asset class totals from subclass values to show CHF amounts next to sliders
 - Fix compile error in Asset Allocation view model by specifying dictionary types

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -278,3 +278,4 @@ All notable changes to this project will be documented in this file.
 - Resolve onChange deprecation warning in AllocationTargetsTableView
 - Document requirements for Allocation Targets table sorting indicators and zero allocation grouping
 - Document Delta % column sorting and revised zero allocation criteria in Allocation Targets spec
+- Clarify macOS Table API assumptions and detail zero-allocation row handling in Allocation Targets spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -276,3 +276,4 @@ All notable changes to this project will be documented in this file.
 - Refine Asset Allocation rows with uniform bars and vibrant deviation colors
 - Increase slider marker size and align allocation bars to the right edge
 - Resolve onChange deprecation warning in AllocationTargetsTableView
+- Document requirements for Allocation Targets table sorting indicators and zero allocation grouping

--- a/DragonShield/docs/UX_UI_concept/allocation_targets_table_spec.md
+++ b/DragonShield/docs/UX_UI_concept/allocation_targets_table_spec.md
@@ -1,10 +1,16 @@
 # Allocation Targets Table View Refinement Specification
 
 ## Purpose
-Provide detailed requirements for improving the `AllocationTargetsTableView` in the macOS app so users can better understand sorting behaviour and quickly identify zero allocation assets. Each asset row exposes three percentage values: `targetPct`, `actualPct` and `deltaPct` (Δ %).
+Provide detailed requirements for improving the `AllocationTargetsTableView` in the macOS app so users can better understand sorting behaviour and quickly identify zero allocation assets. Each asset row exposes three percentage values: `targetPct`, `actualPct` and `deltaPct` (**Delta %**).
+
+## Assumptions & Context
+- Built with the SwiftUI **Table** API on macOS 13 or later.
+- Sorting uses a single `KeyPathComparator` stored in a `@State` property so only one column is sortable at a time.
+- Asset rows expose `targetPct`, `actualPct` and `deltaPct` percentage fields.
+- *Zero allocation* rows have all three percentages set to `0`.
 
 ## Sorting Indicators
-- The **Target %**, **Actual %** and **Δ %** column headers must always display a sort arrow.
+- The **Target %**, **Actual %** and **Delta %** (Δ) column headers must always display a sort arrow.
 - When a column is the active sort key, show a **filled arrow** in the system accent colour.
 - When a column is not active, show an **outlined arrow** coloured grey.
 - The arrow direction reflects ascending or descending order of the active comparator.

--- a/DragonShield/docs/UX_UI_concept/allocation_targets_table_spec.md
+++ b/DragonShield/docs/UX_UI_concept/allocation_targets_table_spec.md
@@ -1,0 +1,29 @@
+# Allocation Targets Table View Refinement Specification
+
+## Purpose
+Provide detailed requirements for improving the `AllocationTargetsTableView` in the macOS app so users can better understand sorting behaviour and quickly identify zero allocation assets.
+
+## Sorting Indicators
+- Both the **Target %** and **Actual %** column headers must always display a sort arrow.
+- When a column is the active sort key, show a **filled arrow** in the system accent colour.
+- When a column is not active, show an **outlined arrow** coloured grey.
+- The arrow direction reflects ascending or descending order of the active comparator.
+- Sorting remains single-column only; clicking a header toggles its ascending/descending state and resets the other column to inactive.
+
+## Row Grouping
+- Assets with both `targetPct` and `actualPct` equal to `0` are considered *zero‑allocation rows*.
+- Display all non‑zero rows first in the table.
+- Insert a header row labelled **"Zero Allocation"** before listing zero‑allocation rows.
+- Render zero‑allocation rows with reduced opacity so they appear visually distinct but remain legible.
+
+## Accessibility
+- Custom table headers must combine the text label and arrow icon into one accessible element.
+- VoiceOver should announce the column title and current sort order when focus lands on the header button.
+
+## Implementation Notes
+- Use `TableColumn` with a custom header view that stacks `Text(title)` and `Image(systemName: ...)`.
+- SF Symbols: `arrowtriangle.up.fill` / `arrowtriangle.down.fill` for the active column; `arrowtriangle.up` / `arrowtriangle.down` for inactive.
+- Determine the active sort column by comparing the stored `KeyPathComparator` with each column’s key path.
+- Split the assets array into `nonZeroAssets` and `zeroAssets` before populating the `List` or `OutlineGroup`.
+- Apply `opacity(0.6)` (approximate) to the zero‑allocation rows.
+

--- a/DragonShield/docs/UX_UI_concept/allocation_targets_table_spec.md
+++ b/DragonShield/docs/UX_UI_concept/allocation_targets_table_spec.md
@@ -1,17 +1,17 @@
 # Allocation Targets Table View Refinement Specification
 
 ## Purpose
-Provide detailed requirements for improving the `AllocationTargetsTableView` in the macOS app so users can better understand sorting behaviour and quickly identify zero allocation assets.
+Provide detailed requirements for improving the `AllocationTargetsTableView` in the macOS app so users can better understand sorting behaviour and quickly identify zero allocation assets. Each asset row exposes three percentage values: `targetPct`, `actualPct` and `deltaPct` (Δ %).
 
 ## Sorting Indicators
-- Both the **Target %** and **Actual %** column headers must always display a sort arrow.
+- The **Target %**, **Actual %** and **Δ %** column headers must always display a sort arrow.
 - When a column is the active sort key, show a **filled arrow** in the system accent colour.
 - When a column is not active, show an **outlined arrow** coloured grey.
 - The arrow direction reflects ascending or descending order of the active comparator.
-- Sorting remains single-column only; clicking a header toggles its ascending/descending state and resets the other column to inactive.
+- Sorting remains single-column only; clicking a header toggles its ascending/descending state and resets the other columns to inactive.
 
 ## Row Grouping
-- Assets with both `targetPct` and `actualPct` equal to `0` are considered *zero‑allocation rows*.
+- Assets with `targetPct`, `actualPct` and `deltaPct` all equal to `0` are considered *zero‑allocation rows*.
 - Display all non‑zero rows first in the table.
 - Insert a header row labelled **"Zero Allocation"** before listing zero‑allocation rows.
 - Render zero‑allocation rows with reduced opacity so they appear visually distinct but remain legible.
@@ -21,9 +21,9 @@ Provide detailed requirements for improving the `AllocationTargetsTableView` in 
 - VoiceOver should announce the column title and current sort order when focus lands on the header button.
 
 ## Implementation Notes
-- Use `TableColumn` with a custom header view that stacks `Text(title)` and `Image(systemName: ...)`.
+- Use `TableColumn` with a custom header view that stacks `Text(title)` and `Image(systemName: ...)` for each sortable column.
 - SF Symbols: `arrowtriangle.up.fill` / `arrowtriangle.down.fill` for the active column; `arrowtriangle.up` / `arrowtriangle.down` for inactive.
-- Determine the active sort column by comparing the stored `KeyPathComparator` with each column’s key path.
+- Determine the active sort column by comparing the stored `KeyPathComparator` with the `targetPct`, `actualPct` or `deltaPct` key path.
 - Split the assets array into `nonZeroAssets` and `zeroAssets` before populating the `List` or `OutlineGroup`.
 - Apply `opacity(0.6)` (approximate) to the zero‑allocation rows.
 


### PR DESCRIPTION
## Summary
- document a detailed specification for refining AllocationTargetsTableView
- note sorting indicator behaviour and zero-allocation grouping in the changelog

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pysqlcipher3)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'DragonShield')*

------
https://chatgpt.com/codex/tasks/task_e_687957f91f7c8323ac0c7f7b34ff0e27