### PR TITLE
Add currency choropleth map tile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -369,3 +369,4 @@ All notable changes to this project will be documented in this file.
 - Close SQLite connection before file moves and update dbVersion on main thread
 - Ensure published properties update on main thread and migrate onChange syntax
 - Distinct colors for each risk bucket segment and matching legend
+- Add Position Value by Currency map tile with blue-shade choropleth

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -370,3 +370,4 @@ All notable changes to this project will be documented in this file.
 - Ensure published properties update on main thread and migrate onChange syntax
 - Distinct colors for each risk bucket segment and matching legend
 - Add Position Value by Currency map tile with blue-shade choropleth
+- Fix compile error using alphaValue on macOS map annotations

--- a/DragonShield/ViewModels/CurrencyMapViewModel.swift
+++ b/DragonShield/ViewModels/CurrencyMapViewModel.swift
@@ -1,0 +1,143 @@
+import SwiftUI
+import MapKit
+
+struct CountryValue: Identifiable {
+    let id = UUID()
+    let country: String
+    let currency: String
+    let totalCHF: Double
+    let polygon: [CLLocationCoordinate2D]
+    var centroid: CLLocationCoordinate2D {
+        let lat = polygon.map { $0.latitude }.reduce(0, +) / Double(polygon.count)
+        let lon = polygon.map { $0.longitude }.reduce(0, +) / Double(polygon.count)
+        return CLLocationCoordinate2D(latitude: lat, longitude: lon)
+    }
+}
+
+class CurrencyMapViewModel: ObservableObject {
+    @Published var countryValues: [CountryValue] = []
+    @Published var quantileBreaks: [Double] = []
+    @Published var loading = false
+
+    private let currencyToCountry: [String: String] = [
+        "USD": "United States",
+        "EUR": "Germany",
+        "GBP": "United Kingdom",
+        "CHF": "Switzerland",
+        "JPY": "Japan",
+        "CNY": "China"
+    ]
+
+    private let polygons: [String: [CLLocationCoordinate2D]] = [
+        "United States": [
+            CLLocationCoordinate2D(latitude: 25, longitude: -125),
+            CLLocationCoordinate2D(latitude: 25, longitude: -66),
+            CLLocationCoordinate2D(latitude: 49, longitude: -66),
+            CLLocationCoordinate2D(latitude: 49, longitude: -125)
+        ],
+        "Germany": [
+            CLLocationCoordinate2D(latitude: 47, longitude: 5),
+            CLLocationCoordinate2D(latitude: 47, longitude: 15),
+            CLLocationCoordinate2D(latitude: 55, longitude: 15),
+            CLLocationCoordinate2D(latitude: 55, longitude: 5)
+        ],
+        "United Kingdom": [
+            CLLocationCoordinate2D(latitude: 50, longitude: -8),
+            CLLocationCoordinate2D(latitude: 50, longitude: 2),
+            CLLocationCoordinate2D(latitude: 59, longitude: 2),
+            CLLocationCoordinate2D(latitude: 59, longitude: -8)
+        ],
+        "Switzerland": [
+            CLLocationCoordinate2D(latitude: 46, longitude: 5),
+            CLLocationCoordinate2D(latitude: 46, longitude: 11),
+            CLLocationCoordinate2D(latitude: 48, longitude: 11),
+            CLLocationCoordinate2D(latitude: 48, longitude: 5)
+        ],
+        "Japan": [
+            CLLocationCoordinate2D(latitude: 31, longitude: 129),
+            CLLocationCoordinate2D(latitude: 31, longitude: 146),
+            CLLocationCoordinate2D(latitude: 45, longitude: 146),
+            CLLocationCoordinate2D(latitude: 45, longitude: 129)
+        ],
+        "China": [
+            CLLocationCoordinate2D(latitude: 18, longitude: 73),
+            CLLocationCoordinate2D(latitude: 18, longitude: 135),
+            CLLocationCoordinate2D(latitude: 53, longitude: 135),
+            CLLocationCoordinate2D(latitude: 53, longitude: 73)
+        ]
+    ]
+
+    private static let formatter: NumberFormatter = {
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        f.maximumFractionDigits = 0
+        f.groupingSeparator = "'"
+        return f
+    }()
+
+    func load(using db: DatabaseManager) {
+        loading = true
+        DispatchQueue.global().async {
+            let positions = db.fetchPositionReports()
+            var totals: [String: Double] = [:]
+            var rateCache: [String: Double] = [:]
+            for p in positions {
+                guard let price = p.currentPrice else { continue }
+                let currency = p.instrumentCurrency.uppercased()
+                var value = p.quantity * price
+                if currency != "CHF" {
+                    if rateCache[currency] == nil {
+                        rateCache[currency] = db.fetchExchangeRates(currencyCode: currency, upTo: nil).first?.rateToChf
+                    }
+                    if let rate = rateCache[currency] { value *= rate } else { continue }
+                }
+                totals[currency, default: 0] += value
+            }
+            let filtered = totals.filter { $0.value > 0 }
+            let sortedVals = filtered.map { $0.value }.sorted()
+            let breaks = (0...5).map { i -> Double in
+                guard !sortedVals.isEmpty else { return 0 }
+                let q = Double(i) / 5.0
+                let idx = Int(Double(sortedVals.count - 1) * q)
+                return sortedVals[idx]
+            }
+            var result: [CountryValue] = []
+            for (currency, value) in filtered {
+                if let country = self.currencyToCountry[currency], let poly = self.polygons[country] {
+                    result.append(CountryValue(country: country, currency: currency, totalCHF: value, polygon: poly))
+                }
+            }
+            DispatchQueue.main.async {
+                self.countryValues = result
+                self.quantileBreaks = breaks
+                self.loading = false
+            }
+        }
+    }
+
+    func color(for value: Double) -> Color {
+        guard quantileBreaks.count == 6 else { return Color.clear }
+        let breaks = quantileBreaks
+        let idx: Int
+        if value <= breaks[1] { idx = 0 }
+        else if value <= breaks[2] { idx = 1 }
+        else if value <= breaks[3] { idx = 2 }
+        else if value <= breaks[4] { idx = 3 }
+        else { idx = 4 }
+        let brightness = 0.4 + Double(idx) * 0.1
+        return Color(hue: 210/360, saturation: 0.6, brightness: brightness)
+    }
+
+    func rangeText(for index: Int) -> String {
+        guard quantileBreaks.count == 6 else { return "" }
+        let lower = quantileBreaks[index]
+        let upper = quantileBreaks[index + 1]
+        let lText = Self.formatter.string(from: NSNumber(value: lower)) ?? "0"
+        let uText = Self.formatter.string(from: NSNumber(value: upper)) ?? "0"
+        return "\(lText)-\(uText)"
+    }
+
+    func formatted(value: Double) -> String {
+        Self.formatter.string(from: NSNumber(value: value)) ?? "0"
+    }
+}

