### PR TITLE
feat: highlight active allocation rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -285,3 +285,4 @@ All notable changes to this project will be documented in this file.
 - Display AssetSubClass actual values and calculate targets relative to parent classes
 - Fix crash when closing Asset Class due to stale index paths in AllocationTargetsTableView
 - Group Allocation Targets table into Active and Inactive sections with orange highlight for subclass-only activity
+- Show amber background instead of red when only subclasses have targets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -284,3 +284,4 @@ All notable changes to this project will be documented in this file.
 - Persist AssetSubClass target edits immediately
 - Display AssetSubClass actual values and calculate targets relative to parent classes
 - Fix crash when closing Asset Class due to stale index paths in AllocationTargetsTableView
+- Group Allocation Targets table into Active and Inactive sections with orange highlight for subclass-only activity

--- a/DragonShield/Views/AllocationTargetsTableView.swift
+++ b/DragonShield/Views/AllocationTargetsTableView.swift
@@ -90,9 +90,9 @@ final class AllocationTargetsTableViewModel: ObservableObject {
 
     func sortAssets() {
         assets.sort { lhs, rhs in
-            let lhsZero = abs(lhs.targetPct) < 0.0001 && abs(lhs.targetChf) < 0.01
-            let rhsZero = abs(rhs.targetPct) < 0.0001 && abs(rhs.targetChf) < 0.01
-            if lhsZero != rhsZero { return !lhsZero }
+            let lhsActive = isActive(lhs)
+            let rhsActive = isActive(rhs)
+            if lhsActive != rhsActive { return lhsActive && !rhsActive }
             let lhsVal: Double
             let rhsVal: Double
            switch sortColumn {
@@ -136,6 +136,46 @@ final class AllocationTargetsTableViewModel: ObservableObject {
         } else if asset.id.hasPrefix("sub-") {
             if let subId = Int(asset.id.dropFirst(4)), let parent = subToClass[subId] {
                 return invalidClassIds.contains("class-\(parent)")
+            }
+        }
+        return false
+    }
+
+    private func isZeroPct(_ value: Double) -> Bool { abs(value) < 0.0001 }
+    private func isZeroChf(_ value: Double) -> Bool { abs(value) < 0.01 }
+
+    func isActive(_ asset: AllocationAsset) -> Bool {
+        if !(isZeroPct(asset.targetPct) && isZeroChf(asset.targetChf) &&
+             isZeroPct(asset.actualPct) && isZeroChf(asset.actualChf)) {
+            return true
+        }
+        if let children = asset.children {
+            for child in children {
+                if !(isZeroPct(child.targetPct) && isZeroChf(child.targetChf) &&
+                      isZeroPct(child.actualPct) && isZeroChf(child.actualChf)) {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    private func parentHasSubActivity(_ asset: AllocationAsset) -> Bool {
+        guard asset.id.hasPrefix("class-"), let children = asset.children else { return false }
+        let assetZero = isZeroPct(asset.targetPct) && isZeroChf(asset.targetChf) &&
+            isZeroPct(asset.actualPct) && isZeroChf(asset.actualChf)
+        guard assetZero else { return false }
+        return children.contains { !(isZeroPct($0.targetPct) && isZeroChf($0.targetChf) &&
+                                     isZeroPct($0.actualPct) && isZeroChf($0.actualChf)) }
+    }
+
+    func rowNeedsOrange(_ asset: AllocationAsset) -> Bool {
+        if asset.id.hasPrefix("class-") {
+            return parentHasSubActivity(asset)
+        } else if asset.id.hasPrefix("sub-") {
+            if let subId = Int(asset.id.dropFirst(4)), let parent = subToClass[subId],
+               let idx = assets.firstIndex(where: { $0.id == "class-\(parent)" }) {
+                return parentHasSubActivity(assets[idx])
             }
         }
         return false
@@ -394,32 +434,25 @@ struct AllocationTargetsTableView: View {
         chfDrafts = Dictionary(uniqueKeysWithValues: viewModel.assets.map { ($0.id, formatChf($0.targetChf)) })
     }
 
-    private func isZeroAllocation(_ asset: AllocationAsset) -> Bool {
-        abs(asset.targetPct) < 0.0001 &&
-        abs(asset.actualPct) < 0.0001 &&
-        abs(asset.deviationPct) < 0.0001
+    private var activeAssets: [AllocationAsset] {
+        viewModel.assets.filter { viewModel.isActive($0) }
     }
 
-    private var nonZeroAssets: [AllocationAsset] {
-        viewModel.assets.filter { !isZeroAllocation($0) }
-    }
-
-    private var zeroAssets: [AllocationAsset] {
-        viewModel.assets.filter(isZeroAllocation)
+    private var inactiveAssets: [AllocationAsset] {
+        viewModel.assets.filter { !viewModel.isActive($0) }
     }
 
     var body: some View {
         List {
             headerRow
             totalsRow
-            OutlineGroup(nonZeroAssets, children: \.children) { asset in
+            OutlineGroup(activeAssets, children: \.children) { asset in
                 tableRow(for: asset)
             }
-            if !zeroAssets.isEmpty {
-                zeroHeader
-                OutlineGroup(zeroAssets, children: \.children) { asset in
+            if !inactiveAssets.isEmpty {
+                inactiveHeader
+                OutlineGroup(inactiveAssets, children: \.children) { asset in
                     tableRow(for: asset)
-                        .opacity(0.6)
                 }
             }
         }
@@ -497,9 +530,9 @@ struct AllocationTargetsTableView: View {
         .font(.subheadline)
     }
 
-    private var zeroHeader: some View {
+    private var inactiveHeader: some View {
         HStack(spacing: 0) {
-            Text("Zero Allocation")
+            Text("Inactive Assets")
                 .fontWeight(.semibold)
                 .frame(width: 200, alignment: .leading)
             Spacer()
@@ -613,7 +646,10 @@ struct AllocationTargetsTableView: View {
             }
         }
         .frame(height: 48)
-        .background(viewModel.rowHasWarning(asset) ? Color.paleRed : Color.clear)
+        .background(
+            viewModel.rowHasWarning(asset) ? Color.paleRed :
+                (viewModel.rowNeedsOrange(asset) ? Color.paleOrange : Color.white)
+        )
     }
 }
 

--- a/DragonShield/helpers/Color+Palette.swift
+++ b/DragonShield/helpers/Color+Palette.swift
@@ -6,4 +6,6 @@ extension Color {
     static let error = Color(red: 255/255, green: 59/255, blue: 48/255)
     /// Light red used to highlight validation warnings.
     static let paleRed = Color(red: 1.0, green: 236/255, blue: 236/255)
+    /// Light orange used to highlight subclass-only activity.
+    static let paleOrange = Color(red: 1.0, green: 244/255, blue: 229/255)
 }


### PR DESCRIPTION
## Summary
- group Allocation Targets by activity rather than zero values
- highlight subclass-only activity with a pale orange tint
- expose `Color.paleOrange` in palette
- document change in the changelog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6879dff11688832386273b7628dafdd0