### PR TITLE
feat(test-data): add asset target allocation dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Show correct database version in startup log
 - Fix seed data to include valor numbers in Instruments table
 - Replace instrument seed data with Consolidated_Instruments_V8.xlsx for updated test dataset
+- Add asset target allocation test dataset (asset_target_allocation_dataset.sql)
 - Expand seed dataset with full production reference data
 - Expand PositionReports with diverse sample entries for testing
 - Add risk concentration dashboard tile showing top 5 groups by value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 - Show correct database version in startup log
 - Fix seed data to include valor numbers in Instruments table
 - Replace instrument seed data with Consolidated_Instruments_V8.xlsx for updated test dataset
-- Add asset target allocation test dataset (asset_target_allocation_dataset.sql)
+- Integrate asset target allocation test dataset into schema.txt
 - Expand seed dataset with full production reference data
 - Expand PositionReports with diverse sample entries for testing
 - Add risk concentration dashboard tile showing top 5 groups by value

--- a/DragonShield/database/schema.txt
+++ b/DragonShield/database/schema.txt
@@ -281,3 +281,80 @@ INSERT INTO ExchangeRates (currency_code, rate_date, rate_to_chf, rate_source, i
 INSERT INTO ExchangeRates (currency_code, rate_date, rate_to_chf, rate_source, is_latest) VALUES ('ETH', '2025-07-11', 2550.0000, 'manual', 0);
 INSERT INTO ExchangeRates (currency_code, rate_date, rate_to_chf, rate_source, is_latest) VALUES ('ETH', '2025-07-12', 2575.0000, 'api', 0);
 INSERT INTO ExchangeRates (currency_code, rate_date, rate_to_chf, rate_source, is_latest) VALUES ('ETH', '2025-07-13', 2600.0000, 'api', 1);
+
+-- Additional account representing real estate holdings at ZKB
+INSERT INTO Accounts VALUES (
+    26,
+    'ZKB-RE1',
+    'ZKB Real Estate Portfolio',
+    12,
+    6,
+    'CHF',
+    1,
+    1,
+    '2018-01-01',
+    NULL,
+    NULL,
+    'Real estate holdings with ZKB',
+    '2025-07-13 10:00:00',
+    '2025-07-13 10:00:00'
+);
+
+-- Import session placeholder
+INSERT INTO ImportSessions VALUES (
+    6,
+    'Test Allocation',
+    'alloc.sql',
+    '/tmp/alloc.sql',
+    'CSV',
+    0,
+    'zzz000',
+    12,
+    'COMPLETED',
+    0,
+    0,
+    0,
+    0,
+    NULL,
+    'Test dataset load',
+    '2025-07-13 10:00:00',
+    '2025-07-13 10:00:00',
+    '2025-07-13 10:00:00'
+);
+
+-- Position holdings for allocation test
+INSERT INTO PositionReports VALUES (
+    23, 6, 26, 12, 50, 50000, 100, 100, '2025-07-01', 'Epic Suisse Fund holding', '2025-07-01', '2025-07-13 10:00:00'
+);
+INSERT INTO PositionReports VALUES (
+    24, 6, 7, 2, 5, 20, 50000, 60000, '2025-07-01', 'Bitcoin holdings', '2025-07-01', '2025-07-13 10:00:00'
+);
+INSERT INTO PositionReports VALUES (
+    25, 6, 7, 2, 8, 400, 2000, 2000, '2025-07-01', 'Ethereum holdings', '2025-07-01', '2025-07-13 10:00:00'
+);
+INSERT INTO PositionReports VALUES (
+    26, 6, 7, 2, 36, 1000, 700, 1000, '2025-07-01', 'NVDA position', '2025-07-01', '2025-07-13 10:00:00'
+);
+INSERT INTO PositionReports VALUES (
+    27, 6, 7, 2, 41, 4000, 100, 250, '2025-07-01', 'MSTR position', '2025-07-01', '2025-07-13 10:00:00'
+);
+INSERT INTO PositionReports VALUES (
+    28, 6, 9, 3, 16, 1000000, 1, 1, '2025-07-01', 'USDC liquidity', '2025-07-01', '2025-07-13 10:00:00'
+);
+
+-- Target allocations (class level)
+INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, updated_at) VALUES (4, NULL, 40, NULL, '2025-07-13 10:00:00');
+INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, updated_at) VALUES (7, NULL, 15, NULL, '2025-07-13 10:00:00');
+INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, updated_at) VALUES (2, NULL, 35, NULL, '2025-07-13 10:00:00');
+INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, updated_at) VALUES (1, NULL, 15, NULL, '2025-07-13 10:00:00');
+INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, updated_at) VALUES (3, NULL, 5, NULL, '2025-07-13 10:00:00');
+
+-- Target allocations (sub-class level)
+INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, updated_at) VALUES (4, 11, 30, NULL, '2025-07-13 10:00:00');
+INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, updated_at) VALUES (4, 14, 10, NULL, '2025-07-13 10:00:00');
+INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, updated_at) VALUES (7, 18, 10, NULL, '2025-07-13 10:00:00');
+INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, updated_at) VALUES (7, 21, 5, NULL, '2025-07-13 10:00:00');
+INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, updated_at) VALUES (2, 3, 20, NULL, '2025-07-13 10:00:00');
+INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, updated_at) VALUES (2, 4, 15, NULL, '2025-07-13 10:00:00');
+INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, updated_at) VALUES (1, 1, 15, NULL, '2025-07-13 10:00:00');
+INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, updated_at) VALUES (3, 7, 5, NULL, '2025-07-13 10:00:00');

