### PR TITLE
Fix restore handling and main-thread updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -362,3 +362,4 @@ All notable changes to this project will be documented in this file.
 - Show detailed Backup Summary and ensure restore logs publish on main thread
 - Keep original backup file by copying to a temporary location before atomic replace
 - Document python backup_restore script in README
+- Resolve "file in use" errors during restore by closing connections and dispatch published updates on main thread


### PR DESCRIPTION
## Summary
- prevent file-in-use errors by copying backup to a temp file and replacing atomically
- ensure database backup timestamps update on the main thread
- update backup directory and schedule settings on the main thread
- keep restore summary logging consistent
- document the fix in the changelog

## Testing
- `PYTHONPATH=$PWD pytest tests/test_backup_restore.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68814b7513f08323b60ba543984fc207