### PR TITLE
feat(backup): validate backups with manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Validate full database backups and store manifest in sandbox container
 - Prompt to confirm option quantity multiplier during position import
 - Confirm deletion of positions per account type with live count
 - Generate full instrument report from Database Management view


### PR DESCRIPTION
## Summary
- store backups in sandbox container path
- generate per-table manifest with counts and checksums
- verify backup files and restore with validation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6880c04b9ee48323b3d49a0930f545d2