### PR TITLE
Add filter toggle to Top 10 positions tile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -369,3 +369,4 @@ All notable changes to this project will be documented in this file.
 - Close SQLite connection before file moves and update dbVersion on main thread
 - Ensure published properties update on main thread and migrate onChange syntax
 - Distinct colors for each risk bucket segment and matching legend
+- Add exclude toggle and header logo to Top 10 Positions dashboard tile

--- a/DragonShield/ViewModels/PositionsViewModel.swift
+++ b/DragonShield/ViewModels/PositionsViewModel.swift
@@ -88,8 +88,12 @@ class PositionsViewModel: ObservableObject {
         }
     }
 
-    func calculateTop10Positions(db: DatabaseManager) {
-        let positions = db.fetchPositionReports()
+    func calculateTop10Positions(db: DatabaseManager,
+                                 excludeOwnRealEstate: Bool = false) {
+        var positions = db.fetchPositionReports()
+        if excludeOwnRealEstate {
+            positions = positions.filter { $0.assetSubClass != "Own Real Estate" }
+        }
         calculateValues(positions: positions, db: db)
     }
 }

--- a/DragonShield/Views/DashboardTiles/DashboardTiles.swift
+++ b/DragonShield/Views/DashboardTiles/DashboardTiles.swift
@@ -139,57 +139,6 @@ struct TotalValueTile: DashboardTile {
     }
 }
 
-struct TopPositionsTile: DashboardTile {
-    @EnvironmentObject var dbManager: DatabaseManager
-    @StateObject private var viewModel = PositionsViewModel()
-
-    init() {}
-    static let tileID = "top_positions"
-    static let tileName = "Top 10 Positions by Asset Value (CHF)"
-    static let iconName = "list.number"
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text(Self.tileName)
-                .font(.headline)
-            if viewModel.calculating {
-                ProgressView()
-                    .frame(maxWidth: .infinity, alignment: .center)
-            } else {
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 4) {
-                        ForEach(Array(viewModel.top10PositionsCHF.enumerated()), id: \.element.id) { index, item in
-                            HStack {
-                                VStack(alignment: .leading, spacing: 2) {
-                                    Text(item.instrument)
-                                        .fontWeight(.semibold)
-                                        .lineLimit(1)
-                                    Text(String(format: "%.2f CHF", item.valueCHF))
-                                        .font(.caption)
-                                        .foregroundColor(Color(red: 30/255, green: 58/255, blue: 138/255))
-                                }
-                                Spacer()
-                                Text(item.currency)
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
-                            }
-                            .padding(4)
-                            .background(index == 0 ? Color(red: 191/255, green: 219/255, blue: 254/255) : Color.clear)
-                            .cornerRadius(6)
-                        }
-                    }
-                }
-                .frame(maxHeight: viewModel.top10PositionsCHF.count > 6 ? 220 : .infinity)
-            }
-        }
-        .padding(16)
-        .background(Color(red: 216/255, green: 236/255, blue: 248/255))
-        .cornerRadius(12)
-        .shadow(color: .black.opacity(0.1), radius: 3, x: 0, y: 2)
-        .onAppear { viewModel.calculateTop10Positions(db: dbManager) }
-        .accessibilityElement(children: .combine)
-    }
-}
 
 struct TextTile: DashboardTile {
     init() {}
@@ -258,7 +207,7 @@ enum TileRegistry {
         TileInfo(id: ListTile.tileID, name: ListTile.tileName, icon: ListTile.iconName) { AnyView(ListTile()) },
         TileInfo(id: MetricTile.tileID, name: MetricTile.tileName, icon: MetricTile.iconName) { AnyView(MetricTile()) },
         TileInfo(id: TotalValueTile.tileID, name: TotalValueTile.tileName, icon: TotalValueTile.iconName) { AnyView(TotalValueTile()) },
-        TileInfo(id: TopPositionsTile.tileID, name: TopPositionsTile.tileName, icon: TopPositionsTile.iconName) { AnyView(TopPositionsTile()) },
+        TileInfo(id: Top10PositionsTile.tileID, name: Top10PositionsTile.tileName, icon: Top10PositionsTile.iconName) { AnyView(Top10PositionsTile()) },
         TileInfo(id: CryptoTop5Tile.tileID, name: CryptoTop5Tile.tileName, icon: CryptoTop5Tile.iconName) { AnyView(CryptoTop5Tile()) },
 
         TileInfo(id: CurrencyExposureTile.tileID, name: CurrencyExposureTile.tileName, icon: CurrencyExposureTile.iconName) { AnyView(CurrencyExposureTile()) },

--- a/DragonShield/Views/Top10PositionsTile.swift
+++ b/DragonShield/Views/Top10PositionsTile.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+struct Top10PositionsTile: DashboardTile {
+    @EnvironmentObject var dbManager: DatabaseManager
+    @StateObject private var viewModel = PositionsViewModel()
+    @State private var excludeRealEstate = false
+
+    init() {}
+    static let tileID = "top_positions"
+    static let tileName = "Top 10 Positions by Asset Value (CHF)"
+    static let iconName = "list.number"
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text(Self.tileName)
+                    .font(.headline)
+                Spacer()
+                Image("Top10Icon")
+                    .resizable()
+                    .frame(width: 24, height: 24)
+                    .accessibilityLabel("Top 10 Positions Icon")
+            }
+            Toggle("Exclude Own Real Estate", isOn: $excludeRealEstate)
+                .font(.subheadline)
+                .accessibilityLabel("Exclude Own Real Estate")
+            if viewModel.calculating {
+                ProgressView()
+                    .frame(maxWidth: .infinity, alignment: .center)
+            } else {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 4) {
+                        ForEach(Array(viewModel.top10PositionsCHF.enumerated()), id: \.
+ element.id) { index, item in
+                            HStack {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(item.instrument)
+                                        .fontWeight(.semibold)
+                                        .lineLimit(1)
+                                    Text(String(format: "%.2f CHF", item.valueCHF))
+                                        .font(.caption)
+                                        .foregroundColor(Color(red: 30/255, green: 58/255, blue: 138/255))
+                                }
+                                Spacer()
+                                Text(item.currency)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                            .padding(4)
+                            .background(index == 0 ? Color(red: 191/255, green: 219/255, blue: 254/255) : Color.clear)
+                            .cornerRadius(6)
+                        }
+                    }
+                }
+                .frame(maxHeight: viewModel.top10PositionsCHF.count > 6 ? 220 : .infinity)
+            }
+        }
+        .padding(16)
+        .background(Color.white)
+        .cornerRadius(12)
+        .shadow(color: .black.opacity(0.1), radius: 3, x: 0, y: 2)
+        .onAppear { viewModel.calculateTop10Positions(db: dbManager, excludeOwnRealEstate: excludeRealEstate) }
+        .onChange(of: excludeRealEstate) { newValue in
+            viewModel.calculateTop10Positions(db: dbManager, excludeOwnRealEstate: newValue)
+        }
+        .accessibilityElement(children: .combine)
+    }
+}


### PR DESCRIPTION
## Summary
- add toggle to filter out Own Real Estate positions
- display a 24x24 logo in the top 10 positions card
- refactor tile into separate file and register in dashboard

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688161e8e2c48323abecfe2b4585e3cb