### PR TITLE
Add Import Session History view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Allow deleting PositionReports for a selected institution when importing ZKB statements
 - Alert when an unknown instrument is encountered during import
 - Fix ZKB CSV import assigning Equate Plus institution and zero quantities
+- Add Import Session History view to review past import sessions
 - Fix type mismatch when selecting parser for statement import
 - Robust ZKB instrument discovery using Valor, ISIN and ticker with logging
 - Visualize target vs actual allocations with dual-ring donut chart and delta bar layout in Allocation Targets view

--- a/DragonShield/DatabaseManager+ImportSessionsFetch.swift
+++ b/DragonShield/DatabaseManager+ImportSessionsFetch.swift
@@ -1,0 +1,113 @@
+import SQLite3
+import Foundation
+
+extension DatabaseManager {
+    struct ImportSessionData: Identifiable, Equatable {
+        var id: Int
+        var sessionName: String
+        var fileName: String
+        var filePath: String?
+        var fileType: String
+        var fileSize: Int
+        var fileHash: String?
+        var institutionId: Int?
+        var importStatus: String
+        var totalRows: Int
+        var successfulRows: Int
+        var failedRows: Int
+        var duplicateRows: Int
+        var errorLog: String?
+        var processingNotes: String?
+        var createdAt: Date
+        var startedAt: Date?
+        var completedAt: Date?
+    }
+
+    func fetchImportSessions() -> [ImportSessionData] {
+        let sql = """
+            SELECT import_session_id, session_name, file_name, file_path, file_type,
+                   file_size, file_hash, institution_id, import_status, total_rows,
+                   successful_rows, failed_rows, duplicate_rows, error_log,
+                   processing_notes, created_at, started_at, completed_at
+              FROM ImportSessions
+             ORDER BY created_at DESC;
+            """
+        var stmt: OpaquePointer?
+        var sessions: [ImportSessionData] = []
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                let id = Int(sqlite3_column_int(stmt, 0))
+                let name = String(cString: sqlite3_column_text(stmt, 1))
+                let fileName = String(cString: sqlite3_column_text(stmt, 2))
+                let filePath = sqlite3_column_text(stmt, 3).map { String(cString: $0) }
+                let fileType = String(cString: sqlite3_column_text(stmt, 4))
+                let fileSize = Int(sqlite3_column_int(stmt, 5))
+                let fileHash = sqlite3_column_text(stmt, 6).map { String(cString: $0) }
+                let instId = sqlite3_column_type(stmt, 7) != SQLITE_NULL ? Int(sqlite3_column_int(stmt, 7)) : nil
+                let status = String(cString: sqlite3_column_text(stmt, 8))
+                let totalRows = Int(sqlite3_column_int(stmt, 9))
+                let successRows = Int(sqlite3_column_int(stmt, 10))
+                let failedRows = Int(sqlite3_column_int(stmt, 11))
+                let dupRows = Int(sqlite3_column_int(stmt, 12))
+                let errorLog = sqlite3_column_text(stmt, 13).map { String(cString: $0) }
+                let notes = sqlite3_column_text(stmt, 14).map { String(cString: $0) }
+                let createdStr = String(cString: sqlite3_column_text(stmt, 15))
+                let startedStr = sqlite3_column_text(stmt, 16).map { String(cString: $0) }
+                let completedStr = sqlite3_column_text(stmt, 17).map { String(cString: $0) }
+                let createdAt = DateFormatter.iso8601DateTime.date(from: createdStr) ?? Date()
+                let startedAt = startedStr.flatMap { DateFormatter.iso8601DateTime.date(from: $0) }
+                let completedAt = completedStr.flatMap { DateFormatter.iso8601DateTime.date(from: $0) }
+                sessions.append(ImportSessionData(
+                    id: id,
+                    sessionName: name,
+                    fileName: fileName,
+                    filePath: filePath,
+                    fileType: fileType,
+                    fileSize: fileSize,
+                    fileHash: fileHash,
+                    institutionId: instId,
+                    importStatus: status,
+                    totalRows: totalRows,
+                    successfulRows: successRows,
+                    failedRows: failedRows,
+                    duplicateRows: dupRows,
+                    errorLog: errorLog,
+                    processingNotes: notes,
+                    createdAt: createdAt,
+                    startedAt: startedAt,
+                    completedAt: completedAt
+                ))
+            }
+        } else {
+            print("❌ Failed to prepare fetchImportSessions: \(String(cString: sqlite3_errmsg(db)))")
+        }
+        sqlite3_finalize(stmt)
+        return sessions
+    }
+
+    func totalReportValue(for sessionId: Int) -> Double {
+        let sql = """
+            SELECT SUM(pr.quantity * COALESCE(pr.current_price,0) *
+                CASE WHEN instr.currency = 'CHF' THEN 1
+                     ELSE COALESCE((SELECT rate_to_chf FROM ExchangeRates
+                                      WHERE currency_code = instr.currency
+                                      ORDER BY rate_date DESC LIMIT 1),1)
+                END)
+              FROM PositionReports pr
+              JOIN Instruments instr ON pr.instrument_id = instr.instrument_id
+             WHERE pr.import_session_id = ?;
+            """
+        var stmt: OpaquePointer?
+        var total: Double = 0
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            sqlite3_bind_int(stmt, 1, Int32(sessionId))
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                total = sqlite3_column_double(stmt, 0)
+            }
+        } else {
+            print("❌ Failed to prepare totalReportValue: \(String(cString: sqlite3_errmsg(db)))")
+        }
+        sqlite3_finalize(stmt)
+        return total
+    }
+}

