### PR TITLE
fix(parser): store cash account positions via valor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Store Credit-Suisse cash account balances using the Valor as instrument with price 1
 - Generate full instrument report from Database Management view
 - Improve Credit-Suisse parser instrument matching via Valor/ISIN with row-level logging of Valor and ISIN
 - Log Valor and ISIN for each parsed Credit-Suisse row and store valor numbers

--- a/DragonShield/ImportManager.swift
+++ b/DragonShield/ImportManager.swift
@@ -376,7 +376,7 @@ class ImportManager {
                 var unmatched = 0
                 for parsed in rows {
                     if parsed.isCash {
-                        let accNumber = parsed.tickerSymbol ?? ""
+                        let accNumber = parsed.valorNr ?? ""
                         var accId = self.dbManager.findAccountId(accountNumber: accNumber)
                         if accId == nil {
                             var proceed = true
@@ -405,15 +405,15 @@ class ImportManager {
                             }
                         }
                         if let aId = accId,
-                           let instrId = self.dbManager.findInstrumentId(ticker: "\(parsed.currency.uppercased())_CASH") {
+                           let instrId = self.dbManager.findInstrumentId(valorNr: parsed.valorNr ?? "") {
                             _ = self.dbManager.addPositionReport(
                                 importSessionId: sessionId,
                                 accountId: aId,
                                 institutionId: institutionId,
                                 instrumentId: instrId,
                                 quantity: parsed.quantity,
-                                purchasePrice: nil,
-                                currentPrice: nil,
+                                purchasePrice: 1,
+                                currentPrice: 1,
                                 instrumentUpdatedAt: parsed.reportDate,
                                 notes: nil,
                                 reportDate: parsed.reportDate


### PR DESCRIPTION
## Summary
- store Credit-Suisse cash account positions using the valor as the instrument
- default purchase and current price to 1 for cash holdings
- document change in CHANGELOG

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'DragonShield', ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687d49d5c0988323bd812aae50daf5ee