### PR TITLE
feat(dashboard): add currency map tile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Show imported position values in CHF after import completes
 - Persist full value reports per import session and view them from history
 - Persist value reports in database after import and fix Session Details sheet closing
+- Display position value by currency on a choropleth world map tile
 - Fix Import Values window closing when pressing the Close button
 - Present value report in a table window after import
 - Document production folder path and backups in README

--- a/DragonShield/ViewModels/CurrencyMapViewModel.swift
+++ b/DragonShield/ViewModels/CurrencyMapViewModel.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+import MapKit
+
+class CurrencyMapViewModel: ObservableObject {
+    @Published var totals: [String: Double] = [:]
+    @Published var quantileBreaks: [Double] = []
+    @Published var loading: Bool = false
+
+    func load(using db: DatabaseManager) {
+        loading = true
+        DispatchQueue.global().async {
+            let positions = db.fetchPositionReports()
+            var totals: [String: Double] = [:]
+            var rateCache: [String: Double] = [:]
+            for p in positions {
+                guard let price = p.currentPrice else { continue }
+                let currency = p.instrumentCurrency.uppercased()
+                var value = p.quantity * price
+                if currency != "CHF" {
+                    if rateCache[currency] == nil {
+                        rateCache[currency] = db.fetchExchangeRates(currencyCode: currency, upTo: nil).first?.rateToChf
+                    }
+                    if let rate = rateCache[currency] { value *= rate } else { continue }
+                }
+                totals[currency, default: 0] += value
+            }
+            let values = totals.values.sorted()
+            var breaks: [Double] = []
+            if !values.isEmpty {
+                for i in 1..<5 {
+                    let idx = Int(Double(values.count - 1) * Double(i) / 5.0)
+                    breaks.append(values[idx])
+                }
+            }
+            DispatchQueue.main.async {
+                self.totals = totals
+                self.quantileBreaks = breaks
+                self.loading = false
+            }
+        }
+    }
+}

--- a/DragonShield/helpers/CountryShapes.swift
+++ b/DragonShield/helpers/CountryShapes.swift
@@ -1,0 +1,46 @@
+import MapKit
+
+struct CountryShape {
+    let code: String
+    let name: String
+    let currency: String
+    let coordinates: [CLLocationCoordinate2D]
+}
+
+struct CountryShapes {
+    static func shape(for currency: String) -> CountryShape? {
+        shapes.first { $0.currency.uppercased() == currency.uppercased() }
+    }
+
+    static let shapes: [CountryShape] = [
+        CountryShape(code: "US", name: "United States", currency: "USD",
+                     coordinates: rectangle(latMin: 24, latMax: 49, lonMin: -125, lonMax: -66)),
+        CountryShape(code: "CH", name: "Switzerland", currency: "CHF",
+                     coordinates: rectangle(latMin: 45, latMax: 48, lonMin: 6, lonMax: 11)),
+        CountryShape(code: "DE", name: "Germany", currency: "EUR",
+                     coordinates: rectangle(latMin: 47, latMax: 55, lonMin: 5, lonMax: 16)),
+        CountryShape(code: "GB", name: "United Kingdom", currency: "GBP",
+                     coordinates: rectangle(latMin: 50, latMax: 59, lonMin: -8, lonMax: 2)),
+        CountryShape(code: "JP", name: "Japan", currency: "JPY",
+                     coordinates: rectangle(latMin: 31, latMax: 46, lonMin: 129, lonMax: 146)),
+        CountryShape(code: "CA", name: "Canada", currency: "CAD",
+                     coordinates: rectangle(latMin: 42, latMax: 83, lonMin: -141, lonMax: -52)),
+        CountryShape(code: "AU", name: "Australia", currency: "AUD",
+                     coordinates: rectangle(latMin: -44, latMax: -10, lonMin: 113, lonMax: 154)),
+        CountryShape(code: "CN", name: "China", currency: "CNY",
+                     coordinates: rectangle(latMin: 18, latMax: 54, lonMin: 73, lonMax: 135)),
+        CountryShape(code: "IN", name: "India", currency: "INR",
+                     coordinates: rectangle(latMin: 8, latMax: 37, lonMin: 68, lonMax: 97)),
+        CountryShape(code: "BR", name: "Brazil", currency: "BRL",
+                     coordinates: rectangle(latMin: -35, latMax: 5, lonMin: -74, lonMax: -34))
+    ]
+
+    private static func rectangle(latMin: Double, latMax: Double, lonMin: Double, lonMax: Double) -> [CLLocationCoordinate2D] {
+        [
+            CLLocationCoordinate2D(latitude: latMin, longitude: lonMin),
+            CLLocationCoordinate2D(latitude: latMin, longitude: lonMax),
+            CLLocationCoordinate2D(latitude: latMax, longitude: lonMax),
+            CLLocationCoordinate2D(latitude: latMax, longitude: lonMin)
+        ]
+    }
+}


### PR DESCRIPTION
## Summary
- show choropleth map of position value by currency
- add simple country shapes and data aggregation view model

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'DragonShield')*

------
https://chatgpt.com/codex/tasks/task_e_6881b17755f4832382d2168503b8d7bf