### PR TITLE
feat: verify table counts on restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Prompt to confirm option quantity multiplier during position import
+- Record table row counts during full backup and verify after restore
 - Confirm deletion of positions per account type with live count
 - Generate full instrument report from Database Management view
 - Use latest flagged FX rates for import value calculations and report applied rates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 - Prompt to confirm option quantity multiplier during position import
 - Record table row counts during full backup and verify after restore
+- Rename WAL and SHM files when restoring database to avoid disk errors
 - Confirm deletion of positions per account type with live count
 - Generate full instrument report from Database Management view
 - Use latest flagged FX rates for import value calculations and report applied rates


### PR DESCRIPTION
## Summary
- use SQLite backup API for full DB backups
- rename existing DB with timestamp before restoring
- compare row counts before and after restore
- log table count differences during restore

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6880dce01ba083239e7325c64163893b