### PR TITLE
Fix ImportSessionHistoryView compile error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 - Fix duplicate IDs in import summary logs to avoid SwiftUI warnings
 - Avoid duplicate IDs in backup and import logs
 - Fix compile error from private `chfFormatter` in ImportSessionHistoryView
+- Add Import Session History link in sidebar navigation
 - Show correct database version in startup log
 - Fix seed data to include valor numbers in Instruments table
 - Replace instrument seed data with Consolidated_Instruments_V8.xlsx for updated test dataset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - Resolve build error by replacing onTapGesture with overlay gesture in donut chart
 - Fix duplicate IDs in import summary logs to avoid SwiftUI warnings
 - Avoid duplicate IDs in backup and import logs
+- Fix compile error from private `chfFormatter` in ImportSessionHistoryView
 - Show correct database version in startup log
 - Fix seed data to include valor numbers in Instruments table
 - Replace instrument seed data with Consolidated_Instruments_V8.xlsx for updated test dataset

--- a/DragonShield/Views/ImportSessionHistoryView.swift
+++ b/DragonShield/Views/ImportSessionHistoryView.swift
@@ -7,7 +7,7 @@ struct ImportSessionHistoryView: View {
     @State private var selected: DatabaseManager.ImportSessionData? = nil
     @State private var showDetails = false
 
-    private static let chfFormatter: NumberFormatter = {
+    static let chfFormatter: NumberFormatter = {
         let f = NumberFormatter()
         f.numberStyle = .currency
         f.currencyCode = "CHF"

--- a/DragonShield/Views/SidebarView.swift
+++ b/DragonShield/Views/SidebarView.swift
@@ -87,7 +87,11 @@ struct SidebarView: View {
                 NavigationLink(destination: DataImportExportView()) {
                     Label("Data Import/Export", systemImage: "square.and.arrow.up.on.square")
                 }
-                
+
+                NavigationLink(destination: ImportSessionHistoryView()) {
+                    Label("Import Session History", systemImage: "clock.arrow.circlepath")
+                }
+
                 NavigationLink(destination: DatabaseManagementView()) {
                     Label("Database Management", systemImage: "externaldrive.badge.timemachine")
                 }


### PR DESCRIPTION
## Summary
- expose `chfFormatter` so nested row views can access it
- update changelog

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687ccc8380fc83239bedc0a7615f04e5