### PR TITLE
feat(restore): show row count comparison after restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Prompt to confirm option quantity multiplier during position import
+- Show per-table row count comparison after restore in a modal window
 - Confirm deletion of positions per account type with live count
 - Generate full instrument report from Database Management view
 - Use latest flagged FX rates for import value calculations and report applied rates

--- a/DragonShield/Views/RestoreComparisonView.swift
+++ b/DragonShield/Views/RestoreComparisonView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+struct RestoreComparisonView: View {
+    let rows: [RestoreDelta]
+    var onClose: () -> Void
+
+    private static let numFormatter: NumberFormatter = {
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        f.groupingSeparator = "'"
+        f.maximumFractionDigits = 0
+        return f
+    }()
+
+    private func fmt(_ value: Int) -> String {
+        Self.numFormatter.string(from: NSNumber(value: value)) ?? "0"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Restore Comparison")
+                .font(.system(size: 16, weight: .bold))
+                .foregroundColor(Theme.primaryAccent)
+            Table(rows) {
+                TableColumn("Table Name") { row in
+                    Text(row.table)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                TableColumn("Pre-Restore Count") { row in
+                    Text(fmt(row.preCount))
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                }
+                TableColumn("Post-Restore Count") { row in
+                    Text(fmt(row.postCount))
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                }
+                TableColumn("Delta") { row in
+                    let d = row.delta
+                    Text((d >= 0 ? "+" : "-") + fmt(abs(d)))
+                        .foregroundColor(d >= 0 ? .green : .red)
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                }
+            }
+            .frame(minHeight: 300)
+            HStack {
+                Spacer()
+                Button("Close") { onClose() }
+                    .buttonStyle(PrimaryButtonStyle())
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 500, minHeight: 400)
+    }
+}


### PR DESCRIPTION
## Summary
- record row counts before and after restoring the DB
- compute per-table deltas and return them to the caller
- display a modal `Restore Comparison` view with the counts
- open this view automatically when a restore finishes
- document the new feature in the changelog

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881539f8bf083238d288914b146f387