### PR TITLE
feat(ui): show subclass aggregates in allocation table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Display sub-class aggregate totals with delta validation in Allocation Targets table
 - Visualize target vs actual allocations with dual-ring donut chart and delta bar layout in Allocation Targets view
 - Remove outdated Asset Allocation view and sidebar link
 - Move Target Asset Allocation link to Key Features section

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Display sub-class aggregate totals with delta validation in Allocation Targets table
+- Fix compile error from variable name clash in AllocationTargetsTableView
 - Visualize target vs actual allocations with dual-ring donut chart and delta bar layout in Allocation Targets view
 - Remove outdated Asset Allocation view and sidebar link
 - Move Target Asset Allocation link to Key Features section

--- a/DragonShield/Views/AllocationTargetsTableView.swift
+++ b/DragonShield/Views/AllocationTargetsTableView.swift
@@ -705,7 +705,7 @@ struct AllocationTargetsTableView: View {
         let subclassSumChf = asset.children?.map(\.targetChf).reduce(0, +) ?? 0
         let deltaChf = asset.targetChf - subclassSumChf
         let deltaTol = abs(asset.targetChf) * 0.01
-        let deltaColor: Color = abs(deltaChf) > deltaTol ? .red : .secondary
+        let aggregateDeltaColor: Color = abs(deltaChf) > deltaTol ? .red : .secondary
 
         HStack(spacing: 0) {
             Text(asset.name)
@@ -747,7 +747,7 @@ struct AllocationTargetsTableView: View {
                                 Text("Σ \(formatChf(subclassSumChf))")
                                 Text(formatSignedChf(deltaChf))
                                     .fontWeight(abs(deltaChf) > deltaTol ? .bold : .regular)
-                                    .foregroundColor(deltaColor)
+                                    .foregroundColor(aggregateDeltaColor)
                             }
                             .font(.caption2)
                             .frame(width: 100, alignment: .trailing)
@@ -787,7 +787,7 @@ struct AllocationTargetsTableView: View {
                                 Text("Σ \(formatChf(subclassSumChf))")
                                 Text(formatSignedChf(deltaChf))
                                     .fontWeight(abs(deltaChf) > deltaTol ? .bold : .regular)
-                                    .foregroundColor(deltaColor)
+                                    .foregroundColor(aggregateDeltaColor)
                             }
                             .font(.caption2)
                             .frame(width: 100, alignment: .trailing)


### PR DESCRIPTION
## Summary
- display sum of subclass targets and delta on parent asset class rows
- log this addition in CHANGELOG

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pysqlcipher3)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687b3a40092c8323b3d4a11b86ac2ac9