### PR TITLE
feat(ui): add collapsible sections and status details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -299,3 +299,4 @@ All notable changes to this project will be documented in this file.
 - Organize Target Asset Allocation view into collapsible sections with status details
 - Resolve Swift compile errors from invalid Unicode escapes in AllocationTargetsTableView
 - Pin Allocation Targets table at top with collapsible error and chart sections
+- Fix unmatched braces causing compile errors in AllocationTargetsTableView

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -296,3 +296,4 @@ All notable changes to this project will be documented in this file.
 - Show amber background instead of red when only subclasses have targets
 - Fix compile errors in AllocationTargetsTableView for totals visibility and system gray color
 - Fix compile error referencing NSColor.systemGray6 by using cross-platform fieldGray color
+- Organize Target Asset Allocation view into collapsible sections with status details

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -297,3 +297,4 @@ All notable changes to this project will be documented in this file.
 - Fix compile errors in AllocationTargetsTableView for totals visibility and system gray color
 - Fix compile error referencing NSColor.systemGray6 by using cross-platform fieldGray color
 - Organize Target Asset Allocation view into collapsible sections with status details
+- Resolve Swift compile errors from invalid Unicode escapes in AllocationTargetsTableView

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,3 +298,4 @@ All notable changes to this project will be documented in this file.
 - Fix compile error referencing NSColor.systemGray6 by using cross-platform fieldGray color
 - Organize Target Asset Allocation view into collapsible sections with status details
 - Resolve Swift compile errors from invalid Unicode escapes in AllocationTargetsTableView
+- Keep Allocation Targets table visible while charts are in collapsible sections

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,4 +298,4 @@ All notable changes to this project will be documented in this file.
 - Fix compile error referencing NSColor.systemGray6 by using cross-platform fieldGray color
 - Organize Target Asset Allocation view into collapsible sections with status details
 - Resolve Swift compile errors from invalid Unicode escapes in AllocationTargetsTableView
-- Keep Allocation Targets table visible while charts are in collapsible sections
+- Pin Allocation Targets table at top with collapsible error and chart sections

