### PR TITLE
feat(parser): record cash accounts from Credit-Suisse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Convert percent-valued bond prices in Credit-Suisse XLS import
 - Save cash account balances from Credit-Suisse statements into PositionReports
 - Fix storing cash account balances when account or instrument lookup fails
+- Log detailed messages when processing cash account rows and report failures
 - Allow selecting tables for transaction backups and restores with versioned filename
 - Allow deleting PositionReports for a selected institution when importing ZKB statements
 - Alert when an unknown instrument is encountered during import

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Fix storing cash account balances when account or instrument lookup fails
 - Log row numbers and failure reasons when processing cash account rows
 - Fix cash account instrument lookup by currency code
+- Sanitize ticker lookup so CASHCHF resolves correctly
 - Allow selecting tables for transaction backups and restores with versioned filename
 - Allow deleting PositionReports for a selected institution when importing ZKB statements
 - Alert when an unknown instrument is encountered during import

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -335,3 +335,4 @@ All notable changes to this project will be documented in this file.
 - Simplify row background colors so valid rows are white
 - Add script to export Instruments table to XLSX
 - Include TargetAllocation and ExchangeRates tables in transaction backup/restore
+- Fix account lookup by valor when importing cash account balances with detailed logging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - Handle percent-valued bond prices in ZKB CSV import
 - Convert percent-valued bond prices in Credit-Suisse XLS import
 - Save cash account balances from Credit-Suisse statements into PositionReports
+- Fix storing cash account balances when account or instrument lookup fails
 - Allow selecting tables for transaction backups and restores with versioned filename
 - Allow deleting PositionReports for a selected institution when importing ZKB statements
 - Alert when an unknown instrument is encountered during import

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - Save cash account balances from Credit-Suisse statements into PositionReports
 - Fix storing cash account balances when account or instrument lookup fails
 - Log row numbers and failure reasons when processing cash account rows
+- Fix cash account instrument lookup by currency code
 - Allow selecting tables for transaction backups and restores with versioned filename
 - Allow deleting PositionReports for a selected institution when importing ZKB statements
 - Alert when an unknown instrument is encountered during import

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to this project will be documented in this file.
 - Convert percent-valued bond prices in Credit-Suisse XLS import
 - Save cash account balances from Credit-Suisse statements into PositionReports
 - Fix storing cash account balances when account or instrument lookup fails
-- Log detailed messages when processing cash account rows and report failures
+- Log row numbers and failure reasons when processing cash account rows
 - Allow selecting tables for transaction backups and restores with versioned filename
 - Allow deleting PositionReports for a selected institution when importing ZKB statements
 - Alert when an unknown instrument is encountered during import

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Update ZKB deletion to use BIC `ZKBKCHZZ80A` and correct institution name
 - Handle percent-valued bond prices in ZKB CSV import
 - Convert percent-valued bond prices in Credit-Suisse XLS import
+- Save cash account balances from Credit-Suisse statements into PositionReports
 - Allow selecting tables for transaction backups and restores with versioned filename
 - Allow deleting PositionReports for a selected institution when importing ZKB statements
 - Alert when an unknown instrument is encountered during import

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 - Visualize target vs actual allocations with dual-ring donut chart and delta bar layout in Allocation Targets view
 - Remove outdated Asset Allocation view and sidebar link
 - Move Target Asset Allocation link to Key Features section
+- Fix compile warnings for immutable variables in import processing
 - Fix compile error in allocation charts by importing Charts framework
 - Resolve build error by replacing onTapGesture with overlay gesture in donut chart
 - Fix duplicate IDs in import summary logs to avoid SwiftUI warnings

