### PR TITLE
Enhance position deletion workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Prompt to confirm option quantity multiplier during position import
+- Confirm deletion of positions per account type with live count
 - Generate full instrument report from Database Management view
 - Use latest flagged FX rates for import value calculations and report applied rates
 - Store import session total value and add CLI summary report


### PR DESCRIPTION
## Summary
- add account type deletion filters and new confirmation sheet
- implement counting and scoped deletion queries
- show detailed toast after deletion
- document new bulk deletion workflow in changelog

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f88c2124c83238c1a6638c88e7ef0