### PR TITLE
feat(ui): add full instrument report generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Update ZKB deletion to use BIC `ZKBKCHZZ80A` and correct institution name
 - Allow deleting PositionReports for a selected institution when importing ZKB statements
 - Alert when an unknown instrument is encountered during import
+- Generate Full Instrument Report from Database Management view
 - Fix ZKB CSV import assigning Equate Plus institution and zero quantities
 - Fix type mismatch when selecting parser for statement import
 - Robust ZKB instrument discovery using Valor, ISIN and ticker with logging

--- a/DragonShield/InstrumentReportService.swift
+++ b/DragonShield/InstrumentReportService.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+final class InstrumentReportService {
+    private let pythonPath = "/usr/bin/python3"
+
+    func generateReport(to url: URL) throws -> String {
+        guard let scriptURL = Bundle.main.url(
+            forResource: "generate_instrument_report",
+            withExtension: "py",
+            subdirectory: "python_scripts"
+        ) else {
+            throw NSError(
+                domain: "InstrumentReportService",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Script not found"]
+            )
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: pythonPath)
+        process.arguments = [scriptURL.path, url.path]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        process.waitUntilExit()
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: data, encoding: .utf8) ?? ""
+
+        if process.terminationStatus != 0 {
+            throw NSError(
+                domain: "InstrumentReportService",
+                code: Int(process.terminationStatus),
+                userInfo: [NSLocalizedDescriptionKey: output]
+            )
+        }
+        return output.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}


### PR DESCRIPTION
## Summary
- support generating a full instrument report via Python
- add a button in Database Management view
- log status messages for report generation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_687bbadff5b083239040abbfbb4fb00e