### PR TITLE
Add allocation comparison charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Visualize target vs actual allocations with dual-ring donut chart and delta bar layout in Allocation Targets view
 - Fix seed data to include valor numbers in Instruments table
 - Replace instrument seed data with Consolidated_Instruments_V8.xlsx for updated test dataset
 - Expand seed dataset with full production reference data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 - Visualize target vs actual allocations with dual-ring donut chart and delta bar layout in Allocation Targets view
 - Fix compile error in allocation charts by importing Charts framework
+- Resolve build error by replacing onTapGesture with overlay gesture in donut chart
 - Fix seed data to include valor numbers in Instruments table
 - Replace instrument seed data with Consolidated_Instruments_V8.xlsx for updated test dataset
 - Expand seed dataset with full production reference data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Visualize target vs actual allocations with dual-ring donut chart and delta bar layout in Allocation Targets view
+- Fix compile error in allocation charts by importing Charts framework
 - Fix seed data to include valor numbers in Instruments table
 - Replace instrument seed data with Consolidated_Instruments_V8.xlsx for updated test dataset
 - Expand seed dataset with full production reference data

--- a/DragonShield/Views/AllocationTargetsTableView.swift
+++ b/DragonShield/Views/AllocationTargetsTableView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Charts
 
 enum AllocationInputMode: String {
     case percent


### PR DESCRIPTION
## Summary
- visualize target vs actual allocations with new donut chart and delta bars
- show the charts below AllocationTargets table

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6879fb808df88323a0e5a48722bc98a9