### PR TITLE
Include TargetAllocation and FX tables in txn backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -322,3 +322,4 @@ All notable changes to this project will be documented in this file.
 - Fix unmatched braces causing compile errors in AllocationTargetsTableView
 - Simplify row background colors so valid rows are white
 - Add script to export Instruments table to XLSX
+- Include TargetAllocation and ExchangeRates tables in transaction backup/restore

--- a/DragonShield/BackupService.swift
+++ b/DragonShield/BackupService.swift
@@ -27,7 +27,8 @@ class BackupService: ObservableObject {
         "Configuration", "Currencies", "ExchangeRates", "FxRateUpdates",
         "AssetClasses", "AssetSubClasses", "Instruments", "Portfolios",
         "PortfolioInstruments", "AccountTypes", "Institutions", "Accounts",
-        "TransactionTypes", "Transactions", "ImportSessions", "PositionReports"
+        "TransactionTypes", "Transactions", "ImportSessions", "PositionReports",
+        "TargetAllocation"
     ]
 
     let referenceTables = [
@@ -38,7 +39,8 @@ class BackupService: ObservableObject {
 
     let transactionTables = [
         "Portfolios", "PortfolioInstruments", "Transactions",
-        "PositionReports", "ImportSessions"
+        "PositionReports", "ImportSessions", "ExchangeRates",
+        "TargetAllocation"
     ]
 
     init() {


### PR DESCRIPTION
## Summary
- include `TargetAllocation` table in full/transaction backup lists
- include `ExchangeRates` table when backing up transaction data
- document the new backup coverage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687bcf6a1b8c83238d6b9cc4abf92815