### PR TITLE
Add manifest validation to backup/restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Persist value reports in database after import and fix Session Details sheet closing
 - Fix Import Values window closing when pressing the Close button
 - Present value report in a table window after import
+- Validate all tables during backup and restore using manifest checksums
 - Compute value report from positions when stored data is missing
 - Fix unused variable warning when computing position values
 - Populate import session value report modal with stored rows

--- a/DragonShield/Views/DatabaseManagementView.swift
+++ b/DragonShield/Views/DatabaseManagementView.swift
@@ -220,6 +220,16 @@ struct DatabaseManagementView: View {
         }
     }
 
+    private var validationList: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            ForEach(Array(backupService.lastValidationMessages.enumerated()), id: \.offset) { _, entry in
+                Text(entry)
+                    .font(.system(.caption2, design: .monospaced))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
     private var logCard: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Backup & Restore Log")
@@ -228,6 +238,9 @@ struct DatabaseManagementView: View {
 
             if !backupService.lastActionSummaries.isEmpty {
                 summaryTable
+            }
+            if !backupService.lastValidationMessages.isEmpty {
+                validationList
             }
 
             Button(showLogDetails ? "Hide Details" : "Show Details") {


### PR DESCRIPTION
## Summary
- validate all DB tables during backup and restore using manifest checksums
- display validation results in Database Management view

## Testing
- `swiftc -parse -module-name DragonShield DragonShield/BackupService.swift`
- `swiftc -parse -module-name DragonShield DragonShield/Views/DatabaseManagementView.swift`
- `pip install -q -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'DragonShield')*

------
https://chatgpt.com/codex/tasks/task_e_687fe9ce1e0c8323b4a7b9c8035cb524