### PR TITLE
feat(import): improve Credit-Suisse instrument lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -326,3 +326,4 @@ All notable changes to this project will be documented in this file.
 - Simplify row background colors so valid rows are white
 - Add script to export Instruments table to XLSX
 - Include TargetAllocation and ExchangeRates tables in transaction backup/restore
+- Robust Credit-Suisse instrument lookup using Valor and ISIN with logging

--- a/DragonShield/Views/DataImportExportView.swift
+++ b/DragonShield/Views/DataImportExportView.swift
@@ -95,7 +95,7 @@ struct DataImportExportView: View {
     }
 
     private var creditSuisseCard: some View {
-        importCard(title: "Import Credit-Suisse Statement", type: .creditSuisse, enabled: true)
+        importCard(title: "Import Credit-Suisse Statement (Position List M DD YYYY.xls)", type: .creditSuisse, enabled: true)
     }
 
     private var zkbCard: some View {

--- a/DragonShield/docs/UX_UI_concept/data_import_export_view.md
+++ b/DragonShield/docs/UX_UI_concept/data_import_export_view.md
@@ -18,7 +18,7 @@ Two cards share the width equally. Each provides drag & drop upload and a file p
 | Credit-Suisse Card | ZKB Card |
 | --- | --- |
 | 48×48 px logo icon | 48×48 px logo icon |
-| Heading: **Import Credit-Suisse Statement** | Heading: **Import ZKB Statement** |
+| Heading: **Import Credit-Suisse Statement (Position List M DD YYYY.xls)** | Heading: **Import ZKB Statement** |
 | Drag & Drop zone, 120 px tall with dashed border and 6 px radius. Centered icon and hint text `Drag & Drop Credit-Suisse File` (`13 pt`, `#888`). | Same style. Text `Drag & Drop ZKB File` and highlight on hover. Disabled until parser is ready. |
 | "or" separator (`12 pt`, `#AAA`) | "or" separator |
 | `Select File` button (`32 px` high, outline style, fills on hover) | `Select File` button (disabled with tooltip "coming soon") |

--- a/tests/test_instrument_lookup.py
+++ b/tests/test_instrument_lookup.py
@@ -1,0 +1,54 @@
+import sys
+import types
+import sqlite3
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / 'DragonShield' / 'python_scripts'
+sys.path.insert(0, str(SCRIPT_DIR))
+
+# stub openpyxl for import
+openpyxl_stub = types.ModuleType('openpyxl')
+cell_mod = types.ModuleType('cell')
+class Cell: ...
+class MergedCell: ...
+cell_mod.Cell = Cell
+cell_mod.MergedCell = MergedCell
+openpyxl_stub.cell = cell_mod
+sys.modules.setdefault('openpyxl', openpyxl_stub)
+sys.modules.setdefault('openpyxl.cell', openpyxl_stub.cell)
+
+import credit_suisse_parser as csp
+
+
+def setup_db():
+    conn = sqlite3.connect(':memory:')
+    conn.execute(
+        'CREATE TABLE Instruments (instrument_id INTEGER PRIMARY KEY, isin TEXT, valor_nr TEXT)'
+    )
+    conn.execute("INSERT INTO Instruments VALUES (1, 'US0000001', '1111')")
+    conn.execute("INSERT INTO Instruments VALUES (2, 'CH1234567890', 'ABC678')")
+    return conn
+
+
+def test_lookup_by_valor():
+    conn = setup_db()
+    logs = []
+    result = csp.lookup_instrument(conn, 'ABC 678', '', 'Test', logs)
+    assert result == 2
+    assert 'via valor' in logs[0]
+
+
+def test_lookup_fallback_isin():
+    conn = setup_db()
+    logs = []
+    result = csp.lookup_instrument(conn, '', 'US0000001', 'Foo', logs)
+    assert result == 1
+    assert 'via ISIN' in logs[0]
+
+
+def test_lookup_unmatched():
+    conn = setup_db()
+    logs = []
+    result = csp.lookup_instrument(conn, '9999', 'NOPE', 'Unknown', logs)
+    assert result is None
+    assert 'Unmatched instrument description' in logs[0]


### PR DESCRIPTION
## Summary
- enhance credit_suisse_parser with Valor/ISIN database lookup and per-row logging
- show sample file name on Credit‑Suisse import card
- update UX docs with new heading text
- add tests for instrument lookup helper
- document change in changelog
- organize imports in parser

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687cbaa705948323a33e5c37b90010a5