### PR TITLE
Update README with production folder details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Persist value reports in database after import and fix Session Details sheet closing
 - Fix Import Values window closing when pressing the Close button
 - Present value report in a table window after import
+- Document production folder path and backups in README
 - Compute value report from positions when stored data is missing
 - Fix unused variable warning when computing position values
 - Populate import session value report modal with stored rows

--- a/README.md
+++ b/README.md
@@ -112,7 +112,11 @@ DragonShield/
 ## 💾 Database Information
 
 - **Type**: SQLite
-- **Path**: `/Users/renekeller/Library/Containers/com.rene.DragonShield/Data/Library/Application Support/DragonShield/dragonshield.sqlite` (generate with `python3 python_scripts/deploy_db.py`)
+- **Production Folder**: `/Users/renekeller/Library/Containers/com.rene.DragonShield/Data/Library/Application Support/DragonShield`
+  - Primary database: `dragonshield.sqlite`
+  - Test database: `dragonshield_test.sqlite`
+  - Backup directory: `Dragonshield DB Backup` (full, reference and transaction backups)
+  - Generate the database with `python3 python_scripts/deploy_db.py`.
 - **Encryption**: SQLCipher (AES-256)
 - **Schema**: `docs/schema.sql`
 - **Dev Key**: Temporary; do not use for production data


### PR DESCRIPTION
## Summary
- document production data folder and backup location in README
- record the README update in the changelog

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pysqlcipher3)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'DragonShield')*

------
https://chatgpt.com/codex/tasks/task_e_6880be46e2bc83238518420a19eca275