### PR TITLE
Add ZKB CSV import path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 - Display sub-class aggregate totals with delta validation in Allocation Targets table
 - Fix compile error from variable name clash in AllocationTargetsTableView
 - Shrink Data Import/Export panels and show square drag-and-drop area
+- Add ZKB CSV import parser and enable ZKB statements in Data Import/Export view
 - Visualize target vs actual allocations with dual-ring donut chart and delta bar layout in Allocation Targets view
 - Remove outdated Asset Allocation view and sidebar link
 - Move Target Asset Allocation link to Key Features section

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Shrink Data Import/Export panels and show square drag-and-drop area
 - Add ZKB CSV import parser and enable ZKB statements in Data Import/Export view
 - Fix compile error when passing statement type to ImportManager
+- Fix type mismatch when selecting parser for statement import
 - Visualize target vs actual allocations with dual-ring donut chart and delta bar layout in Allocation Targets view
 - Remove outdated Asset Allocation view and sidebar link
 - Move Target Asset Allocation link to Key Features section

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Fix compile error from variable name clash in AllocationTargetsTableView
 - Shrink Data Import/Export panels and show square drag-and-drop area
 - Add ZKB CSV import parser and enable ZKB statements in Data Import/Export view
+- Fix compile error when passing statement type to ImportManager
 - Visualize target vs actual allocations with dual-ring donut chart and delta bar layout in Allocation Targets view
 - Remove outdated Asset Allocation view and sidebar link
 - Move Target Asset Allocation link to Key Features section

