### PR TITLE
Add transaction table selection for backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Prompt to delete existing ZKB positions when importing statements
 - Delete existing ZKB positions by name or BIC before import and log removed count
 - Update ZKB deletion to use BIC `ZKBKCHZZ80A` and correct institution name
+- Allow selecting tables for transaction backups and restores with versioned filename
 - Allow deleting PositionReports for a selected institution when importing ZKB statements
 - Alert when an unknown instrument is encountered during import
 - Fix ZKB CSV import assigning Equate Plus institution and zero quantities


### PR DESCRIPTION
## Summary
- add helper for transaction backup filenames
- support table lists when backing up or restoring transactions
- add table selection sheets in `DatabaseManagementView`
- document change in changelog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687be329405083239b3ac078a7fcb877