--- a/DragonShield/ViewModels/ImportSessionHistoryViewModel.swift
+++ b/DragonShield/ViewModels/ImportSessionHistoryViewModel.swift
@@ -1,0 +1,22 @@
+import Foundation
+import SwiftUI
+
+class ImportSessionHistoryViewModel: ObservableObject {
+    @Published var sessions: [SessionRow] = []
+
+    struct SessionRow: Identifiable, Equatable {
+        var data: DatabaseManager.ImportSessionData
+        var totalValue: Double
+        var id: Int { data.id }
+    }
+
+    func load(db: DatabaseManager) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            let rows = db.fetchImportSessions()
+            let result = rows.map { SessionRow(data: $0, totalValue: db.totalReportValue(for: $0.id)) }
+            DispatchQueue.main.async {
+                self.sessions = result
+            }
+        }
+    }
+}

--- a/DragonShield/Views/ImportSessionHistoryView.swift
+++ b/DragonShield/Views/ImportSessionHistoryView.swift
@@ -1,0 +1,110 @@
+import SwiftUI
+
+struct ImportSessionHistoryView: View {
+    @EnvironmentObject var dbManager: DatabaseManager
+    @StateObject private var vm = ImportSessionHistoryViewModel()
+    @State private var selected = Set<Int>()
+    @State private var detail: ImportSessionHistoryViewModel.SessionRow? = nil
+
+    private let chfFormatter: NumberFormatter = {
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        f.maximumFractionDigits = 0
+        f.groupingSeparator = "'"
+        f.usesGroupingSeparator = true
+        return f
+    }()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Table(vm.sessions, selection: $selected) {
+                TableColumn("Import Date") { row in
+                    Text(row.data.createdAt, formatter: DateFormatter.iso8601DateTime)
+                }
+                TableColumn("Session Name") { row in
+                    Text(row.data.sessionName)
+                }
+                TableColumn("Import Status") { row in
+                    Text(row.data.importStatus)
+                }
+                TableColumn("Total Rows") { row in
+                    Text(String(row.data.totalRows))
+                }
+                TableColumn("Successful Rows") { row in
+                    Text(String(row.data.successfulRows))
+                }
+                TableColumn("Failed Rows") { row in
+                    Text(String(row.data.failedRows))
+                }
+                TableColumn("Total Report Value") { row in
+                    Text(chfFormatter.string(from: NSNumber(value: row.totalValue)) ?? "0")
+                }
+                TableColumn("Actions") { row in
+                    Button("Details") { detail = row }
+                        .buttonStyle(PlainButtonStyle())
+                }
+            }
+            .tableStyle(.inset(alternatesRowBackgrounds: true))
+            .onAppear { vm.load(db: dbManager) }
+        }
+        .padding(24)
+        .background(Theme.surface)
+        .cornerRadius(8)
+        .sheet(item: $detail) { item in
+            ImportSessionDetailView(session: item.data)
+        }
+    }
+}
+
+private struct ImportSessionDetailView: View {
+    var session: DatabaseManager.ImportSessionData
+    @Environment(\.dismiss) var dismiss
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 8) {
+                detailRow("Session Name", session.sessionName)
+                detailRow("File Name", session.fileName)
+                if let path = session.filePath { detailRow("File Path", path) }
+                detailRow("File Type", session.fileType)
+                detailRow("File Size", String(session.fileSize))
+                if let hash = session.fileHash { detailRow("File Hash", hash) }
+                if let id = session.institutionId { detailRow("Institution ID", String(id)) }
+                detailRow("Status", session.importStatus)
+                detailRow("Total Rows", String(session.totalRows))
+                detailRow("Successful Rows", String(session.successfulRows))
+                detailRow("Failed Rows", String(session.failedRows))
+                detailRow("Duplicate Rows", String(session.duplicateRows))
+                if let log = session.errorLog { detailRow("Error Log", log) }
+                if let notes = session.processingNotes { detailRow("Notes", notes) }
+                detailRow("Created", DateFormatter.iso8601DateTime.string(from: session.createdAt))
+                if let s = session.startedAt { detailRow("Started", DateFormatter.iso8601DateTime.string(from: s)) }
+                if let c = session.completedAt { detailRow("Completed", DateFormatter.iso8601DateTime.string(from: c)) }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding()
+        }
+        .frame(width: 450, height: 500)
+        .overlay(alignment: .topTrailing) {
+            Button("Close") { dismiss() }
+                .padding(8)
+        }
+    }
+
+    private func detailRow(_ label: String, _ value: String) -> some View {
+        HStack(alignment: .top) {
+            Text(label + ":")
+                .fontWeight(.semibold)
+            Spacer()
+            Text(value)
+                .multilineTextAlignment(.trailing)
+        }
+    }
+}
+
+struct ImportSessionHistoryView_Previews: PreviewProvider {
+    static var previews: some View {
+        ImportSessionHistoryView()
+            .environmentObject(DatabaseManager())
+    }
+}

--- a/DragonShield/Views/SidebarView.swift
+++ b/DragonShield/Views/SidebarView.swift
@@ -87,6 +87,10 @@ struct SidebarView: View {
                 NavigationLink(destination: DataImportExportView()) {
                     Label("Data Import/Export", systemImage: "square.and.arrow.up.on.square")
                 }
+
+                NavigationLink(destination: ImportSessionHistoryView()) {
+                    Label("Import Session History", systemImage: "clock.arrow.circlepath")
+                }
                 
                 NavigationLink(destination: DatabaseManagementView()) {
                     Label("Database Management", systemImage: "externaldrive.badge.timemachine")


### PR DESCRIPTION
## Summary
- implement `ImportSessionData` and supporting DB helpers
- add Import Session History view model and view
- link new view from sidebar
- document the feature in the changelog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas)*

------
https://chatgpt.com/codex/tasks/task_e_687cac2b01f083238f515b42c563231c