--- a/DragonShield/CreditSuisseXLSXProcessor.swift
+++ b/DragonShield/CreditSuisseXLSXProcessor.swift
@@ -111,7 +111,7 @@ struct CreditSuisseXLSXProcessor {
     }
 
     static func parseNumber(_ string: String) -> Double? {
-        var trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
         let isPercent = trimmed.hasSuffix("%") || trimmed.hasSuffix(" %")
         var cleaned = trimmed

--- a/DragonShield/ImportManager.swift
+++ b/DragonShield/ImportManager.swift
@@ -397,6 +397,7 @@ class ImportManager {
                             if let mapping = Self.cashValorMap[sanitized],
                                parsed.instrumentName.lowercased().contains("konto") ||
                                parsed.instrumentName.lowercased().contains("call account") {
+                                LoggingService.shared.log("Processing cash account valor \(sanitized)", type: .debug, logger: .parser)
                                 guard let aId = self.dbManager.findAccountId(valor: val) else {
                                     LoggingService.shared.log("Cash account valor \(sanitized) not found", type: .error, logger: .parser)
                                     continue
@@ -423,7 +424,11 @@ class ImportManager {
                                     LoggingService.shared.log("Failed to record cash account \(mapping.ticker)", type: .error, logger: .parser)
                                 }
                                 continue
+                            } else {
+                                LoggingService.shared.log("Valor \(sanitized) not recognized as cash account", type: .debug, logger: .parser)
                             }
+                        } else {
+                            LoggingService.shared.log("Cash account row missing valor", type: .error, logger: .parser)
                         }
                         let accNumber = parsed.tickerSymbol ?? ""
                         var accId = self.dbManager.findAccountId(accountNumber: accNumber)

--- a/DragonShield/ImportManager.swift
+++ b/DragonShield/ImportManager.swift
@@ -390,20 +390,20 @@ class ImportManager {
                 var success = 0
                 let failure = 0
                 var unmatched = 0
-                for parsed in rows {
+                for (idx, parsed) in rows.enumerated() {
                     if parsed.isCash {
                         if let val = parsed.valorNr {
                             let sanitized = Self.sanitizeValor(val)
                             if let mapping = Self.cashValorMap[sanitized],
                                parsed.instrumentName.lowercased().contains("konto") ||
                                parsed.instrumentName.lowercased().contains("call account") {
-                                LoggingService.shared.log("Processing cash account valor \(sanitized)", type: .debug, logger: .parser)
+                                LoggingService.shared.log("Processing cash account row \(idx+1) valor \(sanitized)", type: .debug, logger: .parser)
                                 guard let aId = self.dbManager.findAccountId(valor: val) else {
-                                    LoggingService.shared.log("Cash account valor \(sanitized) not found", type: .error, logger: .parser)
+                                    LoggingService.shared.log("Row \(idx+1) skipped - account for valor \(sanitized) not found", type: .error, logger: .parser)
                                     continue
                                 }
                                 guard let instrId = self.dbManager.findInstrumentId(ticker: mapping.ticker) else {
-                                    LoggingService.shared.log("Instrument \(mapping.ticker) missing", type: .error, logger: .parser)
+                                    LoggingService.shared.log("Row \(idx+1) skipped - instrument \(mapping.ticker) missing", type: .error, logger: .parser)
                                     continue
                                 }
                                 if self.dbManager.addPositionReport(
@@ -418,17 +418,17 @@ class ImportManager {
                                     notes: nil,
                                     reportDate: parsed.reportDate
                                 ) != nil {
-                                    LoggingService.shared.log("Cash Account \(mapping.ticker) recorded", type: .info, logger: .parser)
+                                    LoggingService.shared.log("Cash Account \(mapping.ticker) recorded for row \(idx+1)", type: .info, logger: .parser)
                                     success += 1
                                 } else {
-                                    LoggingService.shared.log("Failed to record cash account \(mapping.ticker)", type: .error, logger: .parser)
+                                    LoggingService.shared.log("Row \(idx+1) failed to insert cash account \(mapping.ticker)", type: .error, logger: .parser)
                                 }
                                 continue
                             } else {
-                                LoggingService.shared.log("Valor \(sanitized) not recognized as cash account", type: .debug, logger: .parser)
+                                LoggingService.shared.log("Row \(idx+1) valor \(sanitized) not recognized as cash account", type: .debug, logger: .parser)
                             }
                         } else {
-                            LoggingService.shared.log("Cash account row missing valor", type: .error, logger: .parser)
+                            LoggingService.shared.log("Row \(idx+1) cash account missing valor", type: .error, logger: .parser)
                         }
                         let accNumber = parsed.tickerSymbol ?? ""
                         var accId = self.dbManager.findAccountId(accountNumber: accNumber)

--- a/DragonShield/ImportManager.swift
+++ b/DragonShield/ImportManager.swift
@@ -487,10 +487,10 @@ class ImportManager {
                         if case .abort = action { throw ImportError.aborted }
                         continue
                     }
-                    var instrumentId = self.lookupInstrumentId(name: row.instrumentName,
-                                                                valor: row.valorNr,
-                                                                isin: row.isin,
-                                                                ticker: row.tickerSymbol)
+                    let instrumentId = self.lookupInstrumentId(name: row.instrumentName,
+                                                               valor: row.valorNr,
+                                                               isin: row.isin,
+                                                               ticker: row.tickerSymbol)
                     if instrumentId == nil {
                         unmatched += 1
                         var proceed = true


### PR DESCRIPTION
## Summary
- detect cash account valor codes when importing Credit-Suisse positions
- save these rows directly into PositionReports
- add helper to find accounts by valor number

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'DragonShield')*

------
https://chatgpt.com/codex/tasks/task_e_687dbcb009808323b5e94566a388ad43