### PR TITLE
Add custody-only option for Credit-Suisse import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 - Prompt to confirm option quantity multiplier during position import
 - Prompt to delete existing Credit-Suisse positions with custody-only option
 - Fix Credit-Suisse deletion prompt wording and institution lookup
+- Fix Credit-Suisse position cleanup by instrument institution with custody-only option
 - Generate full instrument report from Database Management view
 - Use latest flagged FX rates for import value calculations and report applied rates
 - Store import session total value and add CLI summary report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Prompt to confirm option quantity multiplier during position import
+- Prompt to delete existing Credit-Suisse positions with custody-only option
 - Generate full instrument report from Database Management view
 - Use latest flagged FX rates for import value calculations and report applied rates
 - Store import session total value and add CLI summary report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 - Prompt to confirm option quantity multiplier during position import
 - Prompt to delete existing Credit-Suisse positions with custody-only option
+- Fix Credit-Suisse deletion prompt wording and institution lookup
 - Generate full instrument report from Database Management view
 - Use latest flagged FX rates for import value calculations and report applied rates
 - Store import session total value and add CLI summary report

--- a/DragonShield/DatabaseManager+Accounts.swift
+++ b/DragonShield/DatabaseManager+Accounts.swift
@@ -485,6 +485,59 @@ extension DatabaseManager {
         return results
     }
 
+    /// Returns IDs and numbers of accounts for institutions whose names contain the given fragment.
+    func fetchAccounts(institutionNameLike fragment: String) -> [(id: Int, number: String)] {
+        let sql = """
+            SELECT a.account_id, a.account_number
+              FROM Accounts a
+              JOIN Institutions i ON a.institution_id = i.institution_id
+             WHERE i.institution_name LIKE ? COLLATE NOCASE;
+            """
+        var stmt: OpaquePointer?
+        var results: [(Int, String)] = []
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            print("❌ Failed to prepare fetchAccounts(institutionNameLike): \(String(cString: sqlite3_errmsg(db)))")
+            return []
+        }
+        defer { sqlite3_finalize(stmt) }
+        let pattern = "%\(fragment)%"
+        sqlite3_bind_text(stmt, 1, pattern, -1, nil)
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            let id = Int(sqlite3_column_int(stmt, 0))
+            let number = String(cString: sqlite3_column_text(stmt, 1))
+            results.append((id, number))
+        }
+        return results
+    }
+
+    /// Returns IDs and numbers of accounts for institutions containing the name fragment and matching account type code.
+    func fetchAccounts(institutionNameLike fragment: String, accountTypeCode: String) -> [(id: Int, number: String)] {
+        let sql = """
+            SELECT a.account_id, a.account_number
+              FROM Accounts a
+              JOIN Institutions i ON a.institution_id = i.institution_id
+              JOIN AccountTypes t ON a.account_type_id = t.account_type_id
+             WHERE i.institution_name LIKE ? COLLATE NOCASE
+               AND t.type_code = ? COLLATE NOCASE;
+            """
+        var stmt: OpaquePointer?
+        var results: [(Int, String)] = []
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            print("❌ Failed to prepare fetchAccounts(institutionNameLike:accountType): \(String(cString: sqlite3_errmsg(db)))")
+            return []
+        }
+        defer { sqlite3_finalize(stmt) }
+        let pattern = "%\(fragment)%"
+        sqlite3_bind_text(stmt, 1, pattern, -1, nil)
+        sqlite3_bind_text(stmt, 2, accountTypeCode, -1, nil)
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            let id = Int(sqlite3_column_int(stmt, 0))
+            let number = String(cString: sqlite3_column_text(stmt, 1))
+            results.append((id, number))
+        }
+        return results
+    }
+
     /// Recalculates the earliest instrument update date for all accounts.
     /// - Parameter completion: Called on the main thread with the number of
     ///   rows updated or an error.

--- a/DragonShield/DatabaseManager+Institutions.swift
+++ b/DragonShield/DatabaseManager+Institutions.swift
@@ -191,6 +191,25 @@ extension DatabaseManager {
         return ids
     }
 
