### PR TITLE
Add exclude real estate toggle to Top 10 tile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Widen Restore Comparison window to display all columns without scrolling
 - Confirm deletion of positions per account type with live count
 - Generate full instrument report from Database Management view
+- Revise Top 10 Positions dashboard tile with header logo and "Exclude Own Real Estate" toggle
 - Use latest flagged FX rates for import value calculations and report applied rates
 - Store import session total value and add CLI summary report
 - Show imported position values in CHF after import completes

--- a/DragonShield/ViewModels/PositionsViewModel.swift
+++ b/DragonShield/ViewModels/PositionsViewModel.swift
@@ -88,8 +88,11 @@ class PositionsViewModel: ObservableObject {
         }
     }
 
-    func calculateTop10Positions(db: DatabaseManager) {
-        let positions = db.fetchPositionReports()
+    func calculateTop10Positions(db: DatabaseManager, excludeRealEstate: Bool = false) {
+        var positions = db.fetchPositionReports()
+        if excludeRealEstate {
+            positions.removeAll { $0.assetSubClass?.lowercased() == "own real estate".lowercased() }
+        }
         calculateValues(positions: positions, db: db)
     }
 }

--- a/DragonShield/Views/DashboardTiles/DashboardTiles.swift
+++ b/DragonShield/Views/DashboardTiles/DashboardTiles.swift
@@ -142,6 +142,7 @@ struct TotalValueTile: DashboardTile {
 struct TopPositionsTile: DashboardTile {
     @EnvironmentObject var dbManager: DatabaseManager
     @StateObject private var viewModel = PositionsViewModel()
+    @State private var excludeRealEstate = false
 
     init() {}
     static let tileID = "top_positions"
@@ -150,8 +151,17 @@ struct TopPositionsTile: DashboardTile {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text(Self.tileName)
-                .font(.headline)
+            HStack {
+                Text(Self.tileName)
+                    .font(.headline)
+                Spacer()
+                Image("Top10Icon")
+                    .resizable()
+                    .frame(width: 24, height: 24)
+                    .accessibilityLabel("Top 10 icon")
+            }
+            Toggle("Exclude Own Real Estate", isOn: $excludeRealEstate)
+                .accessibilityLabel("Exclude Own Real Estate")
             if viewModel.calculating {
                 ProgressView()
                     .frame(maxWidth: .infinity, alignment: .center)
@@ -183,10 +193,13 @@ struct TopPositionsTile: DashboardTile {
             }
         }
         .padding(16)
-        .background(Color(red: 216/255, green: 236/255, blue: 248/255))
+        .background(Color.white)
         .cornerRadius(12)
         .shadow(color: .black.opacity(0.1), radius: 3, x: 0, y: 2)
-        .onAppear { viewModel.calculateTop10Positions(db: dbManager) }
+        .onAppear { viewModel.calculateTop10Positions(db: dbManager, excludeRealEstate: excludeRealEstate) }
+        .onChange(of: excludeRealEstate) { _, newValue in
+            viewModel.calculateTop10Positions(db: dbManager, excludeRealEstate: newValue)
+        }
         .accessibilityElement(children: .combine)
     }
 }


### PR DESCRIPTION
## Summary
- update PositionsViewModel helper to optionally filter out own real estate
- restyle Top 10 Positions tile with white background and header icon
- add toggle to exclude "Own Real Estate" positions
- document the new toggle in the changelog

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688161e8e2c48323abecfe2b4585e3cb