### PR TITLE
feat: add currency choropleth map tile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -369,3 +369,4 @@ All notable changes to this project will be documented in this file.
 - Close SQLite connection before file moves and update dbVersion on main thread
 - Ensure published properties update on main thread and migrate onChange syntax
 - Distinct colors for each risk bucket segment and matching legend
+- Display currency choropleth world map in Dashboard

--- a/DragonShield/Resources/geo/countries_simple.geojson
+++ b/DragonShield/Resources/geo/countries_simple.geojson
@@ -1,0 +1,9 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {"type": "Feature", "properties": {"ADMIN": "Switzerland"}, "geometry": {"type": "Polygon", "coordinates": [[[5.956,45.818],[10.492,45.818],[10.492,47.808],[5.956,47.808],[5.956,45.818]]]}},
+    {"type": "Feature", "properties": {"ADMIN": "United States"}, "geometry": {"type": "Polygon", "coordinates": [[[-124.784,24.743],[-66.951,24.743],[-66.951,49.345],[-124.784,49.345],[-124.784,24.743]]]}},
+    {"type": "Feature", "properties": {"ADMIN": "Germany"}, "geometry": {"type": "Polygon", "coordinates": [[[5.866,47.302],[15.041,47.302],[15.041,55.099],[5.866,55.099],[5.866,47.302]]]}},
+    {"type": "Feature", "properties": {"ADMIN": "United Kingdom"}, "geometry": {"type": "Polygon", "coordinates": [[[-8.649,49.906],[1.768,49.906],[1.768,58.635],[-8.649,58.635],[-8.649,49.906]]]}}
+  ]
+}

--- a/DragonShield/ViewModels/MapTileViewModel.swift
+++ b/DragonShield/ViewModels/MapTileViewModel.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+import MapKit
+
+struct CountryExposure: Identifiable {
+    let id = UUID()
+    let country: String
+    let currency: String
+    let totalCHF: Double
+    var polygon: MKPolygon?
+    var fillColor: Color = .blue
+}
+
+final class MapTileViewModel: ObservableObject {
+    @Published var countries: [CountryExposure] = []
+    @Published var legend: [ClosedRange<Double>] = []
+    @Published var loading = false
+
+    private let currencyToCountry: [String: String] = [
+        "USD": "United States",
+        "EUR": "Germany",
+        "GBP": "United Kingdom",
+        "CHF": "Switzerland"
+    ]
+
+    func load(using db: DatabaseManager) {
+        loading = true
+        DispatchQueue.global().async {
+            let positions = db.fetchPositionReports()
+            var totals: [String: Double] = [:]
+            var rateCache: [String: Double] = [:]
+            for p in positions {
+                guard let price = p.currentPrice else { continue }
+                let code = p.instrumentCurrency.uppercased()
+                var value = p.quantity * price
+                if code != "CHF" {
+                    if rateCache[code] == nil {
+                        rateCache[code] = db.fetchExchangeRates(currencyCode: code, upTo: nil).first?.rateToChf
+                    }
+                    guard let rate = rateCache[code] else { continue }
+                    value *= rate
+                }
+                totals[code, default: 0] += value
+            }
+
+            var exposures: [CountryExposure] = []
+            for (code, value) in totals {
+                guard let country = self.currencyToCountry[code], value > 0 else { continue }
+                exposures.append(CountryExposure(country: country, currency: code, totalCHF: value))
+            }
+
+            let values = exposures.map { $0.totalCHF }.sorted()
+            guard values.count > 0 else {
+                DispatchQueue.main.async { self.countries = []; self.loading = false }
+                return
+            }
+
+            let breakCount = 5
+            var ranges: [ClosedRange<Double>] = []
+            for i in 0..<breakCount {
+                let start = values[Int(Double(i) / Double(breakCount) * Double(values.count - 1))]
+                let end = values[Int(Double(i + 1) / Double(breakCount) * Double(values.count - 1))]
+                ranges.append(start...end)
+            }
+            let colors: [Color] = (0..<breakCount).map { i in
+                Color.blue.opacity(Double(i + 1) / Double(breakCount))
+            }
+
+            exposures = exposures.map { exp in
+                var c = exp
+                if let idx = ranges.firstIndex(where: { $0.contains(exp.totalCHF) }) {
+                    c.fillColor = colors[idx]
+                }
+                return c
+            }
+
+            if let polygons = self.loadPolygons() {
+                exposures = exposures.map { exp in
+                    var item = exp
+                    item.polygon = polygons[exp.country]
+                    return item
+                }
+            }
+
+            DispatchQueue.main.async {
+                self.legend = ranges
+                self.countries = exposures
+                self.loading = false
+            }
+        }
+    }
+
+    private func loadPolygons() -> [String: MKPolygon]? {
+        guard let url = Bundle.main.url(forResource: "countries_simple", withExtension: "geojson") else { return nil }
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        guard let features = try? MKGeoJSONDecoder().decode(data) as? [MKGeoJSONFeature] else { return nil }
+        var result: [String: MKPolygon] = [:]
+        for feature in features {
+            guard let name = feature.properties.flatMap({ try? JSONSerialization.jsonObject(with: $0) }) as? [String: Any],
+                  let admin = name["ADMIN"] as? String else { continue }
+            for case let polygon as MKPolygon in feature.geometry {
+                result[admin] = polygon
+            }
+        }
+        return result
+    }
+}

--- a/DragonShield/Views/DashboardTiles/DashboardTiles.swift
+++ b/DragonShield/Views/DashboardTiles/DashboardTiles.swift
@@ -226,24 +226,6 @@ struct ImageTile: DashboardTile {
     }
 }
 