+    /// Returns all institution IDs containing the given name fragment.
+    /// The comparison is case-insensitive.
+    func findInstitutionIds(nameLike fragment: String) -> [Int] {
+        let query = "SELECT institution_id FROM Institutions WHERE institution_name LIKE ? COLLATE NOCASE;"
+        var stmt: OpaquePointer?
+        var ids: [Int] = []
+        guard sqlite3_prepare_v2(db, query, -1, &stmt, nil) == SQLITE_OK else {
+            print("❌ Failed to prepare findInstitutionIds(nameLike): \(String(cString: sqlite3_errmsg(db)))")
+            return []
+        }
+        defer { sqlite3_finalize(stmt) }
+        let pattern = "%\(fragment)%"
+        sqlite3_bind_text(stmt, 1, pattern, -1, nil)
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            ids.append(Int(sqlite3_column_int(stmt, 0)))
+        }
+        return ids
+    }
+
     /// Returns all institution IDs whose BIC matches the given prefix.
     /// The comparison is case-insensitive and allows partial branch codes.
     func findInstitutionIds(bic: String) -> [Int] {

--- a/DragonShield/ImportManager.swift
+++ b/DragonShield/ImportManager.swift
@@ -624,26 +624,25 @@ class ImportManager {
     /// to the Credit Suisse institution.
     /// - Returns: The number of deleted records.
     func deleteCreditSuissePositions() -> Int {
-        let accounts = dbManager.fetchAccounts(institutionName: "Credit Suisse")
+        let accounts = dbManager.fetchAccounts(institutionNameLike: "Credit Suisse")
         if !accounts.isEmpty {
             let numbers = accounts.map { $0.number }.joined(separator: ", ")
             LoggingService.shared.log("Deleting position reports for Credit-Suisse accounts: \(numbers)",
                                       type: .info, logger: .database)
         }
-        return dbManager.deletePositionReports(institutionName: "Credit Suisse")
+        return dbManager.deletePositionReports(instrumentInstitutionNameLike: "Credit Suisse")
     }
 
     /// Deletes Credit-Suisse position reports only for custody accounts.
     /// - Returns: The number of deleted records.
     func deleteCreditSuisseCustodyPositions() -> Int {
-        let accounts = dbManager.fetchAccounts(institutionName: "Credit Suisse", accountTypeCode: "CUSTODY")
+        let accounts = dbManager.fetchAccounts(institutionNameLike: "Credit Suisse", accountTypeCode: "CUSTODY")
         if !accounts.isEmpty {
             let numbers = accounts.map { $0.number }.joined(separator: ", ")
             LoggingService.shared.log("Deleting custody position reports for Credit-Suisse accounts: \(numbers)",
                                       type: .info, logger: .database)
         }
-        let ids = accounts.map { $0.id }
-        return dbManager.deletePositionReports(accountIds: ids)
+        return dbManager.deletePositionReports(instrumentInstitutionNameLike: "Credit Suisse", accountTypeCode: "CUSTODY")
     }
 
     /// Deletes all ZKB position reports by selecting accounts linked to the ZKB institution.

--- a/DragonShield/ImportManager.swift
+++ b/DragonShield/ImportManager.swift
@@ -632,6 +632,19 @@ class ImportManager {
         return dbManager.deletePositionReports(institutionName: "Credit-Suisse")
     }
 
+    /// Deletes Credit-Suisse position reports only for custody accounts.
+    /// - Returns: The number of deleted records.
+    func deleteCreditSuisseCustodyPositions() -> Int {
+        let accounts = dbManager.fetchAccounts(institutionName: "Credit-Suisse", accountTypeCode: "CUSTODY")
+        if !accounts.isEmpty {
+            let numbers = accounts.map { $0.number }.joined(separator: ", ")
+            LoggingService.shared.log("Deleting custody position reports for Credit-Suisse accounts: \(numbers)",
+                                      type: .info, logger: .database)
+        }
+        let ids = accounts.map { $0.id }
+        return dbManager.deletePositionReports(accountIds: ids)
+    }
+
     /// Deletes all ZKB position reports by selecting accounts linked to the ZKB institution.
     /// - Returns: The number of deleted records.
     func deleteZKBPositions() -> Int {

--- a/DragonShield/ImportManager.swift
+++ b/DragonShield/ImportManager.swift
@@ -620,22 +620,23 @@ class ImportManager {
         }
     }
 
-    /// Deletes all Credit-Suisse position reports by selecting accounts linked to the Credit-Suisse institution.
+    /// Deletes all Credit-Suisse position reports by selecting accounts linked
+    /// to the Credit Suisse institution.
     /// - Returns: The number of deleted records.
     func deleteCreditSuissePositions() -> Int {
-        let accounts = dbManager.fetchAccounts(institutionName: "Credit-Suisse")
+        let accounts = dbManager.fetchAccounts(institutionName: "Credit Suisse")
         if !accounts.isEmpty {
             let numbers = accounts.map { $0.number }.joined(separator: ", ")
             LoggingService.shared.log("Deleting position reports for Credit-Suisse accounts: \(numbers)",
                                       type: .info, logger: .database)
         }
-        return dbManager.deletePositionReports(institutionName: "Credit-Suisse")
+        return dbManager.deletePositionReports(institutionName: "Credit Suisse")
     }
 
     /// Deletes Credit-Suisse position reports only for custody accounts.
     /// - Returns: The number of deleted records.
     func deleteCreditSuisseCustodyPositions() -> Int {
-        let accounts = dbManager.fetchAccounts(institutionName: "Credit-Suisse", accountTypeCode: "CUSTODY")
+        let accounts = dbManager.fetchAccounts(institutionName: "Credit Suisse", accountTypeCode: "CUSTODY")
         if !accounts.isEmpty {
             let numbers = accounts.map { $0.number }.joined(separator: ", ")
             LoggingService.shared.log("Deleting custody position reports for Credit-Suisse accounts: \(numbers)",

--- a/DragonShield/Views/DataImportExportView.swift
+++ b/DragonShield/Views/DataImportExportView.swift
@@ -174,7 +174,40 @@ struct DataImportExportView: View {
             appendLog("Existing \(inst.name) positions removed: \(removed)")
             startImport(deleteExisting: false)
         } else {
+            guard let choice = promptCreditSuisseDeletionChoice() else {
+                statusMessage = "Status: Upload cancelled"
+                return
+            }
+            let removed: Int = {
+                switch choice {
+                case .allAccounts:
+                    return ImportManager.shared.deleteCreditSuissePositions()
+                case .custodyOnly:
+                    return ImportManager.shared.deleteCreditSuisseCustodyPositions()
+                }
+            }()
+            appendLog("Existing Credit-Suisse positions removed: \(removed)")
             startImport(deleteExisting: false)
+        }
+    }
+
+    private enum CreditSuisseDeletionChoice {
+        case allAccounts
+        case custodyOnly
+    }
+
+    private func promptCreditSuisseDeletionChoice() -> CreditSuisseDeletionChoice? {
+        let alert = NSAlert()
+        alert.messageText = "Delete existing Credit-Suisse positions?"
+        alert.informativeText = "Choose which positions should be removed before import."
+        alert.addButton(withTitle: "all ZKB Accounts")
+        alert.addButton(withTitle: "ZKB Custody Account positions only")
+        alert.addButton(withTitle: "Cancel")
+        let resp = alert.runModal()
+        switch resp {
+        case .alertFirstButtonReturn: return .allAccounts
+        case .alertSecondButtonReturn: return .custodyOnly
+        default: return nil
         }
     }
 

--- a/DragonShield/Views/DataImportExportView.swift
+++ b/DragonShield/Views/DataImportExportView.swift
@@ -200,8 +200,8 @@ struct DataImportExportView: View {
         let alert = NSAlert()
         alert.messageText = "Delete existing Credit-Suisse positions?"
         alert.informativeText = "Choose which positions should be removed before import."
-        alert.addButton(withTitle: "all ZKB Accounts")
-        alert.addButton(withTitle: "ZKB Custody Account positions only")
+        alert.addButton(withTitle: "all Credit-Suisse Accounts")
+        alert.addButton(withTitle: "Credit-Suisse Custody Account positions only")
         alert.addButton(withTitle: "Cancel")
         let resp = alert.runModal()
         switch resp {


### PR DESCRIPTION
## Summary
- add helper to fetch accounts by institution and type
- allow deleting position reports by account ids
- support deleting Credit-Suisse custody accounts only
- prompt for deletion choice before Credit-Suisse import
- document new Credit-Suisse deletion prompt in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e844186648323b89f7c99e9039a18