### PR TITLE
feat(import): show value report window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Fix unused variable warning when computing position values
 - Populate import session value report modal with stored rows
 - Display value report in a table after import and allow closing properly
+- Fix DispatchQueue closure syntax causing compile error
 - Improve Credit-Suisse parser instrument matching via Valor/ISIN with row-level logging of Valor and ISIN
 - Log Valor and ISIN for each parsed Credit-Suisse row and store valor numbers
 - Fix instrument report generation by locating script path correctly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 - Fix unused variable warning when computing position values
 - Populate import session value report modal with stored rows
 - Display value report in a table after import and allow closing properly
-- Fix DispatchQueue closure syntax causing compile error
+- Fix stray parentheses in DispatchQueue closures causing compile errors
 - Improve Credit-Suisse parser instrument matching via Valor/ISIN with row-level logging of Valor and ISIN
 - Log Valor and ISIN for each parsed Credit-Suisse row and store valor numbers
 - Fix instrument report generation by locating script path correctly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Compute value report from positions when stored data is missing
 - Fix unused variable warning when computing position values
 - Populate import session value report modal with stored rows
+- Display value report in a table after import and allow closing properly
 - Improve Credit-Suisse parser instrument matching via Valor/ISIN with row-level logging of Valor and ISIN
 - Log Valor and ISIN for each parsed Credit-Suisse row and store valor numbers
 - Fix instrument report generation by locating script path correctly

--- a/DragonShield/ImportManager.swift
+++ b/DragonShield/ImportManager.swift
@@ -267,15 +267,15 @@ class ImportManager {
                 let json = String(data: data, encoding: .utf8) ?? "[]"
                 DispatchQueue.main.async {
                     completion(.success(json))
-                })
+                }
                 LoggingService.shared.log("Import complete for \(url.lastPathComponent)", type: .info, logger: .parser)
             } catch {
                 LoggingService.shared.log("Import failed: \(error.localizedDescription)", type: .error, logger: .parser)
                 DispatchQueue.main.async {
                     completion(.failure(error))
-                })
+                }
             }
-        })
+        }
     }
 
     /// Parses a Credit-Suisse statement and saves position reports.
@@ -316,7 +316,7 @@ class ImportManager {
                                            account: first?.accountNumber,
                                            valueDate: first?.reportDate,
                                            validRows: summary.parsedRows)
-                })
+                }
 
                 let attrs = (try? FileManager.default.attributesOfItem(atPath: url.path)) ?? [:]
                 let fileSize = (attrs[.size] as? NSNumber)?.intValue ?? 0
@@ -342,7 +342,7 @@ class ImportManager {
                         accAction = self.promptForAccount(number: custodyNumber,
                                                          currency: rows.first?.currency ?? "CHF",
                                                          accountTypeCode: "CUSTODY")
-                    })
+                    }
                     switch accAction {
                     case let .save(name, instId, number, typeId, curr):
                         _ = self.dbManager.addAccount(accountName: name,
@@ -376,7 +376,7 @@ class ImportManager {
                                 DispatchQueue.main.sync {
                                     self.showStatusAlert(title: "Account Required",
                                                           message: "Account \(custodyNumber) is required to save positions.")
-                                })
+                                }
                             }
                         }
                     case .abort:
@@ -464,7 +464,7 @@ class ImportManager {
                                     proceed = self.confirmCashAccount(name: parsed.accountName,
                                                                       currency: parsed.currency,
                                                                       amount: parsed.quantity)
-                                })
+                                }
                             }
                             if proceed {
                                 let instId = self.dbManager.findInstitutionId(name: "Credit-Suisse") ?? 1
@@ -519,7 +519,7 @@ class ImportManager {
                     if self.checkpointsEnabled {
                         DispatchQueue.main.sync {
                             action = self.promptForPosition(record: parsed)
-                        })
+                        }
                     }
                     guard case let .save(row) = action else {
                         if case .abort = action { throw ImportError.aborted }
@@ -539,7 +539,7 @@ class ImportManager {
                             alert.addButton(withTitle: "Yes")
                             alert.addButton(withTitle: "No")
                             proceed = alert.runModal() == .alertFirstButtonReturn
-                        })
+                        }
                         if !proceed {
                             throw ImportError.aborted
                         }
@@ -566,7 +566,7 @@ class ImportManager {
                         DispatchQueue.main.sync {
                             self.showStatusAlert(title: "Position Saved",
                                                   message: "Saved \(row.instrumentName)")
-                        })
+                        }
                     }
                 }
                 summary.unmatchedInstruments = unmatched
