### PR TITLE
Add SQLite backup/restore script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -358,3 +358,4 @@ All notable changes to this project will be documented in this file.
 - Improve BackupService restore logic with atomic replace and integrity validation
 - Fix compile error when calling FileManager.replaceItem during database restore
 - Fix integrity check failure when validating WAL-mode backups
+- Preserve backup file during restore and log pre/post row comparisons

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -359,4 +359,5 @@ All notable changes to this project will be documented in this file.
 - Fix compile error when calling FileManager.replaceItem during database restore
 - Fix integrity check failure when validating WAL-mode backups
 - Preserve backup file during restore and log pre/post row comparisons
+- Show detailed Backup Summary and ensure restore logs publish on main thread
 - Document python backup_restore script in README

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -354,3 +354,4 @@ All notable changes to this project will be documented in this file.
 - Include TargetAllocation and ExchangeRates tables in transaction backup/restore
 - Fix account lookup by valor when importing cash account balances with detailed logging
 - Remove ZKB position deletion prompt from Data Import/Export view; use Positions view for deletions
+- Add Python script for full database backup and restore using SQLite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -360,4 +360,5 @@ All notable changes to this project will be documented in this file.
 - Fix integrity check failure when validating WAL-mode backups
 - Preserve backup file during restore and log pre/post row comparisons
 - Show detailed Backup Summary and ensure restore logs publish on main thread
+- Keep original backup file by copying to a temporary location before atomic replace
 - Document python backup_restore script in README

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -357,3 +357,4 @@ All notable changes to this project will be documented in this file.
 - Add Python script for full database backup and restore using SQLite
 - Improve BackupService restore logic with atomic replace and integrity validation
 - Fix compile error when calling FileManager.replaceItem during database restore
+- Fix integrity check failure when validating WAL-mode backups

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -356,3 +356,4 @@ All notable changes to this project will be documented in this file.
 - Remove ZKB position deletion prompt from Data Import/Export view; use Positions view for deletions
 - Add Python script for full database backup and restore using SQLite
 - Improve BackupService restore logic with atomic replace and integrity validation
+- Fix compile error when calling FileManager.replaceItem during database restore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -355,3 +355,4 @@ All notable changes to this project will be documented in this file.
 - Fix account lookup by valor when importing cash account balances with detailed logging
 - Remove ZKB position deletion prompt from Data Import/Export view; use Positions view for deletions
 - Add Python script for full database backup and restore using SQLite
+- Improve BackupService restore logic with atomic replace and integrity validation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -359,3 +359,4 @@ All notable changes to this project will be documented in this file.
 - Fix compile error when calling FileManager.replaceItem during database restore
 - Fix integrity check failure when validating WAL-mode backups
 - Preserve backup file during restore and log pre/post row comparisons
+- Document python backup_restore script in README

