### PR TITLE
Add instrument lookup to Credit-Suisse parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 - Display sub-class aggregate totals with delta validation in Allocation Targets table
 - Fix compile error from variable name clash in AllocationTargetsTableView
 - Shrink Data Import/Export panels and show square drag-and-drop area
+- Enhance Credit-Suisse parser with Valor/ISIN instrument matching and detailed logs
+- Clarify Credit-Suisse import card description with expected filename format
 - Add Import Session History tab with per-session totals
 - Add ZKB CSV import parser and enable ZKB statements in Data Import/Export view
 - Fix compile error when passing statement type to ImportManager

--- a/DragonShield/Views/DataImportExportView.swift
+++ b/DragonShield/Views/DataImportExportView.swift
@@ -95,7 +95,7 @@ struct DataImportExportView: View {
     }
 
     private var creditSuisseCard: some View {
-        importCard(title: "Import Credit-Suisse Statement", type: .creditSuisse, enabled: true)
+        importCard(title: "Import Credit-Suisse Statement (Position List M DD YYYY.xls)", type: .creditSuisse, enabled: true)
     }
 
     private var zkbCard: some View {

--- a/tests/test_credit_suisse_parser_lookup.py
+++ b/tests/test_credit_suisse_parser_lookup.py
@@ -1,0 +1,53 @@
+import sqlite3
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / 'DragonShield' / 'python_scripts'
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import types
+openpyxl_stub = types.ModuleType('openpyxl')
+cell_mod = types.ModuleType('cell')
+class Cell: ...
+class MergedCell: ...
+cell_mod.Cell = Cell
+cell_mod.MergedCell = MergedCell
+openpyxl_stub.cell = cell_mod
+sys.modules.setdefault('openpyxl', openpyxl_stub)
+sys.modules.setdefault('openpyxl.cell', openpyxl_stub.cell)
+
+from credit_suisse_parser import lookup_instrument
+
+
+def setup_conn():
+    conn = sqlite3.connect(':memory:')
+    conn.execute(
+        """
+        CREATE TABLE Instruments (
+            instrument_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            isin TEXT UNIQUE,
+            valor_nr TEXT UNIQUE,
+            instrument_name TEXT
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO Instruments (isin, valor_nr, instrument_name) VALUES ('CH000001', '123456', 'Test')"
+    )
+    return conn
+
+
+def test_lookup_by_valor():
+    conn = setup_conn()
+    ins_id, name, method = lookup_instrument(conn, '123456', None)
+    assert ins_id == 1
+    assert method == 'Valor'
+    conn.close()
+
+
+def test_lookup_by_isin():
+    conn = setup_conn()
+    ins_id, name, method = lookup_instrument(conn, None, 'CH000001')
+    assert ins_id == 1
+    assert method == 'ISIN'
+    conn.close()


### PR DESCRIPTION
## Summary
- add Valor/ISIN matching logic with row-level logging in `credit_suisse_parser.py`
- add unmatched instrument counter to summary and close DB connection
- update Credit-Suisse import card text in DataImportExportView
- document changes in CHANGELOG
- unit test for instrument lookup helper

## Testing
- `pytest tests/test_credit_suisse_parser_lookup.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687cdc5f7fa48323b22b06646c16a4a3