### PR TITLE
Add selective Credit-Suisse purge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Improve Credit-Suisse parser instrument matching via Valor/ISIN with row-level logging of Valor and ISIN
 - Log Valor and ISIN for each parsed Credit-Suisse row and store valor numbers
 - Fix instrument report generation by locating script path correctly
+- Prompt to delete all or custody-only Credit-Suisse positions before import
 - Display sub-class aggregate totals with delta validation in Allocation Targets table
 - Fix compile error from variable name clash in AllocationTargetsTableView
 - Shrink Data Import/Export panels and show square drag-and-drop area

--- a/DragonShield/ImportManager.swift
+++ b/DragonShield/ImportManager.swift
@@ -620,16 +620,22 @@ class ImportManager {
         }
     }
 
-    /// Deletes all Credit-Suisse position reports by selecting accounts linked to the Credit-Suisse institution.
+    /// Deletes Credit-Suisse position reports.
+    /// - Parameter custodyOnly: When true, only positions linked to "CUSTODY" accounts are removed.
     /// - Returns: The number of deleted records.
-    func deleteCreditSuissePositions() -> Int {
+    func deleteCreditSuissePositions(custodyOnly: Bool = false) -> Int {
         let accounts = dbManager.fetchAccounts(institutionName: "Credit-Suisse")
         if !accounts.isEmpty {
             let numbers = accounts.map { $0.number }.joined(separator: ", ")
-            LoggingService.shared.log("Deleting position reports for Credit-Suisse accounts: \(numbers)",
+            let scope = custodyOnly ? "CUSTODY" : "all"
+            LoggingService.shared.log("Deleting \(scope) Credit-Suisse position reports for accounts: \(numbers)",
                                       type: .info, logger: .database)
         }
-        return dbManager.deletePositionReports(institutionName: "Credit-Suisse")
+        if custodyOnly {
+            return dbManager.deletePositionReports(institutionName: "Credit-Suisse", accountTypeCode: "CUSTODY")
+        } else {
+            return dbManager.deletePositionReports(institutionName: "Credit-Suisse")
+        }
     }
 
     /// Deletes all ZKB position reports by selecting accounts linked to the ZKB institution.


### PR DESCRIPTION
## Summary
- allow deleting all or only custody Credit-Suisse positions
- support deletion by institution and account type in DatabaseManager
- prompt user for deletion choice during Credit-Suisse import
- test SQL query for custody delete option

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e844186648323b89f7c99e9039a18