### PR TITLE
feat(restore): show row count deltas after restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - Display sub-class aggregate totals with delta validation in Allocation Targets table
 - Fix compile error from variable name clash in AllocationTargetsTableView
 - Shrink Data Import/Export panels and show square drag-and-drop area
+- Present row count comparison after restoring a backup
 - Add Import Session History tab with per-session totals
 - Enable multi-institution selection in Positions view with summary totals and bulk delete
 - Show total CHF value for selected institutions in Positions view

--- a/DragonShield/Views/DatabaseManagementView.swift
+++ b/DragonShield/Views/DatabaseManagementView.swift
@@ -433,8 +433,11 @@ struct DatabaseManagementView: View {
         processing = true
         DispatchQueue.global().async {
             do {
-                try backupService.performRestore(dbManager: dbManager, from: url, tables: backupService.fullTables, label: "Full")
-                DispatchQueue.main.async { processing = false }
+                let rows = try backupService.performRestore(dbManager: dbManager, from: url, tables: backupService.fullTables, label: "Full")
+                DispatchQueue.main.async {
+                    processing = false
+                    showRestoreComparison(rows: rows)
+                }
             } catch {
                 DispatchQueue.main.async {
                     processing = false
@@ -536,6 +539,24 @@ struct DatabaseManagementView: View {
         if backupService.logMessages.count > 10 {
             backupService.logMessages = Array(backupService.logMessages.prefix(10))
         }
+    }
+
+    private func showRestoreComparison(rows: [RestoreComparisonRow]) {
+        let view = RestoreComparisonView(rows: rows) {
+            NSApp.stopModal()
+        }
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 500, height: 400),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "Restore Comparison"
+        window.isReleasedWhenClosed = false
+        window.center()
+        window.contentView = NSHostingView(rootView: view)
+        NSApp.runModal(for: window)
+        window.close()
     }
 }
 

--- a/DragonShield/Views/RestoreComparisonView.swift
+++ b/DragonShield/Views/RestoreComparisonView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+struct RestoreComparisonView: View {
+    let rows: [RestoreComparisonRow]
+    let onClose: () -> Void
+
+    private static let intFormatter: NumberFormatter = {
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        f.groupingSeparator = "'"
+        f.groupingSize = 3
+        f.usesGroupingSeparator = true
+        return f
+    }()
+
+    private func format(_ n: Int) -> String {
+        Self.intFormatter.string(from: NSNumber(value: n)) ?? "0"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Restore Comparison")
+                .font(.headline)
+            ScrollView {
+                Table(rows) {
+                    TableColumn("Table Name") { Text($0.table) }
+                    TableColumn("Pre-Restore Count") { row in
+                        Text(format(row.preCount))
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                    }
+                    TableColumn("Post-Restore Count") { row in
+                        Text(format(row.postCount))
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                    }
+                    TableColumn("Delta") { row in
+                        Text((row.delta >= 0 ? "+" : "") + format(row.delta))
+                            .foregroundColor(row.delta >= 0 ? .success : .error)
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                    }
+                }
+            }
+            HStack {
+                Spacer()
+                Button("Close") { onClose() }
+                    .buttonStyle(PrimaryButtonStyle())
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 500, minHeight: 400)
+    }
+}


### PR DESCRIPTION
## Summary
- create `RestoreComparisonView` modal to list row count differences
- return comparison info from `performRestore`
- present Restore Comparison window after restoring the DB
- log changelog entry

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881539f8bf083238d288914b146f387