### PR TITLE
feat(ui): compact drag-and-drop zone layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 - Display sub-class aggregate totals with delta validation in Allocation Targets table
 - Fix compile error from variable name clash in AllocationTargetsTableView
+- Shrink Data Import/Export panels and show square drag-and-drop area
 - Visualize target vs actual allocations with dual-ring donut chart and delta bar layout in Allocation Targets view
 - Remove outdated Asset Allocation view and sidebar link
 - Move Target Asset Allocation link to Key Features section

--- a/DragonShield/Views/DataImportExportView.swift
+++ b/DragonShield/Views/DataImportExportView.swift
@@ -4,6 +4,8 @@ import UniformTypeIdentifiers
 struct DataImportExportView: View {
     enum StatementType { case creditSuisse, zkb }
 
+    private let dropZoneSize: CGFloat = 160
+
     @State private var logMessages: [String] = UserDefaults.standard.stringArray(forKey: UserDefaultsKeys.statementImportLog) ?? []
     @State private var statusMessage: String = "Status: \u{2B24} Idle \u{2022} No file loaded"
     @State private var showImporterFor: StatementType?
@@ -15,7 +17,7 @@ struct DataImportExportView: View {
                 statusPanel
                 logPanel
             }
-            .frame(minWidth: 1600, minHeight: 1200)
+            .frame(minWidth: 800, minHeight: 800)
             .padding(.top, 32)
             .padding(.horizontal)
         }
@@ -104,7 +106,8 @@ struct DataImportExportView: View {
                 guard enabled, let url = urls.first else { return }
                 importStatement(from: url, type: type)
             }
-            .frame(height: 120)
+            .frame(width: dropZoneSize, height: dropZoneSize)
+            .frame(maxWidth: .infinity)
             .opacity(enabled ? 1 : 0.5)
 
             Text("or")


### PR DESCRIPTION
## Summary
- shrink minimum width of Data Import/Export panels
- use a fixed square drop zone that's centered in each card
- update changelog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'DragonShield' and pandas)*

------
https://chatgpt.com/codex/tasks/task_e_687b4621be808323bb60b535e84b7309