### PR TITLE
chore(import): remove version comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -318,3 +318,4 @@ All notable changes to this project will be documented in this file.
 - Pin Allocation Targets table at top with collapsible error and chart sections
 - Fix unmatched braces causing compile errors in AllocationTargetsTableView
 - Simplify row background colors so valid rows are white
+- Remove version history comments from ImportManager.swift

--- a/DragonShield/ImportManager.swift
+++ b/DragonShield/ImportManager.swift
@@ -1,20 +1,5 @@
 // DragonShield/ImportManager.swift
 
-// MARK: - Version 2.0.3.0
-// MARK: - History
-// - 1.11 -> 2.0.0.0: Rewritten to use native Swift XLSX processing instead of Python parser.
-// - 2.0.0.0 -> 2.0.0.1: Replace deprecated allowedFileTypes API.
-// - 2.0.0.1 -> 2.0.0.2: Begin security-scoped access when reading selected file.
-// - 2.0.0.2 -> 2.0.0.3: Surface detailed file format errors from XLSXProcessor.
-// - 2.0.0.3 -> 2.0.1.0: Expect XLSX files and use XLSXProcessor.
-// - 2.0.1.0 -> 2.0.2.0: Integrate CreditSuisseXLSXProcessor for Credit-Suisse statements.
-// - 2.0.2.0 -> 2.0.2.1: Provide progress logging via callback.
-// - 2.0.2.1 -> 2.0.2.2: Hold DB connection to avoid invalid pointer errors.
-// - 2.0.2.2 -> 2.0.2.3: Propagate detailed repository errors.
-// - 2.0.2.3 -> 2.0.2.4: Keep DB manager alive via repository reference.
-// - 2.0.2.4 -> 2.0.2.5: Guard UTType initialization and minor cleanup.
-// - 2.0.2.5 -> 2.0.2.6: Log import details to file and forward progress.
-// - 2.0.2.6 -> 2.0.3.0: Route log messages through OSLog categories.
 import Foundation
 import AppKit
 import SwiftUI


### PR DESCRIPTION
## Summary
- clean up `ImportManager` version header
- log changelog entry for removing in-file version history

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'DragonShield')*

------
https://chatgpt.com/codex/tasks/task_e_687b8d48d6408323a1a05626253a9513