### PR TITLE
Fix backup thread issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -364,3 +364,5 @@ All notable changes to this project will be documented in this file.
 - Keep original backup file by copying to a temporary location before atomic replace
 - Document python backup_restore script in README
 - Close SQLite connection before file moves and update dbVersion on main thread
+- Publish backup directory updates and last backup date on the main thread
+- Replace deprecated onChange calls in PositionsView

--- a/DragonShield/BackupService.swift
+++ b/DragonShield/BackupService.swift
@@ -102,7 +102,9 @@ class BackupService: ObservableObject {
     func updateBackupDirectory(to url: URL) throws {
         if isAccessing { backupDirectory.stopAccessingSecurityScopedResource(); isAccessing = false }
         try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
-        backupDirectory = url
+        DispatchQueue.main.async {
+            self.backupDirectory = url
+        }
         UserDefaults.standard.set(url, forKey: UserDefaultsKeys.backupDirectoryURL)
         if let data = try? url.bookmarkData(options: [.withSecurityScope], includingResourceValuesForKeys: nil, relativeTo: nil) {
             UserDefaults.standard.set(data, forKey: UserDefaultsKeys.backupDirectoryBookmark)
@@ -185,10 +187,11 @@ class BackupService: ObservableObject {
 
         let counts = rowCounts(db: dst, tables: tables)
 
-        lastBackup = Date()
-        UserDefaults.standard.set(lastBackup, forKey: UserDefaultsKeys.lastBackupTimestamp)
+        let backupDate = Date()
+        UserDefaults.standard.set(backupDate, forKey: UserDefaultsKeys.lastBackupTimestamp)
 
         DispatchQueue.main.async {
+            self.lastBackup = backupDate
             func pad(_ value: String, _ len: Int) -> String {
                 value.padding(toLength: len, withPad: " ", startingAt: 0)
             }

--- a/DragonShield/Views/PositionsView.swift
+++ b/DragonShield/Views/PositionsView.swift
@@ -731,8 +731,8 @@ struct DeletePositionsSheet: View {
         .padding(20)
         .frame(minWidth: 340)
         .onAppear { updateCount() }
-        .onChange(of: instIds) { _ in updateCount() }
-        .onChange(of: typeIds) { _ in updateCount() }
+        .onChange(of: instIds) { updateCount() }
+        .onChange(of: typeIds) { updateCount() }
     }
 
     private func updateCount() {


### PR DESCRIPTION
## Summary
- publish backup updates on main thread
- use modern `onChange` API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'DragonShield')*

------
https://chatgpt.com/codex/tasks/task_e_688156f98bc08323875781ade8cc5d9a