### PR TITLE
Fix duplicate IDs in import summary logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Move Target Asset Allocation link to Key Features section
 - Fix compile error in allocation charts by importing Charts framework
 - Resolve build error by replacing onTapGesture with overlay gesture in donut chart
+- Fix duplicate IDs in import summary logs to avoid SwiftUI warnings
 - Fix seed data to include valor numbers in Instruments table
 - Replace instrument seed data with Consolidated_Instruments_V8.xlsx for updated test dataset
 - Expand seed dataset with full production reference data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Resolve build error by replacing onTapGesture with overlay gesture in donut chart
 - Fix duplicate IDs in import summary logs to avoid SwiftUI warnings
 - Avoid duplicate IDs in backup and import logs
+- Show correct database version in startup log
 - Fix seed data to include valor numbers in Instruments table
 - Replace instrument seed data with Consolidated_Instruments_V8.xlsx for updated test dataset
 - Expand seed dataset with full production reference data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Fix compile error in allocation charts by importing Charts framework
 - Resolve build error by replacing onTapGesture with overlay gesture in donut chart
 - Fix duplicate IDs in import summary logs to avoid SwiftUI warnings
+- Avoid duplicate IDs in backup and import logs
 - Fix seed data to include valor numbers in Instruments table
 - Replace instrument seed data with Consolidated_Instruments_V8.xlsx for updated test dataset
 - Expand seed dataset with full production reference data

--- a/DragonShield/BackupService.swift
+++ b/DragonShield/BackupService.swift
@@ -288,7 +288,7 @@ class BackupService: ObservableObject {
         try execute("COMMIT;", on: db)
         try execute("PRAGMA foreign_keys=ON;", on: db)
 
-        dbManager.loadConfiguration()
+        dbManager.dbVersion = dbManager.loadConfiguration()
         let tableCounts = rowCounts(db: db, tables: referenceTables)
         lastReferenceBackup = Date()
         UserDefaults.standard.set(lastReferenceBackup, forKey: UserDefaultsKeys.lastReferenceBackupTimestamp)

--- a/DragonShield/DatabaseManager.swift
+++ b/DragonShield/DatabaseManager.swift
@@ -84,7 +84,7 @@ class DatabaseManager: ObservableObject {
         }
         
         openDatabase()
-        loadConfiguration()
+        dbVersion = loadConfiguration()
         updateFileMetadata()
         print("📂 Database path: \(dbPath) | version: \(dbVersion)")
     }
@@ -134,7 +134,7 @@ class DatabaseManager: ObservableObject {
     func reopenDatabase() {
         closeConnection()
         openDatabase()
-        loadConfiguration()
+        dbVersion = loadConfiguration()
         updateFileMetadata()
     }
 

--- a/DragonShield/Views/DataImportExportView.swift
+++ b/DragonShield/Views/DataImportExportView.swift
@@ -172,7 +172,7 @@ struct DataImportExportView: View {
                 .foregroundColor(Color(red: 51/255, green: 51/255, blue: 51/255))
             ScrollView {
                 VStack(alignment: .leading, spacing: 2) {
-                    ForEach(logMessages, id: \.self) { entry in
+                    ForEach(Array(logMessages.enumerated()), id: \.offset) { _, entry in
                         Text(entry)
                             .font(.system(size: 12, design: .monospaced))
                             .foregroundColor(Color(red: 34/255, green: 34/255, blue: 34/255))

--- a/DragonShield/Views/DatabaseManagementView.swift
+++ b/DragonShield/Views/DatabaseManagementView.swift
@@ -192,7 +192,7 @@ struct DatabaseManagementView: View {
 
     private var logList: some View {
         VStack(alignment: .leading, spacing: 2) {
-            ForEach(backupService.logMessages, id: \..self) { entry in
+            ForEach(Array(backupService.logMessages.enumerated()), id: \.offset) { _, entry in
                 Text(entry)
                     .font(.system(.caption2, design: .monospaced))
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/DragonShield/Views/ImportSummaryPanel.swift
+++ b/DragonShield/Views/ImportSummaryPanel.swift
@@ -28,7 +28,7 @@ struct ImportSummaryPanel: View {
                 if !logs.isEmpty {
                     Divider()
                     VStack(alignment: .leading, spacing: 2) {
-                        ForEach(logs, id: \.self) { msg in
+                        ForEach(Array(logs.enumerated()), id: \.offset) { _, msg in
                             Text(msg)
                                 .font(.caption2)
                                 .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
## Summary
- avoid duplicate IDs in the import summary panel
- document the fix in the changelog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas)*

------
https://chatgpt.com/codex/tasks/task_e_687aaf419c6c83238b6e7ebca93a05b5