### PR TITLE
Add Crypto Top 5 dashboard tile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Add Crypto Top 5 dashboard tile to highlight largest crypto holdings
 - Prompt to confirm option quantity multiplier during position import
 - Show per-table row count comparison after restore in a modal window
 - Widen Restore Comparison window to display all columns without scrolling

--- a/DragonShield/ViewModels/CryptoTop5ViewModel.swift
+++ b/DragonShield/ViewModels/CryptoTop5ViewModel.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+struct CryptoHolding: Identifiable {
+    let id = UUID()
+    let name: String
+    let valueCHF: Double
+    let percentage: Double
+}
+
+final class CryptoTop5ViewModel: ObservableObject {
+    @Published var holdings: [CryptoHolding] = []
+    @Published var loading: Bool = false
+
+    func load(db: DatabaseManager) {
+        loading = true
+        DispatchQueue.global().async {
+            let positions = db.fetchPositionReports()
+            var crypto: [(name: String, value: Double)] = []
+            var total: Double = 0
+            var rateCache: [String: Double] = [:]
+
+            for p in positions {
+                guard let price = p.currentPrice else { continue }
+                let sub = p.assetSubClass?.lowercased() ?? ""
+                if !sub.contains("crypto") { continue }
+                var value = p.quantity * price
+                let currency = p.instrumentCurrency.uppercased()
+                if currency != "CHF" {
+                    var rate = rateCache[currency]
+                    if rate == nil {
+                        rate = db.fetchExchangeRates(currencyCode: currency, upTo: nil).first?.rateToChf
+                        rateCache[currency] = rate
+                    }
+                    guard let r = rate else { continue }
+                    value *= r
+                }
+                crypto.append((name: p.instrumentName, value: value))
+                total += value
+            }
+
+            crypto.sort { $0.value > $1.value }
+            let top5 = Array(crypto.prefix(5))
+            let rows = top5.map { item -> CryptoHolding in
+                let pct = total > 0 ? (item.value / total * 100) : 0
+                return CryptoHolding(name: item.name, valueCHF: item.value, percentage: pct)
+            }
+
+            DispatchQueue.main.async {
+                self.holdings = rows
+                self.loading = false
+            }
+        }
+    }
+}
+

--- a/DragonShield/Views/DashboardTiles/CryptoTop5Tile.swift
+++ b/DragonShield/Views/DashboardTiles/CryptoTop5Tile.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+struct CryptoTop5Tile: DashboardTile {
+    init() {}
+    static let tileID = "crypto_top5"
+    static let tileName = "Crypto Top 5"
+    static let iconName = "bitcoinsign.circle"
+
+    @EnvironmentObject var dbManager: DatabaseManager
+    @StateObject private var viewModel = CryptoTop5ViewModel()
+
+    private static let valueFormatter: NumberFormatter = {
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        f.maximumFractionDigits = 0
+        f.groupingSeparator = "'"
+        return f
+    }()
+
+    var body: some View {
+        DashboardCard(title: Self.tileName) {
+            if viewModel.loading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, alignment: .center)
+            } else {
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(0..<5, id: \.self) { idx in
+                        rowView(index: idx)
+                    }
+                }
+            }
+        }
+        .onAppear { viewModel.load(db: dbManager) }
+        .accessibilityElement(children: .combine)
+    }
+
+    @ViewBuilder
+    private func rowView(index: Int) -> some View {
+        if index < viewModel.holdings.count {
+            let item = viewModel.holdings[index]
+            HStack {
+                Text(item.name)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                Text(Self.valueFormatter.string(from: NSNumber(value: item.valueCHF)) ?? "0") + Text(" CHF")
+                    .frame(width: 80, alignment: .trailing)
+                Text(String(format: "%.1f%%", item.percentage))
+                    .frame(width: 50, alignment: .trailing)
+            }
+            .font(.system(size: 13))
+            .frame(minHeight: 44)
+        } else {
+            HStack {
+                Text("–")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                Text("–")
+                    .frame(width: 80, alignment: .trailing)
+                Text("–")
+                    .frame(width: 50, alignment: .trailing)
+            }
+            .font(.system(size: 13))
+            .frame(minHeight: 44)
+        }
+    }
+}
+

--- a/DragonShield/Views/DashboardTiles/DashboardTiles.swift
+++ b/DragonShield/Views/DashboardTiles/DashboardTiles.swift
@@ -259,6 +259,7 @@ enum TileRegistry {
         TileInfo(id: MetricTile.tileID, name: MetricTile.tileName, icon: MetricTile.iconName) { AnyView(MetricTile()) },
         TileInfo(id: TotalValueTile.tileID, name: TotalValueTile.tileName, icon: TotalValueTile.iconName) { AnyView(TotalValueTile()) },
         TileInfo(id: TopPositionsTile.tileID, name: TopPositionsTile.tileName, icon: TopPositionsTile.iconName) { AnyView(TopPositionsTile()) },
+        TileInfo(id: CryptoTop5Tile.tileID, name: CryptoTop5Tile.tileName, icon: CryptoTop5Tile.iconName) { AnyView(CryptoTop5Tile()) },
 
         TileInfo(id: CurrencyExposureTile.tileID, name: CurrencyExposureTile.tileName, icon: CurrencyExposureTile.iconName) { AnyView(CurrencyExposureTile()) },
         TileInfo(id: RiskBucketsTile.tileID, name: RiskBucketsTile.tileName, icon: RiskBucketsTile.iconName) { AnyView(RiskBucketsTile()) },

--- a/DragonShield/Views/DashboardView.swift
+++ b/DragonShield/Views/DashboardView.swift
@@ -47,6 +47,9 @@ struct DashboardView: View {
             tileIDs = saved.filter { id in TileRegistry.all.contains { $0.id == id } }
         } else {
             tileIDs = TileRegistry.all.map { $0.id }
+            if let idx = tileIDs.firstIndex(of: CryptoTop5Tile.tileID) {
+                tileIDs.move(fromOffsets: IndexSet(integer: idx), toOffset: 0)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- compute top 5 crypto holdings in CHF
- display them in new `CryptoTop5Tile`
- place the tile first on the dashboard grid
- register the tile in `TileRegistry`
- changelog entry

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'DragonShield')*

------
https://chatgpt.com/codex/tasks/task_e_68815c5632dc8323940259c52848080d