### PR TITLE
Add manifest-based backup validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -353,3 +353,4 @@ All notable changes to this project will be documented in this file.
 - Include TargetAllocation and ExchangeRates tables in transaction backup/restore
 - Fix account lookup by valor when importing cash account balances with detailed logging
 - Remove ZKB position deletion prompt from Data Import/Export view; use Positions view for deletions
+- Validate all tables during backup and restore with manifest checks


### PR DESCRIPTION
## Summary
- add manifest structures and SHA256 helper functions
- validate backups and restores against table manifests
- log results in DatabaseManagement UI

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fe9ce1e0c8323b4a7b9c8035cb524