--- a/DragonShield/Views/AllocationTargetsTableView.swift
+++ b/DragonShield/Views/AllocationTargetsTableView.swift
@@ -395,7 +395,7 @@ struct AllocationTargetsTableView: View {
     @State private var chfDrafts: [String: String] = [:]
     @FocusState private var focusedChfField: String?
     @FocusState private var focusedPctField: String?
-    @State private var showTable = true
+    @State private var showDetails = true
     @State private var showDonut = true
     @State private var showDelta = true
 
@@ -496,31 +496,36 @@ struct AllocationTargetsTableView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
-                DisclosureGroup(isExpanded: $showTable) {
-                    List {
-                        headerRow
-                        totalsRow
-                        OutlineGroup(activeAssets, children: \.children) { asset in
+                List {
+                    headerRow
+                    totalsRow
+                    OutlineGroup(activeAssets, children: \.children) { asset in
+                        tableRow(for: asset)
+                    }
+                    if !inactiveAssets.isEmpty {
+                        Divider()
+                        inactiveHeader
+                        OutlineGroup(inactiveAssets, children: \.children) { asset in
                             tableRow(for: asset)
                         }
-                        if !inactiveAssets.isEmpty {
-                            Divider()
-                            inactiveHeader
-                            OutlineGroup(inactiveAssets, children: \.children) { asset in
-                                tableRow(for: asset)
-                            }
-                        }
                     }
-                    if !validationMessages.isEmpty {
-                        VStack(alignment: .leading, spacing: 2) {
+                }
+
+                DisclosureGroup(isExpanded: $showDetails) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        if validationMessages.isEmpty {
+                            Text("No issues")
+                                .font(.caption)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        } else {
                             ForEach(validationMessages, id: \.self) { msg in
                                 Text("• \(msg)")
                                     .font(.caption)
                                     .frame(maxWidth: .infinity, alignment: .leading)
                             }
                         }
-                        .padding(.top, 8)
                     }
+                    .padding(.top, 8)
                 } label: {
                     Text("Asset Allocation")
                         .font(.headline)

--- a/DragonShield/Views/AllocationTargetsTableView.swift
+++ b/DragonShield/Views/AllocationTargetsTableView.swift
@@ -510,8 +510,6 @@ struct AllocationTargetsTableView: View {
                     }
                 }
 
-            }
-
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
                     DisclosureGroup(isExpanded: $showDetails) {
@@ -520,15 +518,14 @@ struct AllocationTargetsTableView: View {
                                 Text("No issues")
                                     .font(.caption)
                                     .frame(maxWidth: .infinity, alignment: .leading)
-                        } else {
-                            ForEach(validationMessages, id: \.self) { msg in
-                                Text("• \(msg)")
-                                    .font(.caption)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            } else {
+                                ForEach(validationMessages, id: \.self) { msg in
+                                    Text("• \(msg)")
+                                        .font(.caption)
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                }
                             }
                         }
-                    }
-                    .padding(.top, 8)
                     } label: {
                         Text("Asset Allocation Errors")
                             .font(.headline)
@@ -536,6 +533,7 @@ struct AllocationTargetsTableView: View {
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .background(Color.softBlue)
                     }
+                    .padding(.top, 8)
                     .padding(.bottom, 16)
 
                     DisclosureGroup("Double Donut", isExpanded: $showDonut) {

--- a/DragonShield/Views/AllocationTargetsTableView.swift
+++ b/DragonShield/Views/AllocationTargetsTableView.swift
@@ -471,13 +471,13 @@ struct AllocationTargetsTableView: View {
     private var validationMessages: [String] {
         var issues: [String] = []
         if !viewModel.totalsValid {
-            issues.append(String(format: "Overall Target %% total is %.1f%%, which is outside the 99\u2013101%% tolerance", viewModel.targetPctTotal))
+            issues.append(String(format: "Overall Target %% total is %.1f%%, which is outside the 99\u{2013}101%% tolerance", viewModel.targetPctTotal))
         }
         for asset in viewModel.assets {
             if asset.id.hasPrefix("class-") {
                 if viewModel.rowHasWarning(asset) {
                     let sumPct = asset.children?.map(\.targetPct).reduce(0, +) ?? 0
-                    issues.append("Total Target % for Asset Class '\(asset.name)' is \(formatPercent(sumPct))%, which is outside the 99\u2013101% tolerance")
+                    issues.append("Total Target % for Asset Class '\(asset.name)' is \(formatPercent(sumPct))%, which is outside the 99\u{2013}101% tolerance")
                 } else if viewModel.rowNeedsOrange(asset) {
                     issues.append("No sub-asset class allocation defined for Asset Class '\(asset.name)'")
                 }
@@ -514,7 +514,7 @@ struct AllocationTargetsTableView: View {
                     if !validationMessages.isEmpty {
                         VStack(alignment: .leading, spacing: 2) {
                             ForEach(validationMessages, id: \.self) { msg in
-                                Text("\u2022 \(msg)")
+                                Text("• \(msg)")
                                     .font(.caption)
                                     .frame(maxWidth: .infinity, alignment: .leading)
                             }

--- a/DragonShield/Views/AllocationTargetsTableView.swift
+++ b/DragonShield/Views/AllocationTargetsTableView.swift
@@ -494,14 +494,13 @@ struct AllocationTargetsTableView: View {
     }
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
-                List {
-                    headerRow
-                    totalsRow
-                    OutlineGroup(activeAssets, children: \.children) { asset in
-                        tableRow(for: asset)
-                    }
+        VStack(alignment: .leading, spacing: 16) {
+            List {
+                headerRow
+                totalsRow
+                OutlineGroup(activeAssets, children: \.children) { asset in
+                    tableRow(for: asset)
+                }
                     if !inactiveAssets.isEmpty {
                         Divider()
                         inactiveHeader
@@ -511,12 +510,16 @@ struct AllocationTargetsTableView: View {
                     }
                 }
 
-                DisclosureGroup(isExpanded: $showDetails) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        if validationMessages.isEmpty {
-                            Text("No issues")
-                                .font(.caption)
-                                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    DisclosureGroup(isExpanded: $showDetails) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            if validationMessages.isEmpty {
+                                Text("No issues")
+                                    .font(.caption)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
                         } else {
                             ForEach(validationMessages, id: \.self) { msg in
                                 Text("• \(msg)")
@@ -526,30 +529,31 @@ struct AllocationTargetsTableView: View {
                         }
                     }
                     .padding(.top, 8)
-                } label: {
-                    Text("Asset Allocation")
-                        .font(.headline)
-                        .padding(8)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(Color.softBlue)
-                }
-                .padding(.bottom, 16)
+                    } label: {
+                        Text("Asset Allocation Errors")
+                            .font(.headline)
+                            .padding(8)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(Color.softBlue)
+                    }
+                    .padding(.bottom, 16)
 
-                DisclosureGroup("Double Donut", isExpanded: $showDonut) {
-                    DualRingDonutChart(data: chartAllocations)
-                        .frame(maxWidth: .infinity)
-                }
-                .padding(.bottom, 16)
-                .background(Color.softBlue)
+                    DisclosureGroup("Double Donut", isExpanded: $showDonut) {
+                        DualRingDonutChart(data: chartAllocations)
+                            .frame(maxWidth: .infinity)
+                    }
+                    .padding(.bottom, 16)
+                    .background(Color.softBlue)
 
-                DisclosureGroup("Delta Bar", isExpanded: $showDelta) {
-                    DeltaBarLayout(data: chartAllocations)
-                        .frame(maxWidth: .infinity)
+                    DisclosureGroup("Delta Bar Asset Class", isExpanded: $showDelta) {
+                        DeltaBarLayout(data: chartAllocations)
+                            .frame(maxWidth: .infinity)
+                    }
+                    .background(Color.softBlue)
                 }
-                .background(Color.softBlue)
+                .padding()
+                .frame(maxWidth: .infinity)
             }
-            .padding()
-            .frame(maxWidth: .infinity)
         }
         .onAppear {
             viewModel.load(using: dbManager)


### PR DESCRIPTION
## Summary
- make Target Asset Allocation screen scrollable with collapsible sections
- show validation issues beneath the allocation table

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_687a5c7c61d88323a7472f1b953d8b93