### PR TITLE
feat(backup): add manifest validation and sandbox path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Fix unused variable warning when computing position values
 - Populate import session value report modal with stored rows
 - Improve Credit-Suisse parser instrument matching via Valor/ISIN with row-level logging of Valor and ISIN
+- Validate full database backups with per-table checksums and manifest
 - Log Valor and ISIN for each parsed Credit-Suisse row and store valor numbers
 - Fix instrument report generation by locating script path correctly
 - Display sub-class aggregate totals with delta validation in Allocation Targets table

--- a/DragonShield/Views/DatabaseManagementView.swift
+++ b/DragonShield/Views/DatabaseManagementView.swift
@@ -192,6 +192,7 @@ struct DatabaseManagementView: View {
                 Text("Table Name").font(.caption).frame(maxWidth: .infinity, alignment: .leading)
                 Text("Action").font(.caption).frame(maxWidth: .infinity, alignment: .leading)
                 Text("Records Processed").font(.caption).frame(maxWidth: .infinity, alignment: .trailing)
+                Text("Diff").font(.caption).frame(maxWidth: .infinity, alignment: .trailing)
             }
             ForEach(Array(backupService.lastActionSummaries.enumerated()), id: \..offset) { index, entry in
                 HStack {
@@ -203,6 +204,15 @@ struct DatabaseManagementView: View {
                     Text("\(entry.count)")
                         .font(.system(.caption, design: .monospaced))
                         .frame(maxWidth: .infinity, alignment: .trailing)
+                    if let diff = entry.diff {
+                        Text(diff >= 0 ? "+\(diff)" : "\(diff)")
+                            .foregroundColor(diff >= 0 ? .green : .red)
+                            .font(.system(.caption, design: .monospaced))
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                    } else {
+                        Text("")
+                            .frame(maxWidth: .infinity)
+                    }
                 }
                 .padding(.vertical, 2)
                 .background(index % 2 == 0 ? Color.gray.opacity(0.05) : Color.clear)


### PR DESCRIPTION
## Summary
- save backups inside the container path
- generate a per-table manifest with row counts and SHA256 checksums
- validate backups on restore and report per-table diffs
- show diff column in the backup log UI

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880c04b9ee48323b3d49a0930f545d2