--- a/DragonShield/ImportManager.swift
+++ b/DragonShield/ImportManager.swift
@@ -225,8 +225,13 @@ class ImportManager {
                 LoggingService.shared.log("Existing Credit-Suisse positions removed: \(removed)", type: .info, logger: .database)
             }
             do {
-                let parser = (type == .creditSuisse) ? self.positionParser : self.zkbParser
-                let (summary, rows) = try parser.parse(url: url, progress: logger)
+                let (summary, rows) = try {
+                    if type == .creditSuisse {
+                        return try self.positionParser.parse(url: url, progress: logger)
+                    } else {
+                        return try self.zkbParser.parse(url: url, progress: logger)
+                    }
+                }()
                 DispatchQueue.main.sync {
                     let first = rows.first
                     self.showImportSummary(fileName: url.lastPathComponent,

--- a/DragonShield/ImportManager.swift
+++ b/DragonShield/ImportManager.swift
@@ -25,6 +25,7 @@ class ImportManager {
     static let shared = ImportManager()
     private let xlsxProcessor = CreditSuisseXLSXProcessor()
     private let positionParser = CreditSuissePositionParser()
+    private let zkbParser = ZKBStatementParser()
     private let dbManager = DatabaseManager()
     private lazy var repository: BankRecordRepository = {
         BankRecordRepository(dbManager: dbManager)
@@ -57,6 +58,11 @@ class ImportManager {
 
     enum ImportError: Error {
         case aborted
+    }
+
+    enum StatementType {
+        case creditSuisse
+        case zkb
     }
 
 
@@ -204,7 +210,7 @@ class ImportManager {
     }
 
     /// Parses a Credit-Suisse statement and saves position reports.
-    func importPositions(at url: URL, deleteExisting: Bool = false, progress: ((String) -> Void)? = nil, completion: @escaping (Result<PositionImportSummary, Error>) -> Void) {
+    func importPositions(at url: URL, type: StatementType = .creditSuisse, deleteExisting: Bool = false, progress: ((String) -> Void)? = nil, completion: @escaping (Result<PositionImportSummary, Error>) -> Void) {
         LoggingService.shared.clearLog()
         let logger: (String) -> Void = { message in
             LoggingService.shared.log(message, type: .info, logger: .parser)
@@ -214,12 +220,13 @@ class ImportManager {
         DispatchQueue.global(qos: .userInitiated).async {
             let accessGranted = url.startAccessingSecurityScopedResource()
             defer { if accessGranted { url.stopAccessingSecurityScopedResource() } }
-            if deleteExisting {
+            if deleteExisting && type == .creditSuisse {
                 let removed = self.deleteCreditSuissePositions()
                 LoggingService.shared.log("Existing Credit-Suisse positions removed: \(removed)", type: .info, logger: .database)
             }
             do {
-                let (summary, rows) = try self.positionParser.parse(url: url, progress: logger)
+                let parser = (type == .creditSuisse) ? self.positionParser : self.zkbParser
+                let (summary, rows) = try parser.parse(url: url, progress: logger)
                 DispatchQueue.main.sync {
                     let first = rows.first
                     self.showImportSummary(fileName: url.lastPathComponent,
@@ -232,7 +239,8 @@ class ImportManager {
                 let fileSize = (attrs[.size] as? NSNumber)?.intValue ?? 0
                 let hash = url.sha256() ?? ""
                let valueDate = rows.first?.reportDate ?? Date()
-               let baseSessionName = "Credit-Suisse Positions \(DateFormatter.swissDate.string(from: valueDate))"
+               let institutionName = type == .creditSuisse ? "Credit-Suisse" : "Züricher Kantonal Bank ZKB"
+               let baseSessionName = "\(institutionName) Positions \(DateFormatter.swissDate.string(from: valueDate))"
                let sessionName = self.dbManager.nextImportSessionName(base: baseSessionName)
                 let fileType = url.pathExtension.uppercased()
 
@@ -240,7 +248,7 @@ class ImportManager {
                 var accountId = self.dbManager.findAccountId(accountNumber: custodyNumber)
                 LoggingService.shared.log("Lookup account for \(custodyNumber) -> \(accountId?.description ?? "nil")", type: .debug, logger: .database)
                 if accountId == nil {
-                    accountId = self.dbManager.findAccountId(accountNumber: custodyNumber, nameContains: "Credit-Suisse")
+                    accountId = self.dbManager.findAccountId(accountNumber: custodyNumber, nameContains: institutionName)
                     LoggingService.shared.log("Lookup with name filter -> \(accountId?.description ?? "nil")", type: .debug, logger: .database)
                 }
                 while accountId == nil {
@@ -266,7 +274,7 @@ class ImportManager {
                         accountId = self.dbManager.findAccountId(accountNumber: number)
                         LoggingService.shared.log("Post-create lookup -> \(accountId?.description ?? "nil")", type: .debug, logger: .database)
                         if accountId == nil {
-                            accountId = self.dbManager.findAccountId(accountNumber: number, nameContains: "Credit-Suisse")
+                        accountId = self.dbManager.findAccountId(accountNumber: number, nameContains: institutionName)
                             LoggingService.shared.log("Post-create lookup with name filter -> \(accountId?.description ?? "nil")", type: .debug, logger: .database)
                         }
                         if accountId != nil {
@@ -276,7 +284,7 @@ class ImportManager {
                         accountId = self.dbManager.findAccountId(accountNumber: custodyNumber)
                         LoggingService.shared.log("Retry lookup -> \(accountId?.description ?? "nil")", type: .debug, logger: .database)
                         if accountId == nil {
-                            accountId = self.dbManager.findAccountId(accountNumber: custodyNumber, nameContains: "Credit-Suisse")
+                        accountId = self.dbManager.findAccountId(accountNumber: custodyNumber, nameContains: institutionName)
                             LoggingService.shared.log("Retry lookup with name filter -> \(accountId?.description ?? "nil")", type: .debug, logger: .database)
                         }
                         if accountId == nil {
@@ -291,9 +299,10 @@ class ImportManager {
                         throw ImportError.aborted
                     }
                     } else {
-                        let instId = self.dbManager.findInstitutionId(name: "Credit-Suisse") ?? 1
+                        let instId = self.dbManager.findInstitutionId(name: institutionName) ?? 1
                         let typeId = self.dbManager.findAccountTypeId(code: "CUSTODY") ?? 1
-                        _ = self.dbManager.addAccount(accountName: "Credit-Suisse Account",
+                        let defaultName = type == .creditSuisse ? "Credit-Suisse Account" : "ZKB Account"
+                        _ = self.dbManager.addAccount(accountName: defaultName,
                                                        institutionId: instId,
                                                        accountNumber: custodyNumber,
                                                        accountTypeId: typeId,
@@ -308,7 +317,7 @@ class ImportManager {
                 }
                 let accId = accountId!
                 let accountInfo = self.dbManager.fetchAccountDetails(id: accId)
-                let institutionId = accountInfo?.institutionId ?? self.dbManager.findInstitutionId(name: "Credit-Suisse") ?? 1
+                let institutionId = accountInfo?.institutionId ?? self.dbManager.findInstitutionId(name: institutionName) ?? 1
 
                 let sessionId = self.dbManager.startImportSession(sessionName: sessionName,
                                                                   fileName: url.lastPathComponent,

--- a/DragonShield/Views/DataImportExportView.swift
+++ b/DragonShield/Views/DataImportExportView.swift
@@ -4,7 +4,7 @@ import UniformTypeIdentifiers
 struct DataImportExportView: View {
     enum StatementType { case creditSuisse, zkb }
 
-    private let dropZoneSize: CGFloat = 160
+    private let dropZoneSize: CGFloat = 100
 
     @State private var logMessages: [String] = UserDefaults.standard.stringArray(forKey: UserDefaultsKeys.statementImportLog) ?? []
     @State private var statusMessage: String = "Status: \u{2B24} Idle \u{2022} No file loaded"
@@ -89,7 +89,7 @@ struct DataImportExportView: View {
     }
 
     private var zkbCard: some View {
-        importCard(title: "Import ZKB Statement", type: .zkb, enabled: false)
+        importCard(title: "Import ZKB Statement", type: .zkb, enabled: true)
     }
 
     private func importCard(title: String, type: StatementType, enabled: Bool) -> some View {
@@ -134,7 +134,7 @@ struct DataImportExportView: View {
     private func importStatement(from url: URL, type: StatementType) {
         statusMessage = "Status: Importing \(url.lastPathComponent) …"
 
-        ImportManager.shared.importPositions(at: url, progress: { message in
+        ImportManager.shared.importPositions(at: url, type: type, progress: { message in
             DispatchQueue.main.async { self.appendLog(message) }
         }) { result in
             DispatchQueue.main.async {

--- a/DragonShield/Views/DataImportExportView.swift
+++ b/DragonShield/Views/DataImportExportView.swift
@@ -134,7 +134,10 @@ struct DataImportExportView: View {
     private func importStatement(from url: URL, type: StatementType) {
         statusMessage = "Status: Importing \(url.lastPathComponent) …"
 
-        ImportManager.shared.importPositions(at: url, type: type, progress: { message in
+        let importType: ImportManager.StatementType = {
+            switch type { case .creditSuisse: return .creditSuisse; case .zkb: return .zkb }
+        }()
+        ImportManager.shared.importPositions(at: url, type: importType, progress: { message in
             DispatchQueue.main.async { self.appendLog(message) }
         }) { result in
             DispatchQueue.main.async {

--- a/DragonShield/ZKBStatementParser.swift
+++ b/DragonShield/ZKBStatementParser.swift
@@ -1,0 +1,96 @@
+import Foundation
+import OSLog
+
+struct ZKBStatementParser {
+    private let log = Logger.parser
+    private let logging = LoggingService.shared
+
+    func parse(url: URL, progress: ((String) -> Void)? = nil) throws -> (PositionImportSummary, [ParsedPositionRecord]) {
+        logging.log("Starting ZKB CSV parse", type: .info, logger: log)
+        progress?("Opening \(url.lastPathComponent)")
+        let statementDate = Self.statementDate(from: url.lastPathComponent) ?? Date()
+        let dateMsg = "Statement date: \(ISO8601DateFormatter().string(from: statementDate))"
+        logging.log(dateMsg, type: .info, logger: log)
+        progress?(dateMsg)
+
+        let content = try String(contentsOf: url, encoding: .utf8)
+        let lines = content.split(whereSeparator: { $0.isNewline })
+        guard let header = lines.first else { return (PositionImportSummary(totalRows: 0, parsedRows: 0, cashAccounts: 0, securityRecords: 0), []) }
+        let headers = header.replacing("\u{FEFF}", with: "").split(separator: ";").map { $0.trimmingCharacters(in: CharacterSet(charactersIn: "\"")) }
+        var headerMap: [String: Int] = [:]
+        for (idx, name) in headers.enumerated() { headerMap[name] = idx }
+        var summary = PositionImportSummary(totalRows: lines.count - 1, parsedRows: 0, cashAccounts: 0, securityRecords: 0)
+        var records: [ParsedPositionRecord] = []
+        for line in lines.dropFirst() {
+            let cells = line.split(separator: ";", omittingEmptySubsequences: false).map { String($0).trimmingCharacters(in: CharacterSet(charactersIn: "\"")) }
+            let row: (String) -> String = { key in
+                if let idx = headerMap[key], idx < cells.count { return cells[idx] } else { return "" }
+            }
+            let category = row("Anlagekategorie")
+            if category == "Konten" { continue }
+            let quantity = Self.parseNumber(row("Anz./Nom.")) ?? 0
+            let purchasePrice = Self.parseNumber(row("Einstandskurs"))
+            let currentPrice = Self.parseNumber(row("Marktkurs"))
+            let currency = row("Währung")
+            let name = row("Bezeichnung")
+            let valor = row("Valor/IBAN/MSCI ESG-Rating")
+            let rec = ParsedPositionRecord(
+                accountNumber: "1-2600-01180149",
+                accountName: "ZKB Account",
+                instrumentName: name,
+                tickerSymbol: nil,
+                isin: nil,
+                valorNr: valor.isEmpty ? nil : valor,
+                currency: currency,
+                quantity: quantity,
+                purchasePrice: purchasePrice,
+                currentPrice: currentPrice,
+                reportDate: statementDate,
+                isCash: false,
+                subClassIdGuess: Self.subClassId(for: category)
+            )
+            records.append(rec)
+            summary.parsedRows += 1
+            summary.securityRecords += 1
+            let msg = "Parsed row: \(name) qty \(quantity) \(currency)"
+            logging.log(msg, type: .debug, logger: log)
+            progress?(msg)
+        }
+        logging.log("Finished ZKB parsing", type: .info, logger: log)
+        progress?("Parsed \(summary.parsedRows) rows")
+        return (summary, records)
+    }
+
+    private static func subClassId(for category: String) -> Int? {
+        let map: [String: Int] = [
+            "Liquide Mittel": 1,
+            "Obligationen und Ähnliches": 8,
+            "Aktien und Ähnliches": 3
+        ]
+        return map[category]
+    }
+
+    static func parseNumber(_ string: String?) -> Double? {
+        guard let s = string?.trimmingCharacters(in: .whitespacesAndNewlines), !s.isEmpty else { return nil }
+        var cleaned = s.replacingOccurrences(of: "'", with: "")
+        cleaned = cleaned.replacingOccurrences(of: " ", with: "")
+        cleaned = cleaned.replacingOccurrences(of: ",", with: ".")
+        return Double(cleaned)
+    }
+
+    static func statementDate(from filename: String) -> Date? {
+        let pattern = "(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\\s+(\\d{1,2})\\s+(\\d{4})"
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive),
+              let match = regex.firstMatch(in: filename, range: NSRange(filename.startIndex..., in: filename)) else { return nil }
+        let monthStr = String(filename[Range(match.range(at: 1), in: filename)!])
+        let day = Int(filename[Range(match.range(at: 2), in: filename)!]) ?? 1
+        let year = Int(filename[Range(match.range(at: 3), in: filename)!]) ?? 1970
+        let months = ["Jan":1,"Feb":2,"Mar":3,"Apr":4,"May":5,"Jun":6,"Jul":7,"Aug":8,"Sep":9,"Oct":10,"Nov":11,"Dec":12]
+        guard let month = months[String(monthStr.prefix(3)).capitalized] else { return nil }
+        var comps = DateComponents()
+        comps.year = year
+        comps.month = month
+        comps.day = day
+        return Calendar.current.date(from: comps)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ Run the deploy script to rebuild the database from the schema and copy it to the
 python3 python_scripts/deploy_db.py
 ```
 
+### ZKB CSV Import
+Drag a `Depotauszug*.csv` file onto the **Import ZKB Statement** zone in the Data Import/Export view or use *Select File* to choose it manually. The parser maps all rows to the PositionReports table.
+
 
 ### GPT Shell
 A small CLI to experiment with OpenAI function calls. Requires `OPENAI_API_KEY` in the environment.


### PR DESCRIPTION
## Summary
- support ZKB depot statements with a new `ZKBStatementParser`
- switch import pipeline based on statement type
- enable the ZKB card on the Data Import/Export screen and shrink drop zones
- document ZKB CSV import usage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687b4b6eb7788323a9fa7f906d867bf1