### PR TITLE
feat(import): show value report modal and persist data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Show imported position values in CHF after import completes
 - Persist full value reports per import session and view them from history
 - Persist value reports in database after import and fix Session Details sheet closing
+- Display value report table after import and store data in session
 - Compute value report from positions when stored data is missing
 - Fix unused variable warning when computing position values
 - Populate import session value report modal with stored rows

--- a/DragonShield/ImportManager.swift
+++ b/DragonShield/ImportManager.swift
@@ -124,6 +124,7 @@ class ImportManager {
         window.center()
         window.contentView = NSHostingView(rootView: view)
         NSApp.runModal(for: window)
+        window.close()
         return result
     }
 
@@ -221,6 +222,22 @@ class ImportManager {
         window.center()
         window.contentView = NSHostingView(rootView: view)
         NSApp.runModal(for: window)
+        window.close()
+    }
+
+    private func showValueReport(items: [DatabaseManager.ImportSessionValueItem], total: Double) {
+        let view = ImportSessionValueReportView(items: items, totalValue: total) {
+            NSApp.stopModal()
+        }
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 600, height: 420),
+                              styleMask: [.titled, .closable, .resizable],
+                              backing: .buffered, defer: false)
+        window.title = "Import Values"
+        window.isReleasedWhenClosed = false
+        window.center()
+        window.contentView = NSHostingView(rootView: view)
+        NSApp.runModal(for: window)
+        window.close()
     }
 
     private func showStatusAlert(title: String, message: String) {
@@ -567,13 +584,8 @@ class ImportManager {
                                                        notes: note)
                     let items = self.dbManager.positionValuesForSession(sid)
                     self.dbManager.saveValueReport(items, forSession: sid)
-                    let lines = items.map {
-                        String(format: "%@: %.2f %@ -> %.2f CHF",
-                               $0.instrument, $0.valueOrig, $0.currency, $0.valueChf)
-                    }.joined(separator: "\n")
-                    let msg = lines + String(format: "\nTotal: %.2f CHF", total)
                     DispatchQueue.main.sync {
-                        self.showStatusAlert(title: "Import Values", message: msg)
+                        self.showValueReport(items: items, total: total)
                     }
                 }
                 DispatchQueue.main.async {

--- a/DragonShield/Views/ImportSessionHistoryView.swift
+++ b/DragonShield/Views/ImportSessionHistoryView.swift
@@ -221,35 +221,6 @@ private struct ImportSessionDetailView: View {
     }
 }
 
-private struct ImportSessionValueReportView: View {
-    let items: [DatabaseManager.ImportSessionValueItem]
-    let totalValue: Double
-    let onClose: () -> Void
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Value Report")
-                .font(.headline)
-            Table(items) {
-                TableColumn("Instrument") { Text($0.instrument) }
-                TableColumn("Currency") { Text($0.currency) }
-                TableColumn("Value") { item in Text(String(format: "%.2f", item.valueOrig)) }
-                TableColumn("Value CHF") { item in Text(String(format: "%.2f", item.valueChf)) }
-            }
-            Text(
-                "Total Value CHF: " + (ImportSessionHistoryView.chfFormatter.string(from: NSNumber(value: totalValue)) ?? "0")
-            )
-            HStack {
-                Spacer()
-                Button("Close") { onClose() }
-                    .buttonStyle(PrimaryButtonStyle())
-            }
-        }
-        .padding(24)
-        .frame(minWidth: 500, minHeight: 400)
-    }
-}
-
 #Preview {
     ImportSessionHistoryView()
         .environmentObject(DatabaseManager())

--- a/DragonShield/Views/ImportSessionValueReportView.swift
+++ b/DragonShield/Views/ImportSessionValueReportView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct ImportSessionValueReportView: View {
+    let items: [DatabaseManager.ImportSessionValueItem]
+    let totalValue: Double
+    let onClose: () -> Void
+
+    private static let chfFormatter: NumberFormatter = {
+        let f = NumberFormatter()
+        f.numberStyle = .currency
+        f.currencyCode = "CHF"
+        return f
+    }()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Value Report")
+                .font(.headline)
+            Table(items) {
+                TableColumn("Instrument") { Text($0.instrument) }
+                TableColumn("Currency") { Text($0.currency) }
+                TableColumn("Value") { item in
+                    Text(String(format: "%.2f", item.valueOrig))
+                }
+                TableColumn("Value CHF") { item in
+                    Text(String(format: "%.2f", item.valueChf))
+                }
+            }
+            Text(
+                "Total Value CHF: " + (Self.chfFormatter.string(from: NSNumber(value: totalValue)) ?? "0")
+            )
+            HStack {
+                Spacer()
+                Button("Close") { onClose() }
+                    .buttonStyle(PrimaryButtonStyle())
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 500, minHeight: 400)
+    }
+}
+
+#if DEBUG
+#Preview {
+    ImportSessionValueReportView(items: [], totalValue: 0) {}
+}
+#endif


### PR DESCRIPTION
## Summary
- show Import Session Value Report in a table after import
- keep the value report window closed properly
- share ImportSessionValueReportView for history and import
- note change in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e2770f13c8323b020d21c689c52ec