--- a/DragonShield/Views/CurrencyChoroplethMapView.swift
+++ b/DragonShield/Views/CurrencyChoroplethMapView.swift
@@ -24,6 +24,12 @@ struct CurrencyChoroplethMapView: NSViewRepresentable {
             polygon.title = country.country
             context.coordinator.data[polygon] = country
             mapView.addOverlay(polygon)
+
+            let annotation = MKPointAnnotation()
+            annotation.coordinate = country.centroid
+            annotation.title = "\(country.country) – \(country.currency)"
+            annotation.subtitle = "\(viewModel.formatted(value: country.totalCHF)) CHF"
+            mapView.addAnnotation(annotation)
         }
         mapView.setVisibleMapRect(MKMapRect.world, animated: false)
     }
@@ -43,19 +49,10 @@ struct CurrencyChoroplethMapView: NSViewRepresentable {
             return renderer
         }
 
-        func mapView(_ mapView: MKMapView, didSelect overlay: MKOverlay) {
-            guard let poly = overlay as? MKPolygon, let info = data[poly] else { return }
-            let annotation = MKPointAnnotation()
-            annotation.coordinate = info.centroid
-            annotation.title = "\(info.country) – \(info.currency)"
-            annotation.subtitle = "\(viewModel.formatted(value: info.totalCHF)) CHF"
-            mapView.addAnnotation(annotation)
-            mapView.selectAnnotation(annotation, animated: true)
-        }
-
         func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
             let view = MKMarkerAnnotationView(annotation: annotation, reuseIdentifier: nil)
             view.canShowCallout = true
+            view.alpha = 0
             return view
         }
     }

