### PR TITLE
feat(parser): prompt option quantity multiplier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Prompt to confirm option quantity multiplier during position import
 - Generate full instrument report from Database Management view
 - Use latest flagged FX rates for import value calculations and report applied rates
 - Store import session total value and add CLI summary report


### PR DESCRIPTION
## Summary
- prompt the user when an imported instrument name contains "Option" to confirm multiplying quantity by 100
- document the new behavior in the changelog

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pysqlcipher3)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'DragonShield')*

------
https://chatgpt.com/codex/tasks/task_e_687e7c7126688323985877edbdd00f16