### PR TITLE
Fix background publish warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -364,3 +364,4 @@ All notable changes to this project will be documented in this file.
 - Keep original backup file by copying to a temporary location before atomic replace
 - Document python backup_restore script in README
 - Close SQLite connection before file moves and update dbVersion on main thread
+- Ensure published properties update on main thread and migrate onChange syntax

--- a/DragonShield/Views/PositionsView.swift
+++ b/DragonShield/Views/PositionsView.swift
@@ -731,8 +731,8 @@ struct DeletePositionsSheet: View {
         .padding(20)
         .frame(minWidth: 340)
         .onAppear { updateCount() }
-        .onChange(of: instIds) { _ in updateCount() }
-        .onChange(of: typeIds) { _ in updateCount() }
+        .onChange(of: instIds) { updateCount() }
+        .onChange(of: typeIds) { updateCount() }
     }
 
     private func updateCount() {


### PR DESCRIPTION
## Summary
- publish BackupService property updates on the main thread
- migrate onChange handlers in Positions view

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'DragonShield')*
- `pip install -r requirements.txt` *(fails: could not find pysqlcipher3 due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688156f98bc08323875781ade8cc5d9a