### PR TITLE
fix(ui): close Import Values modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Show imported position values in CHF after import completes
 - Persist full value reports per import session and view them from history
 - Persist value reports in database after import and fix Session Details sheet closing
+- Fix Import Values window closing when pressing the Close button
 - Present value report in a table window after import
 - Compute value report from positions when stored data is missing
 - Fix unused variable warning when computing position values

--- a/DragonShield/ImportManager.swift
+++ b/DragonShield/ImportManager.swift
@@ -255,6 +255,7 @@ class ImportManager {
         window.center()
         window.contentView = NSHostingView(rootView: view)
         NSApp.runModal(for: window)
+        window.close()
     }
 
     /// Parses a XLSX document and saves the records to the database.


### PR DESCRIPTION
## Summary
- ensure the Import Values pop-up closes when pressing **Close**
- document fix in the changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e7fcffedc8323b55e0cdb80929932