### PR TITLE
fix positions deletion by institution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Prompt to delete existing ZKB positions when importing statements
 - Delete existing ZKB positions by name or BIC before import and log removed count
 - Update ZKB deletion to use BIC `ZKBKCHZZ80A` and correct institution name
+- Fix manual deletion of position reports by institution and log removed count
 - Alert when an unknown instrument is encountered during import
 - Fix ZKB CSV import assigning Equate Plus institution and zero quantities
 - Fix type mismatch when selecting parser for statement import

--- a/DragonShield/Views/PositionsView.swift
+++ b/DragonShield/Views/PositionsView.swift
@@ -130,7 +130,9 @@ struct PositionsView: View {
             Button("Cancel", role: .cancel) {}
             Button("Delete", role: .destructive) {
                 if let id = selectedInstitutionId {
-                    _ = dbManager.deletePositionReports(institutionIds: [id])
+                    let removed = dbManager.deletePositionReports(institutionIds: [id])
+                    LoggingService.shared.log("Deleted \(removed) position reports for institution id \(id)",
+                                              type: .info, logger: .database)
                     loadPositions()
                 }
             }
@@ -586,6 +588,11 @@ struct PositionsView: View {
 
     private func loadInstitutions() {
         institutions = dbManager.fetchInstitutions()
+        if selectedInstitutionId == nil {
+            if let zkb = institutions.first(where: { $0.name.localizedCaseInsensitiveContains("z\u00fcrcher kantonalbank") }) {
+                selectedInstitutionId = zkb.id
+            }
+        }
     }
 
     private func animateEntrance() {


### PR DESCRIPTION
## Summary
- preselect ZKB when loading institutions in Positions view
- log number of deleted rows when wiping positions
- document fix in changelog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'DragonShield')*

------
https://chatgpt.com/codex/tasks/task_e_687bb6e88c188323ab3634b9117f800e