### PR TITLE
Add import session value summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Generate full instrument report from Database Management view
+- Store import session total value and add CLI summary report
 - Improve Credit-Suisse parser instrument matching via Valor/ISIN with row-level logging of Valor and ISIN
 - Log Valor and ISIN for each parsed Credit-Suisse row and store valor numbers
 - Fix instrument report generation by locating script path correctly

--- a/DragonShield/ImportManager.swift
+++ b/DragonShield/ImportManager.swift
@@ -557,12 +557,14 @@ class ImportManager {
                 }
                 summary.unmatchedInstruments = unmatched
                 if let sid = sessionId {
+                    let total = self.dbManager.totalReportValueForSession(sid)
+                    let note = String(format: "total_value_chf=%.2f", total)
                     self.dbManager.completeImportSession(id: sid,
                                                        totalRows: summary.totalRows,
                                                        successRows: success,
                                                        failedRows: failure,
                                                        duplicateRows: 0,
-                                                       notes: "will be determined later")
+                                                       notes: note)
                 }
                 DispatchQueue.main.async {
                     completion(.success(summary))

--- a/DragonShield/python_scripts/import_session_report.py
+++ b/DragonShield/python_scripts/import_session_report.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Summarize values for an import session."""
+
+import argparse
+import sqlite3
+from typing import Any, Dict, List
+
+DB_PATH = (
+    "/Users/renekeller/Library/Containers/com.rene.DragonShield/Data/Library/Application Support/DragonShield"
+    "/dragonshield.sqlite"
+)
+
+
+def get_fx_rate(conn: sqlite3.Connection, currency: str, date: str) -> float | None:
+    cur = conn.execute(
+        """SELECT rate_to_chf FROM ExchangeRates
+           WHERE currency_code=? AND rate_date<=?
+           ORDER BY rate_date DESC LIMIT 1""",
+        (currency, date),
+    )
+    row = cur.fetchone()
+    return row[0] if row else None
+
+
+def fetch_positions(conn: sqlite3.Connection, session_id: int) -> List[Dict[str, Any]]:
+    query = """
+        SELECT i.instrument_name, i.currency, pr.quantity, pr.current_price, pr.report_date
+          FROM PositionReports pr
+          JOIN Instruments i ON pr.instrument_id = i.instrument_id
+         WHERE pr.import_session_id = ?;
+    """
+    rows = conn.execute(query, (session_id,)).fetchall()
+    result = []
+    for name, currency, qty, price, date in rows:
+        result.append(
+            {
+                "instrument": name,
+                "currency": currency,
+                "quantity": qty,
+                "price": price,
+                "date": date,
+            }
+        )
+    return result
+
+
+def summarize_positions(conn: sqlite3.Connection, positions: List[Dict[str, Any]]) -> Dict[str, Any]:
+    totals: Dict[str, float] = {}
+    items: List[Dict[str, Any]] = []
+    total_chf = 0.0
+    for p in positions:
+        price = p.get("price")
+        if price is None:
+            continue
+        qty = p.get("quantity", 0.0)
+        value = qty * price
+        currency = str(p.get("currency", "CHF")).upper()
+        rate = 1.0
+        if currency != "CHF":
+            r = get_fx_rate(conn, currency, p.get("date"))
+            if r is None:
+                continue
+            rate = r
+        value_chf = value * rate
+        items.append(
+            {
+                "instrument": p.get("instrument", ""),
+                "currency": currency,
+                "value_orig": value,
+                "value_chf": value_chf,
+            }
+        )
+        totals[currency] = totals.get(currency, 0.0) + value_chf
+        total_chf += value_chf
+    return {"total_chf": total_chf, "breakdown": totals, "positions": items}
+
+
+def save_total(conn: sqlite3.Connection, session_id: int, total: float) -> None:
+    note = f"total_value_chf={total:.2f}"
+    conn.execute(
+        "UPDATE ImportSessions SET processing_notes=? WHERE import_session_id=?",
+        (note, session_id),
+    )
+    conn.commit()
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Summarize import session values")
+    parser.add_argument("session_id", type=int, help="Import session id")
+    parser.add_argument("--db", default=DB_PATH, help="Path to database")
+    args = parser.parse_args(argv)
+
+    conn = sqlite3.connect(args.db)
+    positions = fetch_positions(conn, args.session_id)
+    summary = summarize_positions(conn, positions)
+    save_total(conn, args.session_id, summary["total_chf"])
+
+    print(f"Total value CHF: {summary['total_chf']:.2f}")
+    print("Breakdown by currency:")
+    for cur, val in summary["breakdown"].items():
+        print(f"  {cur}: {val:.2f} CHF")
+    print("Positions:")
+    for item in summary["positions"]:
+        print(
+            f"  {item['instrument']}: {item['value_orig']:.2f} {item['currency']} -> {item['value_chf']:.2f} CHF"
+        )
+    conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_import_session_report.py
+++ b/tests/test_import_session_report.py
@@ -1,0 +1,80 @@
+import sys
+import sqlite3
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / 'DragonShield' / 'python_scripts'
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import import_session_report as report
+
+
+def setup_db():
+    conn = sqlite3.connect(':memory:')
+    conn.execute(
+        """
+        CREATE TABLE ImportSessions (
+            import_session_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_name TEXT,
+            processing_notes TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE Instruments (
+            instrument_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            instrument_name TEXT,
+            currency TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE ExchangeRates (
+            currency_code TEXT,
+            rate_date TEXT,
+            rate_to_chf REAL
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE PositionReports (
+            position_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            import_session_id INTEGER,
+            account_id INTEGER,
+            institution_id INTEGER,
+            instrument_id INTEGER,
+            quantity REAL,
+            current_price REAL,
+            report_date TEXT
+        )
+        """
+    )
+    return conn
+
+
+def test_summary_and_save():
+    conn = setup_db()
+    conn.execute("INSERT INTO ImportSessions (session_name) VALUES ('test')")
+    conn.execute("INSERT INTO Instruments (instrument_name, currency) VALUES ('A', 'USD')")
+    conn.execute("INSERT INTO Instruments (instrument_name, currency) VALUES ('B', 'CHF')")
+    conn.execute("INSERT INTO ExchangeRates VALUES ('USD','2025-01-01',0.9)")
+    conn.execute(
+        "INSERT INTO PositionReports (import_session_id, account_id, institution_id, instrument_id, quantity, current_price, report_date) VALUES (1,1,1,1,10,5,'2025-01-01')"
+    )
+    conn.execute(
+        "INSERT INTO PositionReports (import_session_id, account_id, institution_id, instrument_id, quantity, current_price, report_date) VALUES (1,1,1,2,20,2,'2025-01-01')"
+    )
+    conn.commit()
+
+    positions = report.fetch_positions(conn, 1)
+    summary = report.summarize_positions(conn, positions)
+    assert round(summary['total_chf'], 2) == 85.0
+    assert summary['breakdown']['USD'] == 45.0
+    assert summary['breakdown']['CHF'] == 40.0
+
+    report.save_total(conn, 1, summary['total_chf'])
+    note = conn.execute('SELECT processing_notes FROM ImportSessions WHERE import_session_id=1').fetchone()[0]
+    assert 'total_value_chf=85.00' == note
+    conn.close()


### PR DESCRIPTION
## Summary
- store import session CHF value in notes
- provide `import_session_report.py` CLI to summarise imported position values
- test session value summary helper

## Testing
- `python3 -m pip install -r requirements.txt` *(fails: Could not find pysqlcipher3)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'DragonShield')*

------
https://chatgpt.com/codex/tasks/task_e_687e061aca5c8323a1967464d9a2733a