--- a/DragonShield/BackupService.swift
+++ b/DragonShield/BackupService.swift
@@ -275,7 +275,11 @@ class BackupService: ObservableObject {
 
         var usedOldURL = false
         do {
-            _ = try fm.replaceItem(at: dbURL, withItemAt: url, backupItemName: oldName)
+            _ = try fm.replaceItem(at: dbURL,
+                                   withItemAt: url,
+                                   backupItemName: oldName,
+                                   options: [],
+                                   resultingItemURL: nil)
         } catch {
             do {
                 try fm.moveItem(at: dbURL, to: oldURL)

--- a/DragonShield/BackupService.swift
+++ b/DragonShield/BackupService.swift
@@ -511,7 +511,10 @@ class BackupService: ObservableObject {
 
     private func checkIntegrity(path: String) -> Bool {
         var db: OpaquePointer?
-        guard sqlite3_open_v2(path, &db, SQLITE_OPEN_READONLY | SQLITE_OPEN_FULLMUTEX, nil) == SQLITE_OK, let db else { return false }
+        // opening read-write allows SQLite to create a temporary WAL file if the
+        // database uses WAL mode. Without this, opening a WAL-mode database
+        // read-only fails when the WAL file is missing.
+        guard sqlite3_open_v2(path, &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX, nil) == SQLITE_OK, let db else { return false }
         defer { sqlite3_close(db) }
         var stmt: OpaquePointer?
         defer { sqlite3_finalize(stmt) }

--- a/DragonShield/BackupService.swift
+++ b/DragonShield/BackupService.swift
@@ -279,12 +279,16 @@ class BackupService: ObservableObject {
 
         dbManager.closeConnection()
 
+        let tempURL = dbURL.deletingLastPathComponent().appendingPathComponent("restore_temp_" + ts + ".sqlite")
+        try? fm.removeItem(at: tempURL)
+        try fm.copyItem(at: url, to: tempURL)
+
         var usedOldURL = false
         do {
             _ = try fm.replaceItem(at: dbURL,
-                                   withItemAt: url,
+                                   withItemAt: tempURL,
                                    backupItemName: oldName,
-                                   options: [.withoutDeletingBackupItem],
+                                   options: [],
                                    resultingItemURL: nil)
         } catch {
             do {
@@ -296,6 +300,7 @@ class BackupService: ObservableObject {
                 throw error
             }
         }
+        try? fm.removeItem(at: tempURL)
 
         guard checkIntegrity(path: dbPath) else {
             if usedOldURL {

--- a/DragonShield/BackupService.swift
+++ b/DragonShield/BackupService.swift
@@ -181,8 +181,14 @@ class BackupService: ObservableObject {
         UserDefaults.standard.set(lastBackup, forKey: UserDefaultsKeys.lastBackupTimestamp)
 
         DispatchQueue.main.async {
-            let summary = counts.map { "\($0.0): \($0.1)" }.joined(separator: ", ")
-            self.logMessages.append("✅ Backed up \(label) data — " + summary)
+            func pad(_ value: String, _ len: Int) -> String {
+                value.padding(toLength: len, withPad: " ", startingAt: 0)
+            }
+            var lines: [String] = ["Backup Summary", pad("Table", 20) + "Rows"]
+            for (tbl, count) in counts {
+                lines.append(pad(tbl, 20) + String(count))
+            }
+            self.logMessages.append("✅ Backed up \(label) data\n" + lines.joined(separator: "\n"))
             self.appendLog(action: "Backup", file: destination.lastPathComponent, success: true)
             self.lastActionSummaries = tables.map { tbl in
                 TableActionSummary(table: tbl, action: "Backed up", count: (try? dbManager.rowCount(table: tbl)) ?? 0)

--- a/DragonShield/python_scripts/backup_restore.py
+++ b/DragonShield/python_scripts/backup_restore.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Backup and restore DragonShield database using SQLite's online backup API."""
+
+import argparse
+import json
+import os
+import shutil
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Tuple
+
+
+def _row_counts(conn: sqlite3.Connection) -> Dict[str, int]:
+    cur = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%';"
+    )
+    tables = [r[0] for r in cur.fetchall()]
+    counts = {}
+    for tbl in tables:
+        cur = conn.execute(f"SELECT COUNT(*) FROM {tbl};")
+        counts[tbl] = cur.fetchone()[0]
+    return counts
+
+
+def backup_database(db_path: Path, dest_dir: Path, env: str) -> Tuple[Path, Dict[str, int]]:
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    backup_path = dest_dir / f"{env}_backup_{ts}.sqlite"
+    manifest_path = backup_path.with_suffix(".manifest.json")
+
+    with sqlite3.connect(db_path) as src, sqlite3.connect(backup_path) as dst:
+        src.backup(dst)
+        if dst.execute("PRAGMA integrity_check;").fetchone()[0] != "ok":
+            backup_path.unlink(missing_ok=True)
+            raise RuntimeError("Integrity check failed")
+        counts = _row_counts(dst)
+
+    with open(manifest_path, "w", encoding="utf-8") as f:
+        json.dump(counts, f, indent=2)
+
+    return backup_path, counts
+
+
+def restore_database(db_path: Path, backup_file: Path) -> Dict[str, Tuple[int, int]]:
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    old_path = db_path.with_name(db_path.name + f".old.{ts}")
+
+    with sqlite3.connect(db_path) as conn:
+        pre_counts = _row_counts(conn)
+
+    os.replace(db_path, old_path)
+    try:
+        shutil.copy2(backup_file, db_path)
+        with sqlite3.connect(db_path) as conn:
+            post_counts = _row_counts(conn)
+    except Exception:
+        if old_path.exists():
+            os.replace(old_path, db_path)
+        raise
+
+    summary = {}
+    for tbl in sorted(set(pre_counts) | set(post_counts)):
+        pre = pre_counts.get(tbl, 0)
+        post = post_counts.get(tbl, 0)
+        summary[tbl] = (pre, post)
+
+    return summary
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Backup or restore dragonshield.sqlite")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    b = sub.add_parser("backup", help="Create a backup")
+    b.add_argument("db", type=Path, help="Path to dragonshield.sqlite")
+    b.add_argument("dest", type=Path, help="Directory for backup file")
+
+    r = sub.add_parser("restore", help="Restore from a backup")
+    r.add_argument("db", type=Path, help="Path to dragonshield.sqlite")
+    r.add_argument("backup", type=Path, help="Backup file to restore")
+
+    args = parser.parse_args(argv)
+
+    if args.cmd == "backup":
+        env = input("Environment label (prod/test): ").strip() or "prod"
+        backup_path, counts = backup_database(args.db, args.dest, env)
+        print("Backup Summary")
+        print(f"{'Table':20}Rows")
+        for tbl, cnt in counts.items():
+            print(f"{tbl:20}{cnt}")
+        print(f"Backup created at {backup_path}")
+        return 0
+    else:
+        summary = restore_database(args.db, args.backup)
+        print("Restore Summary")
+        print(f"{'Table':20}{'Pre-Restore':12}{'Post-Restore':14}Delta")
+        for tbl, (pre, post) in summary.items():
+            delta = post - pre
+            sign = '+' if delta >= 0 else ''
+            print(f"{tbl:20}{pre:<12}{post:<14}{sign}{delta}")
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ DragonShield/
   - Test database: `dragonshield_test.sqlite`
   - Backup directory: `Dragonshield DB Backup` (full, reference and transaction backups)
   - Generate the database with `python3 python_scripts/deploy_db.py`.
+  - Full database backup/restore via `python3 python_scripts/backup_restore.py`
 - **Encryption**: SQLCipher (AES-256)
 - **Schema**: `docs/schema.sql`
 - **Dev Key**: Temporary; do not use for production data

--- a/tests/test_backup_restore.py
+++ b/tests/test_backup_restore.py
@@ -1,0 +1,39 @@
+import sqlite3
+from pathlib import Path
+import re
+
+from DragonShield.python_scripts.backup_restore import backup_database, restore_database
+
+
+def setup_db(path: Path):
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE t1(id INTEGER)")
+    conn.execute("INSERT INTO t1 VALUES (1),(2)")
+    conn.commit()
+    conn.close()
+
+
+def test_backup_and_restore(tmp_path):
+    db = tmp_path / "dragonshield.sqlite"
+    setup_db(db)
+
+    backup_dir = tmp_path / "backups"
+    backup_file, counts = backup_database(db, backup_dir, "test")
+
+    assert backup_file.exists()
+    assert counts == {"t1": 2}
+
+    # remove one row so restore has effect
+    conn = sqlite3.connect(db)
+    conn.execute("DELETE FROM t1 WHERE id=1")
+    conn.commit()
+    conn.close()
+
+    summary = restore_database(db, backup_file)
+
+    assert summary["t1"] == (1, 2)
+
+    # check old file preserved
+    old_files = list(tmp_path.glob("dragonshield.sqlite.old.*"))
+    assert len(old_files) == 1
+

--- a/tests/test_backup_restore.py
+++ b/tests/test_backup_restore.py
@@ -1,6 +1,6 @@
 import sqlite3
 from pathlib import Path
-import re
+
 
 from DragonShield.python_scripts.backup_restore import backup_database, restore_database
 
@@ -36,4 +36,7 @@ def test_backup_and_restore(tmp_path):
     # check old file preserved
     old_files = list(tmp_path.glob("dragonshield.sqlite.old.*"))
     assert len(old_files) == 1
+
+    # backup should still exist
+    assert backup_file.exists()
 


### PR DESCRIPTION
## Summary
- implement `backup_restore.py` with SQLite online backup API
- test backup and restore logic
- document new script in changelog

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880e8edc61c8323817c0bffb7d7e958