### PR TITLE
feat(import): persist value reports and fix history view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Fix compile error from variable name clash in AllocationTargetsTableView
 - Shrink Data Import/Export panels and show square drag-and-drop area
 - Add Import Session History tab with per-session totals
+- Persist value import reports per session and view them from history
 - Add ZKB CSV import parser and enable ZKB statements in Data Import/Export view
 - Fix compile error when passing statement type to ImportManager
 - Prompt to delete existing ZKB positions when importing statements

--- a/DragonShield/ImportManager.swift
+++ b/DragonShield/ImportManager.swift
@@ -566,6 +566,8 @@ class ImportManager {
                                                        duplicateRows: 0,
                                                        notes: note)
                     let items = self.dbManager.positionValuesForSession(sid)
+                    self.dbManager.deleteImportSessionValues(sessionId: sid)
+                    self.dbManager.saveImportSessionValues(sessionId: sid, items: items)
                     let lines = items.map {
                         String(format: "%@: %.2f %@ -> %.2f CHF",
                                $0.instrument, $0.valueOrig, $0.currency, $0.valueChf)

--- a/DragonShield/Views/ImportSessionHistoryView.swift
+++ b/DragonShield/Views/ImportSessionHistoryView.swift
@@ -6,6 +6,7 @@ struct ImportSessionHistoryView: View {
     @State private var totalValues: [Int: Double] = [:]
     @State private var selected: DatabaseManager.ImportSessionData? = nil
     @State private var showDetails = false
+    @State private var showValues = false
 
     static let chfFormatter: NumberFormatter = {
         let f = NumberFormatter()
@@ -55,6 +56,12 @@ struct ImportSessionHistoryView: View {
                     .environmentObject(dbManager)
             }
         }
+        .sheet(isPresented: $showValues) {
+            if let s = selected {
+                ImportSessionValueReportView(session: s)
+                    .environmentObject(dbManager)
+            }
+        }
     }
 
     private var tableHeader: some View {
@@ -78,6 +85,9 @@ struct ImportSessionHistoryView: View {
             Rectangle().fill(Color.gray.opacity(0.2)).frame(height: 1)
             HStack {
                 Button("Show Details") { showDetails = true }
+                    .buttonStyle(SecondaryButtonStyle())
+                    .disabled(selected == nil)
+                Button("Value Report") { showValues = true }
                     .buttonStyle(SecondaryButtonStyle())
                     .disabled(selected == nil)
                 Spacer()
@@ -164,6 +174,7 @@ private struct ImportSessionRowView: View {
 private struct ImportSessionDetailView: View {
     let session: DatabaseManager.ImportSessionData
     let totalValue: Double
+    @Environment(\.dismiss) private var dismiss
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -193,7 +204,7 @@ private struct ImportSessionDetailView: View {
             }
             HStack {
                 Spacer()
-                Button("Close") { NSApp.keyWindow?.close() }
+                Button("Close") { dismiss() }
                     .buttonStyle(PrimaryButtonStyle())
             }
         }

--- a/DragonShield/Views/ImportSessionValueReportView.swift
+++ b/DragonShield/Views/ImportSessionValueReportView.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+struct ImportSessionValueReportView: View {
+    @EnvironmentObject var dbManager: DatabaseManager
+    @Environment(\.dismiss) private var dismiss
+
+    let session: DatabaseManager.ImportSessionData
+    @State private var values: [DatabaseManager.ImportSessionValueData] = []
+
+    private static let valueFormatter: NumberFormatter = {
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        f.maximumFractionDigits = 2
+        return f
+    }()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Value Report – \(session.sessionName)")
+                .font(.headline)
+            Table(values) {
+                TableColumn("Instrument") { item in
+                    Text(item.instrument)
+                }
+                TableColumn("Currency") { item in
+                    Text(item.currency)
+                }
+                TableColumn("Value") { item in
+                    Text(ImportSessionValueReportView.valueFormatter.string(from: NSNumber(value: item.valueOrig)) ?? "0")
+                        .monospacedDigit()
+                }
+                TableColumn("Value CHF") { item in
+                    Text(ImportSessionValueReportView.valueFormatter.string(from: NSNumber(value: item.valueChf)) ?? "0")
+                        .monospacedDigit()
+                }
+            }
+            .tableStyle(.inset(alternatesRowBackgrounds: true))
+            HStack {
+                Spacer()
+                Button("Close") { dismiss() }
+                    .buttonStyle(PrimaryButtonStyle())
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 400, minHeight: 400)
+        .onAppear { values = dbManager.fetchImportSessionValues(session.id) }
+    }
+}
+
+#Preview {
+    ImportSessionValueReportView(session: DatabaseManager.ImportSessionData(
+        id: 1,
+        sessionName: "Demo",
+        fileName: "file.csv",
+        fileType: "CSV",
+        fileSize: 0,
+        fileHash: "",
+        institutionId: nil,
+        importStatus: "COMPLETED",
+        totalRows: 0,
+        successfulRows: 0,
+        failedRows: 0,
+        duplicateRows: 0,
+        errorLog: nil,
+        processingNotes: nil,
+        createdAt: Date(),
+        startedAt: nil,
+        completedAt: nil
+    ))
+    .environmentObject(DatabaseManager())
+}

--- a/DragonShield/database/schema.sql
+++ b/DragonShield/database/schema.sql
@@ -1,10 +1,11 @@
 -- DragonShield/docs/schema.sql
 -- Dragon Shield Database Creation Script
--- Version 4.16 - Add TargetAllocation table
+-- Version 4.17 - Add ImportSessionValues table
 -- Created: 2025-05-24
 -- Updated: 2025-07-13
 --
 -- RECENT HISTORY:
+-- - v4.16 -> v4.17: Added ImportSessionValues table for storing value reports.
 -- - v4.7 -> v4.8: Added Institutions table and linked Accounts to it.
 -- - v4.6 -> v4.7: Added db_version configuration row in seed data.
 -- - v4.5 -> v4.6: Extracted seed data into schema.txt for easier migrations.
@@ -358,6 +359,16 @@ CREATE TABLE PositionReports (
     FOREIGN KEY (account_id) REFERENCES Accounts(account_id),
     FOREIGN KEY (institution_id) REFERENCES Institutions(institution_id),
     FOREIGN KEY (instrument_id) REFERENCES Instruments(instrument_id)
+);
+
+CREATE TABLE ImportSessionValues (
+    value_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    import_session_id INTEGER NOT NULL,
+    instrument_name TEXT NOT NULL,
+    currency TEXT NOT NULL,
+    value_original REAL NOT NULL,
+    value_chf REAL NOT NULL,
+    FOREIGN KEY (import_session_id) REFERENCES ImportSessions(import_session_id)
 );
 
 -- Sample import sessions for testing

--- a/DragonShield/database/schema.txt
+++ b/DragonShield/database/schema.txt
@@ -29,7 +29,7 @@ INSERT INTO Configuration VALUES ('9', 'table_row_padding', '12.0', 'number', 'V
 INSERT INTO Configuration VALUES ('10', 'table_font_size', '14.0', 'number', 'Font size for text in data table rows (in points)', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('11', 'include_direct_re', 'true', 'boolean', 'Include direct real estate in allocation views', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('12', 'direct_re_target_chf', '0', 'number', 'Target CHF amount for direct real estate', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
-INSERT INTO Configuration VALUES ('13', 'db_version', '4.16', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
+INSERT INTO Configuration VALUES ('13', 'db_version', '4.17', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('CHF', 'Swiss Franc', 'CHF', '1', '0', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('EUR', 'Euro', '€', '1', '1', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('USD', 'US Dollar', '$', '1', '1', '2025-07-13 09:04:29', '2025-07-13 09:04:29');

--- a/DragonShield/python_scripts/import_session_report.py
+++ b/DragonShield/python_scripts/import_session_report.py
@@ -84,6 +84,24 @@ def save_total(conn: sqlite3.Connection, session_id: int, total: float) -> None:
     conn.commit()
 
 
+def save_items(conn: sqlite3.Connection, session_id: int, items: List[Dict[str, Any]]) -> None:
+    conn.executemany(
+        """INSERT INTO ImportSessionValues (import_session_id, instrument_name, currency, value_original, value_chf)
+            VALUES (?,?,?,?,?)""",
+        [
+            (
+                session_id,
+                i.get("instrument", ""),
+                i.get("currency", "CHF"),
+                i.get("value_orig", 0.0),
+                i.get("value_chf", 0.0),
+            )
+            for i in items
+        ],
+    )
+    conn.commit()
+
+
 def main(argv: List[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Summarize import session values")
     parser.add_argument("session_id", type=int, help="Import session id")
@@ -94,6 +112,7 @@ def main(argv: List[str] | None = None) -> int:
     positions = fetch_positions(conn, args.session_id)
     summary = summarize_positions(conn, positions)
     save_total(conn, args.session_id, summary["total_chf"])
+    save_items(conn, args.session_id, summary["positions"])
 
     print(f"Total value CHF: {summary['total_chf']:.2f}")
     print("Breakdown by currency:")

--- a/tests/test_import_session_report.py
+++ b/tests/test_import_session_report.py
@@ -51,6 +51,18 @@ def setup_db():
         )
         """
     )
+    conn.execute(
+        """
+        CREATE TABLE ImportSessionValues (
+            value_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            import_session_id INTEGER,
+            instrument_name TEXT,
+            currency TEXT,
+            value_original REAL,
+            value_chf REAL
+        )
+        """
+    )
     return conn
 
 
@@ -75,6 +87,9 @@ def test_summary_and_save():
     assert summary['breakdown']['CHF'] == 40.0
 
     report.save_total(conn, 1, summary['total_chf'])
+    report.save_items(conn, 1, summary['positions'])
     note = conn.execute('SELECT processing_notes FROM ImportSessions WHERE import_session_id=1').fetchone()[0]
     assert 'total_value_chf=85.00' == note
+    count = conn.execute('SELECT COUNT(*) FROM ImportSessionValues').fetchone()[0]
+    assert count == 2
     conn.close()

--- a/tests/test_schema_version.py
+++ b/tests/test_schema_version.py
@@ -8,4 +8,4 @@ from deploy_db import parse_version
 
 def test_schema_version_updated():
     schema_path = Path(__file__).resolve().parents[1] / 'database' / 'schema.sql'
-    assert parse_version(str(schema_path)) == '4.16'
+    assert parse_version(str(schema_path)) == '4.17'


### PR DESCRIPTION
## Summary
- add `ImportSessionValues` table and bump schema to v4.17
- store value report rows after each import
- view value report from Import Session History
- fix detail sheet close button
- update tests for new database version

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'DragonShield', pandas)*

------
https://chatgpt.com/codex/tasks/task_e_687e14b9d1388323af642710cd0074b0