### PR TITLE
Add manifest validation to backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Validate backups and restores with per-table checksums
 - Prompt to confirm option quantity multiplier during position import
 - Confirm deletion of positions per account type with live count
 - Generate full instrument report from Database Management view


### PR DESCRIPTION
## Summary
- validate all tables when performing full database backups
- validate before and after restore using saved manifest
- persist manifest alongside backup file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f9e3328a88323b5f2726c8404b940