### PR TITLE
feat(ui): show restore comparison window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Persist value reports in database after import and fix Session Details sheet closing
 - Fix Import Values window closing when pressing the Close button
 - Present value report in a table window after import
+- Show Restore Comparison window with per-table row count delta after database restore
 - Document production folder path and backups in README
 - Compute value report from positions when stored data is missing
 - Fix unused variable warning when computing position values

--- a/DragonShield/Views/DatabaseManagementView.swift
+++ b/DragonShield/Views/DatabaseManagementView.swift
@@ -433,8 +433,11 @@ struct DatabaseManagementView: View {
         processing = true
         DispatchQueue.global().async {
             do {
-                try backupService.performRestore(dbManager: dbManager, from: url, tables: backupService.fullTables, label: "Full")
-                DispatchQueue.main.async { processing = false }
+                let comparison = try backupService.performRestore(dbManager: dbManager, from: url, tables: backupService.fullTables, label: "Full")
+                DispatchQueue.main.async {
+                    processing = false
+                    showRestoreComparison(items: comparison)
+                }
             } catch {
                 DispatchQueue.main.async {
                     processing = false
@@ -508,6 +511,21 @@ struct DatabaseManagementView: View {
                 }
             }
         }
+    }
+
+    private func showRestoreComparison(items: [RestoreComparisonRow]) {
+        let view = RestoreComparisonView(items: items) {
+            NSApp.stopModal()
+        }
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 600, height: 400),
+                              styleMask: [.titled, .closable, .resizable],
+                              backing: .buffered, defer: false)
+        window.title = "Restore Comparison"
+        window.isReleasedWhenClosed = false
+        window.center()
+        window.contentView = NSHostingView(rootView: view)
+        NSApp.runModal(for: window)
+        window.close()
     }
 
     private func confirmSwitchMode() {

--- a/DragonShield/Views/RestoreComparisonView.swift
+++ b/DragonShield/Views/RestoreComparisonView.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+struct RestoreComparisonView: View {
+    let items: [RestoreComparisonRow]
+    let onClose: () -> Void
+
+    private static let intFormatter: NumberFormatter = {
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        f.groupingSeparator = "'"
+        f.usesGroupingSeparator = true
+        return f
+    }()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Restore Comparison")
+                .font(.headline)
+            ScrollView {
+                Table(items) {
+                    TableColumn("Table Name") { item in
+                        Text(item.table)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    TableColumn("Pre-Restore Count") { item in
+                        Text(Self.intFormatter.string(from: NSNumber(value: item.preCount)) ?? "0")
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                    }
+                    TableColumn("Post-Restore Count") { item in
+                        Text(Self.intFormatter.string(from: NSNumber(value: item.postCount)) ?? "0")
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                    }
+                    TableColumn("Delta") { item in
+                        Text((item.delta >= 0 ? "+" : "") + (Self.intFormatter.string(from: NSNumber(value: abs(item.delta))) ?? "0"))
+                            .foregroundColor(item.delta >= 0 ? Color.success : Color.error)
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                    }
+                }
+            }
+            HStack {
+                Spacer()
+                Button("Close") { onClose() }
+                    .buttonStyle(PrimaryButtonStyle())
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 500, minHeight: 400)
+    }
+}


### PR DESCRIPTION
## Summary
- gather row counts before and after restoring a database
- expose the row deltas through `RestoreComparisonRow`
- present a modal Restore Comparison table after restore

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881539f8bf083238d288914b146f387