### PR TITLE
Fix SQLite restore lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -362,3 +362,4 @@ All notable changes to this project will be documented in this file.
 - Show detailed Backup Summary and ensure restore logs publish on main thread
 - Keep original backup file by copying to a temporary location before atomic replace
 - Document python backup_restore script in README
+- Close SQLite connection before file moves and update dbVersion on main thread

--- a/DragonShield/BackupService.swift
+++ b/DragonShield/BackupService.swift
@@ -277,7 +277,9 @@ class BackupService: ObservableObject {
             throw NSError(domain: "SQLite", code: 1, userInfo: [NSLocalizedDescriptionKey: "Backup integrity check failed"])
         }
 
-        dbManager.closeConnection()
+        if !dbManager.closeConnection() || dbManager.db != nil {
+            print("⚠️ Database connection still open before restore")
+        }
 
         let tempURL = dbURL.deletingLastPathComponent().appendingPathComponent("restore_temp_" + ts + ".sqlite")
         try? fm.removeItem(at: tempURL)

--- a/DragonShield/DatabaseManager+Configuration.swift
+++ b/DragonShield/DatabaseManager+Configuration.swift
@@ -95,7 +95,8 @@ extension DatabaseManager {
             print("✅ Configuration updated for key '\(key)' to value '\(value)'")
             // Reload configuration to update @Published properties
             // This ensures that if one part of the app updates config, others see it if observing DatabaseManager
-            self.dbVersion = loadConfiguration()
+            let version = loadConfiguration()
+            DispatchQueue.main.async { self.dbVersion = version }
         } else {
             print("❌ Failed to update configuration for key '\(key)': \(String(cString: sqlite3_errmsg(db)))")
         }
@@ -104,7 +105,8 @@ extension DatabaseManager {
 
     func forceReloadData() { // This mainly reloads configuration currently
         print("🔄 Force reloading database configuration...")
-        self.dbVersion = loadConfiguration()
+        let version = loadConfiguration()
+        DispatchQueue.main.async { self.dbVersion = version }
         NotificationCenter.default.post(name: NSNotification.Name("DatabaseForceReloaded"), object: nil)
     }
 }


### PR DESCRIPTION
## Summary
- ensure DB version updates happen on the main thread
- close SQLite connections with `sqlite3_close_v2` and verify before restoring

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68814fc21fa88323af04a4ae129e46b3