### PR TITLE
feat(import): show value report in table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Compute value report from positions when stored data is missing
 - Fix unused variable warning when computing position values
 - Populate import session value report modal with stored rows
+- Display table-based value report after import and from session history
 - Improve Credit-Suisse parser instrument matching via Valor/ISIN with row-level logging of Valor and ISIN
 - Log Valor and ISIN for each parsed Credit-Suisse row and store valor numbers
 - Fix instrument report generation by locating script path correctly

--- a/DragonShield/ImportManager.swift
+++ b/DragonShield/ImportManager.swift
@@ -223,6 +223,20 @@ class ImportManager {
         NSApp.runModal(for: window)
     }
 
+    private func showValueReport(items: [DatabaseManager.ImportSessionValueItem], total: Double) {
+        let view = ImportSessionValueReportView(items: items, totalValue: total) {
+            NSApp.stopModal()
+        }
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 700, height: 420),
+                              styleMask: [.titled, .closable, .resizable],
+                              backing: .buffered, defer: false)
+        window.title = "Import Values"
+        window.isReleasedWhenClosed = false
+        window.center()
+        window.contentView = NSHostingView(rootView: view)
+        NSApp.runModal(for: window)
+    }
+
     private func showStatusAlert(title: String, message: String) {
         let alert = NSAlert()
         alert.messageText = title
@@ -565,15 +579,11 @@ class ImportManager {
                                                        failedRows: failure,
                                                        duplicateRows: 0,
                                                        notes: note)
-                    let items = self.dbManager.positionValuesForSession(sid)
-                    self.dbManager.saveValueReport(items, forSession: sid)
-                    let lines = items.map {
-                        String(format: "%@: %.2f %@ -> %.2f CHF",
-                               $0.instrument, $0.valueOrig, $0.currency, $0.valueChf)
-                    }.joined(separator: "\n")
-                    let msg = lines + String(format: "\nTotal: %.2f CHF", total)
+                    let tuples = self.dbManager.positionValuesForSession(sid)
+                    self.dbManager.saveValueReport(tuples, forSession: sid)
+                    let reportItems = self.dbManager.fetchValueReport(forSession: sid)
                     DispatchQueue.main.sync {
-                        self.showStatusAlert(title: "Import Values", message: msg)
+                        self.showValueReport(items: reportItems, total: total)
                     }
                 }
                 DispatchQueue.main.async {

--- a/DragonShield/Views/ImportSessionHistoryView.swift
+++ b/DragonShield/Views/ImportSessionHistoryView.swift
@@ -221,35 +221,6 @@ private struct ImportSessionDetailView: View {
     }
 }
 
-private struct ImportSessionValueReportView: View {
-    let items: [DatabaseManager.ImportSessionValueItem]
-    let totalValue: Double
-    let onClose: () -> Void
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Value Report")
-                .font(.headline)
-            Table(items) {
-                TableColumn("Instrument") { Text($0.instrument) }
-                TableColumn("Currency") { Text($0.currency) }
-                TableColumn("Value") { item in Text(String(format: "%.2f", item.valueOrig)) }
-                TableColumn("Value CHF") { item in Text(String(format: "%.2f", item.valueChf)) }
-            }
-            Text(
-                "Total Value CHF: " + (ImportSessionHistoryView.chfFormatter.string(from: NSNumber(value: totalValue)) ?? "0")
-            )
-            HStack {
-                Spacer()
-                Button("Close") { onClose() }
-                    .buttonStyle(PrimaryButtonStyle())
-            }
-        }
-        .padding(24)
-        .frame(minWidth: 500, minHeight: 400)
-    }
-}
-
 #Preview {
     ImportSessionHistoryView()
         .environmentObject(DatabaseManager())

--- a/DragonShield/Views/ImportSessionValueReportView.swift
+++ b/DragonShield/Views/ImportSessionValueReportView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct ImportSessionValueReportView: View {
+    let items: [DatabaseManager.ImportSessionValueItem]
+    let totalValue: Double
+    let onClose: () -> Void
+
+    private static let chfFormatter: NumberFormatter = {
+        let f = NumberFormatter()
+        f.numberStyle = .currency
+        f.currencyCode = "CHF"
+        return f
+    }()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Value Report")
+                .font(.headline)
+            Table(items) { item in
+                TableColumn("Instrument") { Text(item.instrument) }
+                TableColumn("Currency") { Text(item.currency) }
+                TableColumn("Value") { Text(String(format: "%.2f", item.valueOrig)) }
+                TableColumn("Value CHF") { Text(String(format: "%.2f", item.valueChf)) }
+            }
+            Text(
+                "Total Value CHF: " + (
+                    Self.chfFormatter.string(from: NSNumber(value: totalValue)) ?? "0"
+                )
+            )
+            HStack {
+                Spacer()
+                Button("Close") { onClose() }
+                    .buttonStyle(PrimaryButtonStyle())
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 500, minHeight: 400)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add ImportSessionValueReportView component
- display value report after import using a table-based window
- expose the value report sheet from Import Session History
- document feature in changelog

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e2770f13c8323b020d21c689c52ec