### PR TITLE
Add scrolling crypto allocation tile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Document production folder path and backups in README
 - Compute value report from positions when stored data is missing
 - Fix unused variable warning when computing position values
+- Display consolidated crypto allocations with scrolling in Dashboard (#PR)
 - Add Crypto Top 5 dashboard tile showing largest crypto holdings
 - Populate import session value report modal with stored rows
 - Improve Credit-Suisse parser instrument matching via Valor/ISIN with row-level logging of Valor and ISIN


### PR DESCRIPTION
## Summary
- aggregate crypto holdings across all accounts
- display all cryptocurrencies sorted by CHF value
- allow vertical scrolling within the crypto tile
- rename tile to *Crypto Allocations*

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68815f3f60c4832387f2b745fa7ffdbc