### PR TITLE
Add full instrument report to Database Management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Generate full instrument report from Database Management view
 - Display sub-class aggregate totals with delta validation in Allocation Targets table
 - Fix compile error from variable name clash in AllocationTargetsTableView
 - Shrink Data Import/Export panels and show square drag-and-drop area

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Generate full instrument report from Database Management view
+- Fix instrument report generation by locating script path correctly
 - Display sub-class aggregate totals with delta validation in Allocation Targets table
 - Fix compile error from variable name clash in AllocationTargetsTableView
 - Shrink Data Import/Export panels and show square drag-and-drop area

--- a/DragonShield/InstrumentReportService.swift
+++ b/DragonShield/InstrumentReportService.swift
@@ -1,0 +1,27 @@
+// DragonShield/InstrumentReportService.swift
+// MARK: - Version 1.0
+// MARK: - History
+// - 1.0: Execute Python script to generate a full Instruments XLSX report.
+
+import Foundation
+
+final class InstrumentReportService {
+    func generateReport(outputPath: String) throws {
+        guard let scriptURL = Bundle.main.url(forResource: "generate_instrument_report", withExtension: "py", subdirectory: "python_scripts") else {
+            throw NSError(domain: "InstrumentReportService", code: 1, userInfo: [NSLocalizedDescriptionKey: "Script not found"])
+        }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+        process.arguments = [scriptURL.path, outputPath]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        process.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        guard process.terminationStatus == 0 else {
+            let message = String(data: data, encoding: .utf8) ?? "Unknown error"
+            throw NSError(domain: "InstrumentReportService", code: Int(process.terminationStatus), userInfo: [NSLocalizedDescriptionKey: message])
+        }
+    }
+}

--- a/DragonShield/InstrumentReportService.swift
+++ b/DragonShield/InstrumentReportService.swift
@@ -7,12 +7,10 @@ import Foundation
 
 final class InstrumentReportService {
     func generateReport(outputPath: String) throws {
-        guard let scriptURL = Bundle.main.url(forResource: "generate_instrument_report", withExtension: "py", subdirectory: "python_scripts") else {
-            throw NSError(domain: "InstrumentReportService", code: 1, userInfo: [NSLocalizedDescriptionKey: "Script not found"])
-        }
+        let scriptPath = try locateScript()
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
-        process.arguments = [scriptURL.path, outputPath]
+        process.arguments = [scriptPath, outputPath]
         let pipe = Pipe()
         process.standardOutput = pipe
         process.standardError = pipe
@@ -23,5 +21,32 @@ final class InstrumentReportService {
             let message = String(data: data, encoding: .utf8) ?? "Unknown error"
             throw NSError(domain: "InstrumentReportService", code: Int(process.terminationStatus), userInfo: [NSLocalizedDescriptionKey: message])
         }
+    }
+
+    private func locateScript() throws -> String {
+        var checked: [String] = []
+        let fm = FileManager.default
+
+        if let url = Bundle.main.url(forResource: "generate_instrument_report", withExtension: "py", subdirectory: "python_scripts"), fm.fileExists(atPath: url.path) {
+            return url.path
+        }
+
+        let moduleDir = URL(fileURLWithPath: #file).deletingLastPathComponent()
+        let candidates = [
+            moduleDir.appendingPathComponent("python_scripts/generate_instrument_report.py").path,
+            moduleDir.appendingPathComponent("../python_scripts/generate_instrument_report.py").path,
+            moduleDir.appendingPathComponent("../../python_scripts/generate_instrument_report.py").path,
+        ]
+
+        for path in candidates {
+            checked.append(path)
+            if fm.fileExists(atPath: path) { return path }
+        }
+
+        throw NSError(
+            domain: "InstrumentReportService",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Script not found. Checked: \(checked)"]
+        )
     }
 }


### PR DESCRIPTION
## Summary
- allow generating a full instrument report from Database Management view
- implement InstrumentReportService for Python bridge
- log instrument report status in existing log window

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'DragonShield', 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687bbadff5b083239040abbfbb4fb00e