### PR TITLE
feat(import): persist value reports and fix session popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 - Generate full instrument report from Database Management view
 - Store import session total value and add CLI summary report
 - Show imported position values in CHF after import completes
+- Persist detailed value reports per import session and view them from history
 - Improve Credit-Suisse parser instrument matching via Valor/ISIN with row-level logging of Valor and ISIN
 - Log Valor and ISIN for each parsed Credit-Suisse row and store valor numbers
 - Fix instrument report generation by locating script path correctly

--- a/DragonShield/ImportManager.swift
+++ b/DragonShield/ImportManager.swift
@@ -566,6 +566,7 @@ class ImportManager {
                                                        duplicateRows: 0,
                                                        notes: note)
                     let items = self.dbManager.positionValuesForSession(sid)
+                    self.dbManager.saveSessionValues(sessionId: sid, values: items.map { ($0.instrument, $0.currency, $0.valueOrig, $0.valueChf) })
                     let lines = items.map {
                         String(format: "%@: %.2f %@ -> %.2f CHF",
                                $0.instrument, $0.valueOrig, $0.currency, $0.valueChf)

--- a/DragonShield/Views/ImportSessionHistoryView.swift
+++ b/DragonShield/Views/ImportSessionHistoryView.swift
@@ -164,6 +164,9 @@ private struct ImportSessionRowView: View {
 private struct ImportSessionDetailView: View {
     let session: DatabaseManager.ImportSessionData
     let totalValue: Double
+    @EnvironmentObject var dbManager: DatabaseManager
+    @Environment(\.dismiss) var dismiss
+    @State private var valueItems: [DatabaseManager.SessionValueItem] = []
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -190,15 +193,28 @@ private struct ImportSessionDetailView: View {
                     if let c = session.completedAt { Text("Completed: \(c.formatted())") }
                     Text("Total Value CHF: " + (ImportSessionHistoryView.chfFormatter.string(from: NSNumber(value: totalValue)) ?? "0"))
                 }
+                if !valueItems.isEmpty {
+                    Divider()
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Value Report")
+                            .font(.subheadline)
+                            .padding(.bottom, 2)
+                        ForEach(valueItems) { item in
+                            Text(String(format: "%@ - %.2f %@ -> %.2f CHF", item.instrumentName, item.valueOrig, item.currency, item.valueChf))
+                                .font(.system(size: 13, weight: .regular, design: .monospaced))
+                        }
+                    }
+                }
             }
             HStack {
                 Spacer()
-                Button("Close") { NSApp.keyWindow?.close() }
+                Button("Close") { dismiss() }
                     .buttonStyle(PrimaryButtonStyle())
             }
         }
         .padding(24)
         .frame(minWidth: 400, minHeight: 400)
+        .onAppear { valueItems = dbManager.fetchSessionValues(sessionId: session.id) }
     }
 }
 

--- a/DragonShield/database/schema.sql
+++ b/DragonShield/database/schema.sql
@@ -1,6 +1,4 @@
--- DragonShield/docs/schema.sql
--- Dragon Shield Database Creation Script
--- Version 4.16 - Add TargetAllocation table
+-- Version 4.17 - Add ImportSessionValues table
 -- Created: 2025-05-24
 -- Updated: 2025-07-13
 --
@@ -15,6 +13,7 @@
 -- - v4.8 -> v4.9: Introduced AssetClasses and AssetSubClasses tables.
 -- - v4.10 -> v4.11: Expanded Institutions with contact info and currency fields.
 -- - v4.11 -> v4.12: Added notes column to PositionReports table.
+-- - v4.16 -> v4.17: Added ImportSessionValues table.
 -- - (Previous history for v4.3 and earlier...)
 --
 
@@ -28,6 +27,7 @@ DROP VIEW IF EXISTS PortfolioSummary;
 DROP VIEW IF EXISTS Positions;
 
 DROP TABLE IF EXISTS PositionReports;
+DROP TABLE IF EXISTS ImportSessionValues;
 DROP TABLE IF EXISTS ImportSessions;
 DROP TABLE IF EXISTS Transactions;
 DROP TABLE IF EXISTS TransactionTypes;
@@ -358,6 +358,17 @@ CREATE TABLE PositionReports (
     FOREIGN KEY (account_id) REFERENCES Accounts(account_id),
     FOREIGN KEY (institution_id) REFERENCES Institutions(institution_id),
     FOREIGN KEY (instrument_id) REFERENCES Instruments(instrument_id)
+);
+
+CREATE TABLE ImportSessionValues (
+    value_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    import_session_id INTEGER NOT NULL,
+    instrument_name TEXT NOT NULL,
+    currency TEXT NOT NULL,
+    value_orig REAL NOT NULL,
+    value_chf REAL NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (import_session_id) REFERENCES ImportSessions(import_session_id)
 );
 
 -- Sample import sessions for testing

--- a/DragonShield/database/schema.txt
+++ b/DragonShield/database/schema.txt
@@ -29,7 +29,7 @@ INSERT INTO Configuration VALUES ('9', 'table_row_padding', '12.0', 'number', 'V
 INSERT INTO Configuration VALUES ('10', 'table_font_size', '14.0', 'number', 'Font size for text in data table rows (in points)', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('11', 'include_direct_re', 'true', 'boolean', 'Include direct real estate in allocation views', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('12', 'direct_re_target_chf', '0', 'number', 'Target CHF amount for direct real estate', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
-INSERT INTO Configuration VALUES ('13', 'db_version', '4.16', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
+INSERT INTO Configuration VALUES ('13', 'db_version', '4.17', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('CHF', 'Swiss Franc', 'CHF', '1', '0', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('EUR', 'Euro', '€', '1', '1', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('USD', 'US Dollar', '$', '1', '1', '2025-07-13 09:04:29', '2025-07-13 09:04:29');

--- a/DragonShield/test_data/reference_data.sql
+++ b/DragonShield/test_data/reference_data.sql
@@ -21,7 +21,7 @@ INSERT INTO Configuration VALUES ('9', 'table_row_padding', '12.0', 'number', 'V
 INSERT INTO Configuration VALUES ('10', 'table_font_size', '14.0', 'number', 'Font size for text in data table rows (in points)', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('11', 'include_direct_re', 'true', 'boolean', 'Include direct real estate in allocation views', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('12', 'direct_re_target_chf', '0', 'number', 'Target CHF amount for direct real estate', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
-INSERT INTO Configuration VALUES ('13', 'db_version', '4.16', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
+INSERT INTO Configuration VALUES ('13', 'db_version', '4.17', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 CREATE TABLE Currencies (
     currency_code TEXT PRIMARY KEY,
     currency_name TEXT NOT NULL,

--- a/tests/test_schema_version.py
+++ b/tests/test_schema_version.py
@@ -8,4 +8,4 @@ from deploy_db import parse_version
 
 def test_schema_version_updated():
     schema_path = Path(__file__).resolve().parents[1] / 'database' / 'schema.sql'
-    assert parse_version(str(schema_path)) == '4.16'
+    assert parse_version(str(schema_path)) == '4.17'


### PR DESCRIPTION
## Summary
- persist value report details in new `ImportSessionValues` table
- expose DB helpers to save and fetch session value reports
- save import value details after processing a statement
- show the value report in Import Session History details
- fix Close button on the details sheet
- bump schema version to 4.17 and adjust tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687e14b9d1388323af642710cd0074b0