--- a/test_data/asset_target_allocation_dataset.sql
+++ b/test_data/asset_target_allocation_dataset.sql
@@ -1,0 +1,80 @@
+PRAGMA foreign_keys=OFF;
+
+-- Additional account representing real estate holdings at ZKB
+INSERT INTO Accounts VALUES (
+    26,
+    'ZKB-RE1',
+    'ZKB Real Estate Portfolio',
+    12,
+    6,
+    'CHF',
+    1,
+    1,
+    '2018-01-01',
+    NULL,
+    NULL,
+    'Real estate holdings with ZKB',
+    '2025-07-13 10:00:00',
+    '2025-07-13 10:00:00'
+);
+
+-- Import session placeholder
+INSERT INTO ImportSessions VALUES (
+    6,
+    'Test Allocation',
+    'alloc.sql',
+    '/tmp/alloc.sql',
+    'CSV',
+    0,
+    'zzz000',
+    12,
+    'COMPLETED',
+    0,
+    0,
+    0,
+    0,
+    NULL,
+    'Test dataset load',
+    '2025-07-13 10:00:00',
+    '2025-07-13 10:00:00',
+    '2025-07-13 10:00:00'
+);
+
+-- Position holdings
+INSERT INTO PositionReports VALUES (
+    23, 6, 26, 12, 50, 50000, 100, 100, '2025-07-01', 'Epic Suisse Fund holding', '2025-07-01', '2025-07-13 10:00:00'
+);
+INSERT INTO PositionReports VALUES (
+    24, 6, 7, 2, 5, 20, 50000, 60000, '2025-07-01', 'Bitcoin holdings', '2025-07-01', '2025-07-13 10:00:00'
+);
+INSERT INTO PositionReports VALUES (
+    25, 6, 7, 2, 8, 400, 2000, 2000, '2025-07-01', 'Ethereum holdings', '2025-07-01', '2025-07-13 10:00:00'
+);
+INSERT INTO PositionReports VALUES (
+    26, 6, 7, 2, 36, 1000, 700, 1000, '2025-07-01', 'NVDA position', '2025-07-01', '2025-07-13 10:00:00'
+);
+INSERT INTO PositionReports VALUES (
+    27, 6, 7, 2, 41, 4000, 100, 250, '2025-07-01', 'MSTR position', '2025-07-01', '2025-07-13 10:00:00'
+);
+INSERT INTO PositionReports VALUES (
+    28, 6, 9, 3, 16, 1000000, 1, 1, '2025-07-01', 'USDC liquidity', '2025-07-01', '2025-07-13 10:00:00'
+);
+
+-- Target allocations (class level)
+INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, updated_at) VALUES (4, NULL, 40, NULL, '2025-07-13 10:00:00');
+INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, updated_at) VALUES (7, NULL, 15, NULL, '2025-07-13 10:00:00');
+INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, updated_at) VALUES (2, NULL, 35, NULL, '2025-07-13 10:00:00');
+INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, updated_at) VALUES (1, NULL, 15, NULL, '2025-07-13 10:00:00');
+INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, updated_at) VALUES (3, NULL, 5, NULL, '2025-07-13 10:00:00');
+
+-- Target allocations (sub-class level)
+INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, updated_at) VALUES (4, 11, 30, NULL, '2025-07-13 10:00:00');
+INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, updated_at) VALUES (4, 14, 10, NULL, '2025-07-13 10:00:00');
+INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, updated_at) VALUES (7, 18, 10, NULL, '2025-07-13 10:00:00');
+INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, updated_at) VALUES (7, 21, 5, NULL, '2025-07-13 10:00:00');
+INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, updated_at) VALUES (2, 3, 20, NULL, '2025-07-13 10:00:00');
+INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, updated_at) VALUES (2, 4, 15, NULL, '2025-07-13 10:00:00');
+INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, updated_at) VALUES (1, 1, 15, NULL, '2025-07-13 10:00:00');
+INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, updated_at) VALUES (3, 7, 5, NULL, '2025-07-13 10:00:00');
+
+PRAGMA foreign_keys=ON;


### PR DESCRIPTION
## Summary
- create SQL dataset for asset allocation testing
- log addition in changelog

## Testing
- `pytest -q` *(fails: pandas missing)*

------
https://chatgpt.com/codex/tasks/task_e_687b348cfac083238359749e0c95fb4f