### PR TITLE
feat(backup): validate tables using manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Fix unused variable warning when computing position values
 - Populate import session value report modal with stored rows
 - Improve Credit-Suisse parser instrument matching via Valor/ISIN with row-level logging of Valor and ISIN
+- Validate backups using manifest and abort restore if validation fails
 - Log Valor and ISIN for each parsed Credit-Suisse row and store valor numbers
 - Fix instrument report generation by locating script path correctly
 - Display sub-class aggregate totals with delta validation in Allocation Targets table


### PR DESCRIPTION
## Summary
- verify table row counts and checksums when backing up and restoring
- abort restore if manifest validation fails
- log validation results in the Database Management view

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fe9ce1e0c8323b4a7b9c8035cb524