### PR TITLE
fix: close SQLite connection before restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Fix unused variable warning when computing position values
 - Populate import session value report modal with stored rows
 - Improve Credit-Suisse parser instrument matching via Valor/ISIN with row-level logging of Valor and ISIN
+- Close SQLite connection before restore to prevent vnode errors and ensure UI updates occur on main thread
 - Log Valor and ISIN for each parsed Credit-Suisse row and store valor numbers
 - Fix instrument report generation by locating script path correctly
 - Display sub-class aggregate totals with delta validation in Allocation Targets table


### PR DESCRIPTION
## Summary
- close database connection with `sqlite3_close_v2`
- validate connection state before moving DB files
- update backup helpers so published values change on main thread
- note fix in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68814fc21fa88323af04a4ae129e46b3