### PR TITLE
Update stale accounts tile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Show per-table row count comparison after restore in a modal window
 - Widen Restore Comparison window to display all columns without scrolling
 - Confirm deletion of positions per account type with live count
+- Revise Accounts Needing Update tile with calendar icon, scrolling list and color-coded rows
 - Generate full instrument report from Database Management view
 - Use latest flagged FX rates for import value calculations and report applied rates
 - Store import session total value and add CLI summary report

--- a/DragonShield/Views/DashboardTiles/DashboardTiles.swift
+++ b/DragonShield/Views/DashboardTiles/DashboardTiles.swift
@@ -9,17 +9,27 @@ protocol DashboardTile: View {
 
 struct DashboardCard<Content: View>: View {
     let title: String
+    let headerIcon: Image?
     let content: Content
 
-    init(title: String, @ViewBuilder content: () -> Content) {
+    init(title: String, headerIcon: Image? = nil, @ViewBuilder content: () -> Content) {
         self.title = title
+        self.headerIcon = headerIcon
         self.content = content()
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text(title)
-                .font(.headline)
+            HStack {
+                Text(title)
+                    .font(.headline)
+                Spacer()
+                if let icon = headerIcon {
+                    icon
+                        .resizable()
+                        .frame(width: 24, height: 24)
+                }
+            }
             content
         }
         .padding(16)


### PR DESCRIPTION
## Summary
- revise Accounts Needing Update tile view
- support optional header icon on dashboard cards
- document tile improvements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'DragonShield')*

------
https://chatgpt.com/codex/tasks/task_e_6881b827e7d48323833d9d794888db08