@@ -583,7 +583,7 @@ class ImportManager {
                     self.dbManager.saveValueReport(items, forSession: sid)
                     DispatchQueue.main.sync {
                         self.showValueReport(items: items, total: total)
-                    })
+                    }
                 }
                 DispatchQueue.main.async {
                     completion(.success(summary))
@@ -595,7 +595,7 @@ class ImportManager {
                     completion(.failure(error))
                 }
             }
-        })
+        }
     }
 
     /// Deletes all Credit-Suisse position reports by selecting accounts linked to the Credit-Suisse institution.

--- a/DragonShield/ImportManager.swift
+++ b/DragonShield/ImportManager.swift
@@ -253,7 +253,7 @@ class ImportManager {
             progress?(message)
         }
         LoggingService.shared.log("Importing file: \(url.lastPathComponent)", type: .info, logger: .parser)
-        DispatchQueue.global(qos: .userInitiated).async(execute: {
+        DispatchQueue.global(qos: .userInitiated).async {
             let accessGranted = url.startAccessingSecurityScopedResource()
             defer { if accessGranted { url.stopAccessingSecurityScopedResource() } }
             do {
@@ -265,13 +265,13 @@ class ImportManager {
                 encoder.dateEncodingStrategy = .iso8601
                 let data = try encoder.encode(records)
                 let json = String(data: data, encoding: .utf8) ?? "[]"
-                DispatchQueue.main.async(execute: {
+                DispatchQueue.main.async {
                     completion(.success(json))
                 })
                 LoggingService.shared.log("Import complete for \(url.lastPathComponent)", type: .info, logger: .parser)
             } catch {
                 LoggingService.shared.log("Import failed: \(error.localizedDescription)", type: .error, logger: .parser)
-                DispatchQueue.main.async(execute: {
+                DispatchQueue.main.async {
                     completion(.failure(error))
                 })
             }
@@ -286,7 +286,7 @@ class ImportManager {
             progress?(message)
         }
         LoggingService.shared.log("Importing positions: \(url.lastPathComponent)", type: .info, logger: .parser)
-        DispatchQueue.global(qos: .userInitiated).async(execute: {
+        DispatchQueue.global(qos: .userInitiated).async {
             let accessGranted = url.startAccessingSecurityScopedResource()
             defer { if accessGranted { url.stopAccessingSecurityScopedResource() } }
             if deleteExisting {
@@ -310,7 +310,7 @@ class ImportManager {
                         return try self.zkbParser.parse(url: url, progress: logger)
                     }
                 }()
-                DispatchQueue.main.sync(execute: {
+                DispatchQueue.main.sync {
                     let first = rows.first
                     self.showImportSummary(fileName: url.lastPathComponent,
                                            account: first?.accountNumber,
@@ -338,7 +338,7 @@ class ImportManager {
                 while accountId == nil {
                     if self.checkpointsEnabled {
                         var accAction: AccountPromptResult = .cancel
-                    DispatchQueue.main.sync(execute: {
+                    DispatchQueue.main.sync {
                         accAction = self.promptForAccount(number: custodyNumber,
                                                          currency: rows.first?.currency ?? "CHF",
                                                          accountTypeCode: "CUSTODY")
@@ -373,7 +373,7 @@ class ImportManager {
                         }
                         if accountId == nil {
                             if self.checkpointsEnabled {
-                                DispatchQueue.main.sync(execute: {
+                                DispatchQueue.main.sync {
                                     self.showStatusAlert(title: "Account Required",
                                                           message: "Account \(custodyNumber) is required to save positions.")
                                 })
@@ -460,7 +460,7 @@ class ImportManager {
                             var proceed = true
                             if self.checkpointsEnabled {
                                 proceed = false
-                                DispatchQueue.main.sync(execute: {
+                                DispatchQueue.main.sync {
                                     proceed = self.confirmCashAccount(name: parsed.accountName,
                                                                       currency: parsed.currency,
                                                                       amount: parsed.quantity)
@@ -517,7 +517,7 @@ class ImportManager {
 
                     var action: RecordPromptResult = .save(parsed)
                     if self.checkpointsEnabled {
-                        DispatchQueue.main.sync(execute: {
+                        DispatchQueue.main.sync {
                             action = self.promptForPosition(record: parsed)
                         })
                     }
@@ -532,7 +532,7 @@ class ImportManager {
                     if instrumentId == nil {
                         unmatched += 1
                         var proceed = true
-                        DispatchQueue.main.sync(execute: {
+                        DispatchQueue.main.sync {
                             let alert = NSAlert()
                             alert.messageText = "Unknown Instrument"
                             alert.informativeText = "Instrument \(row.instrumentName) is not in the database. Please add it manually. Do you want to continue the upload?"
@@ -563,7 +563,7 @@ class ImportManager {
                     )
                     success += 1
                     if self.checkpointsEnabled {
-                        DispatchQueue.main.sync(execute: {
+                        DispatchQueue.main.sync {
                             self.showStatusAlert(title: "Position Saved",
                                                   message: "Saved \(row.instrumentName)")
                         })
@@ -581,7 +581,7 @@ class ImportManager {
                                                        notes: note)
                     let items = self.dbManager.positionValuesForSession(sid)
                     self.dbManager.saveValueReport(items, forSession: sid)
-                    DispatchQueue.main.sync(execute: {
+                    DispatchQueue.main.sync {
                         self.showValueReport(items: items, total: total)
                     })
                 }

--- a/DragonShield/ImportManager.swift
+++ b/DragonShield/ImportManager.swift
@@ -231,6 +231,20 @@ class ImportManager {
         alert.runModal()
     }
 
+    private func showValueReport(items: [DatabaseManager.ImportSessionValueItem], total: Double) {
+        let view = ImportSessionValueReportView(items: items, totalValue: total) {
+            NSApp.stopModal()
+        }
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 700, height: 500),
+                              styleMask: [.titled, .closable, .resizable],
+                              backing: .buffered, defer: false)
+        window.title = "Import Values"
+        window.isReleasedWhenClosed = false
+        window.center()
+        window.contentView = NSHostingView(rootView: view.environmentObject(dbManager))
+        NSApp.runModal(for: window)
+    }
+
     /// Parses a XLSX document and saves the records to the database.
     func parseDocument(at url: URL, progress: ((String) -> Void)? = nil, completion: @escaping (Result<String, Error>) -> Void) {
         LoggingService.shared.clearLog()
@@ -567,13 +581,8 @@ class ImportManager {
                                                        notes: note)
                     let items = self.dbManager.positionValuesForSession(sid)
                     self.dbManager.saveValueReport(items, forSession: sid)
-                    let lines = items.map {
-                        String(format: "%@: %.2f %@ -> %.2f CHF",
-                               $0.instrument, $0.valueOrig, $0.currency, $0.valueChf)
-                    }.joined(separator: "\n")
-                    let msg = lines + String(format: "\nTotal: %.2f CHF", total)
                     DispatchQueue.main.sync {
-                        self.showStatusAlert(title: "Import Values", message: msg)
+                        self.showValueReport(items: items, total: total)
                     }
                 }
                 DispatchQueue.main.async {

--- a/DragonShield/Views/ImportSessionHistoryView.swift
+++ b/DragonShield/Views/ImportSessionHistoryView.swift
@@ -221,34 +221,6 @@ private struct ImportSessionDetailView: View {
     }
 }
 
-private struct ImportSessionValueReportView: View {
-    let items: [DatabaseManager.ImportSessionValueItem]
-    let totalValue: Double
-    let onClose: () -> Void
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Value Report")
-                .font(.headline)
-            Table(items) {
-                TableColumn("Instrument") { Text($0.instrument) }
-                TableColumn("Currency") { Text($0.currency) }
-                TableColumn("Value") { item in Text(String(format: "%.2f", item.valueOrig)) }
-                TableColumn("Value CHF") { item in Text(String(format: "%.2f", item.valueChf)) }
-            }
-            Text(
-                "Total Value CHF: " + (ImportSessionHistoryView.chfFormatter.string(from: NSNumber(value: totalValue)) ?? "0")
-            )
-            HStack {
-                Spacer()
-                Button("Close") { onClose() }
-                    .buttonStyle(PrimaryButtonStyle())
-            }
-        }
-        .padding(24)
-        .frame(minWidth: 500, minHeight: 400)
-    }
-}
 
 #Preview {
     ImportSessionHistoryView()

--- a/DragonShield/Views/ImportSessionValueReportView.swift
+++ b/DragonShield/Views/ImportSessionValueReportView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct ImportSessionValueReportView: View {
+    let items: [DatabaseManager.ImportSessionValueItem]
+    let totalValue: Double
+    let onClose: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Value Report")
+                .font(.headline)
+            Table(items) {
+                TableColumn("Instrument") { Text($0.instrument) }
+                TableColumn("Currency") { Text($0.currency) }
+                TableColumn("Value") { item in Text(String(format: "%.2f", item.valueOrig)) }
+                TableColumn("Value CHF") { item in Text(String(format: "%.2f", item.valueChf)) }
+            }
+            Text("Total Value CHF: " + (ImportSessionHistoryView.chfFormatter.string(from: NSNumber(value: totalValue)) ?? "0"))
+            HStack {
+                Spacer()
+                Button("Close") { onClose() }
+                    .buttonStyle(PrimaryButtonStyle())
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 500, minHeight: 400)
+    }
+}
+


### PR DESCRIPTION
## Summary
- display import value report in a modal table
- make the value report component reusable
- show the report at the end of an import session

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e2770f13c8323b020d21c689c52ec