### PR TITLE
Add choropleth map tile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Generate full instrument report from Database Management view
 - Use latest flagged FX rates for import value calculations and report applied rates
 - Store import session total value and add CLI summary report
+- Visualize position value by currency on a world map dashboard tile
 - Show imported position values in CHF after import completes
 - Persist full value reports per import session and view them from history
 - Persist value reports in database after import and fix Session Details sheet closing

--- a/DragonShield/ViewModels/CurrencyMapViewModel.swift
+++ b/DragonShield/ViewModels/CurrencyMapViewModel.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+struct CurrencyMapEntry: Identifiable {
+    let id = UUID()
+    let currency: String
+    let country: String
+    let totalCHF: Double
+}
+
+class CurrencyMapViewModel: ObservableObject {
+    @Published var entries: [CurrencyMapEntry] = []
+    @Published var quantiles: [Double] = []
+    @Published var loading: Bool = false
+
+    private let currencyToCountry: [String: String] = [
+        "USD": "United States",
+        "EUR": "Germany",
+        "GBP": "United Kingdom",
+        "CHF": "Switzerland",
+        "JPY": "Japan",
+        "CAD": "Canada",
+        "AUD": "Australia",
+        "CNY": "China",
+        "HKD": "Hong Kong",
+        "INR": "India"
+    ]
+
+    func calculate(db: DatabaseManager) {
+        loading = true
+        DispatchQueue.global().async {
+            let positions = db.fetchPositionReports()
+            var totals: [String: Double] = [:]
+            var rateCache: [String: Double] = [:]
+            for p in positions {
+                guard let price = p.currentPrice else { continue }
+                let currency = p.instrumentCurrency.uppercased()
+                var value = p.quantity * price
+                if currency != "CHF" {
+                    if rateCache[currency] == nil {
+                        let rates = db.fetchExchangeRates(currencyCode: currency, upTo: nil)
+                        if let rate = rates.first?.rateToChf { rateCache[currency] = rate }
+                    }
+                    if let rate = rateCache[currency] { value *= rate }
+                }
+                totals[currency, default: 0] += value
+            }
+            var entries: [CurrencyMapEntry] = []
+            for (code, total) in totals {
+                guard let country = self.currencyToCountry[code] else { continue }
+                entries.append(CurrencyMapEntry(currency: code, country: country, totalCHF: total))
+            }
+            entries.sort { $0.totalCHF > $1.totalCHF }
+            let values = entries.map { $0.totalCHF }.sorted()
+            var quantiles: [Double] = []
+            if !values.isEmpty {
+                for q in 1..<5 {
+                    let idx = Int(Double(values.count - 1) * Double(q) / 5.0)
+                    quantiles.append(values[idx])
+                }
+            }
+            DispatchQueue.main.async {
+                self.entries = entries
+                self.quantiles = quantiles
+                self.loading = false
+            }
+        }
+    }
+}

--- a/DragonShield/Views/CurrencyMapView.swift
+++ b/DragonShield/Views/CurrencyMapView.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+import MapKit
+
+struct CurrencyMapView: View {
+    let entries: [CurrencyMapEntry]
+    let quantiles: [Double]
+    @State private var selected: CurrencyMapEntry?
+    @State private var region = MKCoordinateRegion(
+        center: CLLocationCoordinate2D(latitude: 20, longitude: 0),
+        span: MKCoordinateSpan(latitudeDelta: 140, longitudeDelta: 360)
+    )
+
+    private func coordinate(for country: String) -> CLLocationCoordinate2D {
+        switch country {
+        case "United States": return .init(latitude: 37.0902, longitude: -95.7129)
+        case "Germany": return .init(latitude: 51.1657, longitude: 10.4515)
+        case "United Kingdom": return .init(latitude: 55.3781, longitude: -3.4360)
+        case "Switzerland": return .init(latitude: 46.8182, longitude: 8.2275)
+        case "Japan": return .init(latitude: 36.2048, longitude: 138.2529)
+        case "Canada": return .init(latitude: 56.1304, longitude: -106.3468)
+        case "Australia": return .init(latitude: -25.2744, longitude: 133.7751)
+        case "China": return .init(latitude: 35.8617, longitude: 104.1954)
+        case "Hong Kong": return .init(latitude: 22.3193, longitude: 114.1694)
+        case "India": return .init(latitude: 20.5937, longitude: 78.9629)
+        default: return .init(latitude: 0, longitude: 0)
+        }
+    }
+
+    private func color(for value: Double) -> Color {
+        guard !quantiles.isEmpty else { return Color.blue.opacity(0.3) }
+        switch value {
+        case ..<quantiles[0]: return Color.blue.opacity(0.3)
+        case ..<quantiles[1]: return Color.blue.opacity(0.45)
+        case ..<quantiles[2]: return Color.blue.opacity(0.6)
+        case ..<quantiles[3]: return Color.blue.opacity(0.75)
+        default: return Color.blue
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Map(coordinateRegion: $region) {
+                ForEach(entries) { entry in
+                    let coord = coordinate(for: entry.country)
+                    Annotation(entry.country, coordinate: coord) {
+                        Circle()
+                            .fill(color(for: entry.totalCHF))
+                            .frame(width: 16, height: 16)
+                            .onTapGesture { selected = entry }
+                    }
+                }
+            }
+            .frame(height: 160)
+            .cornerRadius(8)
+            .alert(item: $selected) { sel in
+                Alert(title: Text(sel.country), message: Text("\(sel.currency): \(Int(sel.totalCHF).formatted()) CHF"))
+            }
+
+            HStack(spacing: 4) {
+                Rectangle()
+                    .fill(LinearGradient(colors: [Color.blue.opacity(0.3), Color.blue], startPoint: .leading, endPoint: .trailing))
+                    .frame(height: 10)
+                if let min = entries.map({ $0.totalCHF }).min(), let max = entries.map({ $0.totalCHF }).max() {
+                    Text("\(Int(min))")
+                        .font(.caption2)
+                    Spacer()
+                    Text("\(Int(max))")
+                        .font(.caption2)
+                }
+            }
+        }
+    }
+}

--- a/DragonShield/Views/DashboardTiles/DashboardTiles.swift
+++ b/DragonShield/Views/DashboardTiles/DashboardTiles.swift
@@ -227,20 +227,24 @@ struct ImageTile: DashboardTile {
 }
 
 struct MapTile: DashboardTile {
+    @EnvironmentObject var dbManager: DatabaseManager
+    @StateObject private var viewModel = CurrencyMapViewModel()
+
     init() {}
     static let tileID = "map"
-    static let tileName = "Map Tile"
+    static let tileName = "Position Value by Currency"
     static let iconName = "map"
 
     var body: some View {
         DashboardCard(title: Self.tileName) {
-            Color.gray.opacity(0.3)
-                .frame(height: 120)
-                .overlay(Image(systemName: "map")
-                            .font(.largeTitle)
-                            .foregroundColor(.gray))
-                .cornerRadius(4)
+            if viewModel.loading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, alignment: .center)
+            } else {
+                CurrencyMapView(entries: viewModel.entries, quantiles: viewModel.quantiles)
+            }
         }
+        .onAppear { viewModel.calculate(db: dbManager) }
         .accessibilityElement(children: .combine)
     }
 }


### PR DESCRIPTION
## Summary
- visualize position value by currency on a world map tile

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881b17755f4832382d2168503b8d7bf