### PR TITLE
Fix percentage handling for bond prices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Delete existing ZKB positions by name or BIC before import and log removed count
 - Update ZKB deletion to use BIC `ZKBKCHZZ80A` and correct institution name
 - Handle percent-valued bond prices in ZKB CSV import
+- Convert percent-valued bond prices in Credit-Suisse XLS import
 - Allow selecting tables for transaction backups and restores with versioned filename
 - Allow deleting PositionReports for a selected institution when importing ZKB statements
 - Alert when an unknown instrument is encountered during import

--- a/DragonShield/CreditSuisseXLSXProcessor.swift
+++ b/DragonShield/CreditSuisseXLSXProcessor.swift
@@ -111,9 +111,10 @@ struct CreditSuisseXLSXProcessor {
     }
 
     static func parseNumber(_ string: String) -> Double? {
-        var cleaned = string.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !cleaned.isEmpty else { return nil }
-        cleaned = cleaned
+        var trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let isPercent = trimmed.hasSuffix("%") || trimmed.hasSuffix(" %")
+        var cleaned = trimmed
             .replacingOccurrences(of: "'", with: "")
             .replacingOccurrences(of: "’", with: "")
             .replacingOccurrences(of: "%", with: "")
@@ -123,7 +124,8 @@ struct CreditSuisseXLSXProcessor {
             cleaned.removeFirst(); cleaned.removeLast()
             cleaned = "-" + cleaned
         }
-        return Double(cleaned)
+        guard let value = Double(cleaned) else { return nil }
+        return isPercent ? value / 100.0 : value
     }
 
     static func statementDate(from filename: String) -> Date? {


### PR DESCRIPTION
## Summary
- update number parser for Credit-Suisse XLS import to support trailing `%`
- note the new behaviour in the changelog

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687d41bb7f308323a401b60db7596098