--- a/DragonShield/Views/CurrencyChoroplethMapView.swift
+++ b/DragonShield/Views/CurrencyChoroplethMapView.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+import MapKit
+
+struct CurrencyChoroplethMapView: NSViewRepresentable {
+    @ObservedObject var viewModel: CurrencyMapViewModel
+
+    func makeCoordinator() -> Coordinator { Coordinator(viewModel: viewModel) }
+
+    func makeNSView(context: Context) -> MKMapView {
+        let map = MKMapView()
+        map.delegate = context.coordinator
+        map.isRotateEnabled = false
+        map.isZoomEnabled = false
+        map.isScrollEnabled = false
+        map.pointOfInterestFilter = .excludingAll
+        return map
+    }
+
+    func updateNSView(_ mapView: MKMapView, context: Context) {
+        mapView.removeOverlays(mapView.overlays)
+        mapView.removeAnnotations(mapView.annotations)
+        for country in viewModel.countryValues {
+            let polygon = MKPolygon(coordinates: country.polygon, count: country.polygon.count)
+            polygon.title = country.country
+            context.coordinator.data[polygon] = country
+            mapView.addOverlay(polygon)
+        }
+        mapView.setVisibleMapRect(MKMapRect.world, animated: false)
+    }
+
+    class Coordinator: NSObject, MKMapViewDelegate {
+        var viewModel: CurrencyMapViewModel
+        var data: [MKPolygon: CountryValue] = [:]
+        init(viewModel: CurrencyMapViewModel) { self.viewModel = viewModel }
+
+        func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
+            guard let poly = overlay as? MKPolygon, let info = data[poly] else {
+                return MKOverlayRenderer()
+            }
+            let renderer = MKPolygonRenderer(polygon: poly)
+            renderer.fillColor = NSColor(viewModel.color(for: info.totalCHF))
+            renderer.strokeColor = .clear
+            return renderer
+        }
+
+        func mapView(_ mapView: MKMapView, didSelect overlay: MKOverlay) {
+            guard let poly = overlay as? MKPolygon, let info = data[poly] else { return }
+            let annotation = MKPointAnnotation()
+            annotation.coordinate = info.centroid
+            annotation.title = "\(info.country) – \(info.currency)"
+            annotation.subtitle = "\(viewModel.formatted(value: info.totalCHF)) CHF"
+            mapView.addAnnotation(annotation)
+            mapView.selectAnnotation(annotation, animated: true)
+        }
+
+        func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
+            let view = MKMarkerAnnotationView(annotation: annotation, reuseIdentifier: nil)
+            view.canShowCallout = true
+            return view
+        }
+    }
+}

--- a/DragonShield/Views/CurrencyChoroplethMapView.swift
+++ b/DragonShield/Views/CurrencyChoroplethMapView.swift
@@ -52,7 +52,7 @@ struct CurrencyChoroplethMapView: NSViewRepresentable {
         func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
             let view = MKMarkerAnnotationView(annotation: annotation, reuseIdentifier: nil)
             view.canShowCallout = true
-            view.alpha = 0
+            view.alphaValue = 0
             return view
         }
     }

--- a/DragonShield/Views/DashboardTiles/DashboardTiles.swift
+++ b/DragonShield/Views/DashboardTiles/DashboardTiles.swift
@@ -229,18 +229,26 @@ struct ImageTile: DashboardTile {
 struct MapTile: DashboardTile {
     init() {}
     static let tileID = "map"
-    static let tileName = "Map Tile"
+    static let tileName = "Position Value by Currency"
     static let iconName = "map"
+
+    @EnvironmentObject var dbManager: DatabaseManager
+    @StateObject private var viewModel = CurrencyMapViewModel()
 
     var body: some View {
         DashboardCard(title: Self.tileName) {
-            Color.gray.opacity(0.3)
-                .frame(height: 120)
-                .overlay(Image(systemName: "map")
-                            .font(.largeTitle)
-                            .foregroundColor(.gray))
-                .cornerRadius(4)
+            if viewModel.loading {
+                ProgressView()
+                    .frame(height: 140)
+            } else {
+                VStack(alignment: .leading, spacing: 8) {
+                    CurrencyChoroplethMapView(viewModel: viewModel)
+                        .frame(height: 140)
+                    MapLegend(viewModel: viewModel)
+                }
+            }
         }
+        .onAppear { viewModel.load(using: dbManager) }
         .accessibilityElement(children: .combine)
     }
 }

--- a/DragonShield/Views/MapLegend.swift
+++ b/DragonShield/Views/MapLegend.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+struct MapLegend: View {
+    let viewModel: CurrencyMapViewModel
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ForEach(0..<5, id: \.self) { idx in
+                VStack(spacing: 2) {
+                    Rectangle()
+                        .fill(viewModel.color(for: viewModel.quantileBreaks[min(idx+1, viewModel.quantileBreaks.count-1)]))
+                        .frame(width: 20, height: 12)
+                    Text(viewModel.rangeText(for: idx))
+                        .font(.caption2)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- show a world map of position values by currency
- compute quantile breaks and colors in CurrencyMapViewModel
- display map overlays via CurrencyChoroplethMapView
- add MapLegend for blue-scale ranges
- document the new dashboard tile in the changelog

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881b17755f4832382d2168503b8d7bf