-struct MapTile: DashboardTile {
-    init() {}
-    static let tileID = "map"
-    static let tileName = "Map Tile"
-    static let iconName = "map"
-
-    var body: some View {
-        DashboardCard(title: Self.tileName) {
-            Color.gray.opacity(0.3)
-                .frame(height: 120)
-                .overlay(Image(systemName: "map")
-                            .font(.largeTitle)
-                            .foregroundColor(.gray))
-                .cornerRadius(4)
-        }
-        .accessibilityElement(children: .combine)
-    }
-}
 
 struct TileInfo {
     let id: String

--- a/DragonShield/Views/DashboardTiles/MapTile.swift
+++ b/DragonShield/Views/DashboardTiles/MapTile.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+import MapKit
+
+struct MapTile: DashboardTile {
+    init() {}
+    static let tileID = "map"
+    static let tileName = "Position Value by Currency"
+    static let iconName = "map"
+
+    @EnvironmentObject var dbManager: DatabaseManager
+    @StateObject private var viewModel = MapTileViewModel()
+    @State private var tooltip: CountryExposure?
+
+    var body: some View {
+        DashboardCard(title: Self.tileName) {
+            if viewModel.loading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .frame(height: 150)
+            } else {
+                VStack(alignment: .leading, spacing: 8) {
+                    ChoroplethMap(countries: viewModel.countries, tooltip: $tooltip)
+                        .frame(maxWidth: .infinity)
+                        .aspectRatio(2, contentMode: .fit)
+                        .cornerRadius(4)
+                    LegendView(ranges: viewModel.legend)
+                }
+            }
+        }
+        .onAppear { viewModel.load(using: dbManager) }
+        .popover(item: $tooltip) { item in
+            VStack(alignment: .leading, spacing: 4) {
+                Text(item.country).bold()
+                Text(item.currency)
+                Text(Self.formatCHF(item.totalCHF))
+            }
+            .padding(8)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private static func formatCHF(_ value: Double) -> String {
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        f.maximumFractionDigits = 0
+        f.groupingSeparator = "'"
+        f.usesGroupingSeparator = true
+        return f.string(from: NSNumber(value: value)) ?? "0"
+    }
+}
+
+struct ChoroplethMap: UIViewRepresentable {
+    var countries: [CountryExposure]
+    @Binding var tooltip: CountryExposure?
+
+    func makeUIView(context: Context) -> MKMapView {
+        let map = MKMapView()
+        map.delegate = context.coordinator
+        map.isRotateEnabled = false
+        map.isZoomEnabled = false
+        map.isScrollEnabled = false
+        map.camera = MKMapCamera(lookingAtCenter: CLLocationCoordinate2D(latitude: 20, longitude: 0), fromDistance: 20000000, pitch: 0, heading: 0)
+        return map
+    }
+
+    func updateUIView(_ uiView: MKMapView, context: Context) {
+        uiView.removeOverlays(uiView.overlays)
+        for c in countries {
+            if let poly = c.polygon {
+                poly.title = c.country
+                uiView.addOverlay(poly)
+            }
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    class Coordinator: NSObject, MKMapViewDelegate {
+        var parent: ChoroplethMap
+        init(_ parent: ChoroplethMap) { self.parent = parent }
+
+        func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
+            guard let poly = overlay as? MKPolygon,
+                  let country = poly.title else { return MKOverlayRenderer(overlay: overlay) }
+            let renderer = MKPolygonRenderer(polygon: poly)
+            if let exposure = parent.countries.first(where: { $0.country == country }) {
+                renderer.fillColor = UIColor(exposure.fillColor)
+                renderer.strokeColor = UIColor.secondaryLabel
+                renderer.lineWidth = 0.5
+            }
+            return renderer
+        }
+
+        func mapView(_ mapView: MKMapView, didSelect overlay: MKOverlay) {
+            guard let poly = overlay as? MKPolygon,
+                  let title = poly.title,
+                  let exposure = parent.countries.first(where: { $0.country == title }) else { return }
+            parent.tooltip = exposure
+        }
+
+        func mapView(_ mapView: MKMapView, didDeselect overlay: MKOverlay) {
+            parent.tooltip = nil
+        }
+    }
+}
+
+struct LegendView: View {
+    var ranges: [ClosedRange<Double>]
+    private static let formatter: NumberFormatter = {
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        f.maximumFractionDigits = 0
+        f.groupingSeparator = "'"
+        f.usesGroupingSeparator = true
+        return f
+    }()
+
+    var body: some View {
+        HStack(spacing: 4) {
+            ForEach(Array(ranges.enumerated()), id: \._offset) { index, range in
+                Rectangle()
+                    .fill(Color.blue.opacity(Double(index + 1) / Double(ranges.count)))
+                    .frame(width: 20, height: 10)
+            }
+            Spacer()
+            if let first = ranges.first, let last = ranges.last {
+                Text(Self.formatter.string(from: NSNumber(value: first.lowerBound)) ?? "")
+                Text("-")
+                Text(Self.formatter.string(from: NSNumber(value: last.upperBound)) ?? "")
+            }
+        }
+        .font(.caption2)
+    }
+}


### PR DESCRIPTION
## Summary
- implement MapTileViewModel to aggregate currency values and load GeoJSON
- create MapTile SwiftUI view with interactive choropleth map and legend
- ship a minimal countries_simple.geojson resource
- hook MapTile into tile registry
- document the new dashboard map tile in the changelog

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881b17755f4832382d2168503b8d7bf