### PR TITLE
feat(db): auto-update account timestamps via trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Widen Restore Comparison window to display all columns without scrolling
 - Confirm deletion of positions per account type with live count
 - Display stale accounts grouped by age with collapsible sections
+- Maintain account update timestamps via trigger and remove manual refresh
 - Generate full instrument report from Database Management view
 - Use latest flagged FX rates for import value calculations and report applied rates
 - Store import session total value and add CLI summary report

--- a/DragonShield/DatabaseManager+Accounts.swift
+++ b/DragonShield/DatabaseManager+Accounts.swift
@@ -458,38 +458,4 @@ extension DatabaseManager {
         return results
     }
 
-    /// Recalculates the earliest instrument update date for all accounts.
-    /// - Parameter completion: Called on the main thread with the number of
-    ///   rows updated or an error.
-    func refreshEarliestInstrumentTimestamps(completion: @escaping (Result<Int, Error>) -> Void) {
-        DispatchQueue.global(qos: .userInitiated).async {
-            let sql = """
-                UPDATE Accounts
-                   SET earliest_instrument_last_updated_at = (
-                        SELECT MIN(instrument_updated_at)
-                          FROM PositionReports pr
-                         WHERE pr.account_id = Accounts.account_id
-                   );
-                """
-            var stmt: OpaquePointer?
-            guard sqlite3_prepare_v2(self.db, sql, -1, &stmt, nil) == SQLITE_OK else {
-                let msg = String(cString: sqlite3_errmsg(self.db))
-                DispatchQueue.main.async {
-                    completion(.failure(NSError(domain: "SQLite", code: 1, userInfo: [NSLocalizedDescriptionKey: msg])))
-                }
-                return
-            }
-            let step = sqlite3_step(stmt)
-            let changed = sqlite3_changes(self.db)
-            sqlite3_finalize(stmt)
-            DispatchQueue.main.async {
-                if step == SQLITE_DONE {
-                    completion(.success(Int(changed)))
-                } else {
-                    let msg = String(cString: sqlite3_errmsg(self.db))
-                    completion(.failure(NSError(domain: "SQLite", code: 2, userInfo: [NSLocalizedDescriptionKey: msg])))
-                }
-            }
-        }
-    }
 }

--- a/DragonShield/ViewModels/StaleAccountsViewModel.swift
+++ b/DragonShield/ViewModels/StaleAccountsViewModel.swift
@@ -19,8 +19,6 @@ class StaleAccountsViewModel: ObservableObject {
         let accounts = dbManager.fetchAccounts()
         staleAccounts = accounts
             .sorted(by: Self.earliestFirst)
-            .prefix(10)
-            .map { $0 }
     }
 
     private static func earliestFirst(_ a: DatabaseManager.AccountData,

--- a/DragonShield/Views/AccountsView.swift
+++ b/DragonShield/Views/AccountsView.swift
@@ -23,9 +23,6 @@ struct AccountsView: View {
     @State private var accountToDelete: DatabaseManager.AccountData? = nil
     @State private var searchText = ""
 
-    @State private var isRefreshing = false
-    @State private var refreshMessage = ""
-    @State private var showRefreshAlert = false
 
     @State private var headerOpacity: Double = 0
     @State private var contentOffset: CGFloat = 30
@@ -88,11 +85,6 @@ struct AccountsView: View {
             if let account = accountToDelete {
                 Text("Choose whether to disable or permanently delete '\(account.accountName)' (\(account.accountNumber)). Accounts can only be modified if no instruments are linked.")
             }
-        }
-        .alert("Refresh", isPresented: $showRefreshAlert) {
-            Button("OK") { showRefreshAlert = false }
-        } message: {
-            Text(refreshMessage)
         }
     }
 
@@ -210,31 +202,6 @@ struct AccountsView: View {
             Rectangle().fill(Color.gray.opacity(0.2)).frame(height: 1)
             HStack(spacing: 16) {
                 Button { showAddAccountSheet = true } label: { HStack(spacing: 8) { Image(systemName: "plus"); Text("Add New Account") }.font(.system(size: 16, weight: .semibold)).foregroundColor(.white).padding(.horizontal, 20).padding(.vertical, 12).background(Color.blue).clipShape(Capsule()) .shadow(color: .blue.opacity(0.3), radius: 6, x: 0, y: 3) }.buttonStyle(ScaleButtonStyle())
-                Button {
-                    isRefreshing = true
-                    dbManager.refreshEarliestInstrumentTimestamps { result in
-                        isRefreshing = false
-                        switch result {
-                        case .success(let n):
-                            refreshMessage = "✅ Updated earliest timestamps for \(n) accounts."
-                        case .failure:
-                            refreshMessage = "❌ Failed to refresh timestamps."
-                        }
-                        showRefreshAlert = true
-                        loadAccounts()
-                    }
-                } label: {
-                    HStack(spacing: 6) {
-                        if isRefreshing { ProgressView().scaleEffect(0.7) } else { Image(systemName: "arrow.clockwise") }
-                        Text("Refresh Instrument Timestamps")
-                    }
-                    .font(.system(size: 14, weight: .medium))
-                    .foregroundColor(.purple)
-                    .padding(.horizontal, 16).padding(.vertical, 10)
-                    .background(Color.purple.opacity(0.1))
-                    .clipShape(Capsule())
-                    .overlay(Capsule().stroke(Color.purple.opacity(0.3), lineWidth: 1))
-                }.buttonStyle(ScaleButtonStyle()).disabled(isRefreshing)
                 if selectedAccount != nil {
                     Button { showEditAccountSheet = true } label: { HStack(spacing: 6) { Image(systemName: "pencil"); Text("Edit") }.font(.system(size: 14, weight: .medium)).foregroundColor(.orange) .padding(.horizontal, 16).padding(.vertical, 10).background(Color.orange.opacity(0.1)).clipShape(Capsule()).overlay(Capsule().stroke(Color.orange.opacity(0.3), lineWidth: 1)) }.buttonStyle(ScaleButtonStyle())
                     Button { if let acc = selectedAccount { accountToDelete = acc; showingDeleteAlert = true } } label: { HStack(spacing: 6) { Image(systemName: "trash"); Text("Delete") }.font(.system(size: 14, weight: .medium)).foregroundColor(.red).padding(.horizontal, 16).padding(.vertical, 10).background(Color.red.opacity(0.1)).clipShape(Capsule()).overlay(Capsule().stroke(Color.red.opacity(0.3), lineWidth: 1)) }.buttonStyle(ScaleButtonStyle())

--- a/DragonShield/database/schema.sql
+++ b/DragonShield/database/schema.sql
@@ -1,6 +1,6 @@
 -- DragonShield/docs/schema.sql
 -- Dragon Shield Database Creation Script
--- Version 4.17 - Add ImportSessionValueReports table
+-- Version 4.18 - Touch account timestamp trigger
 -- Created: 2025-05-24
 -- Updated: 2025-07-13
 --
@@ -412,6 +412,24 @@ BEGIN
     UPDATE Instruments
     SET updated_at = CURRENT_TIMESTAMP
     WHERE instrument_id = NEW.instrument_id;
+END;
+
+CREATE TRIGGER tr_touch_account_last_updated
+AFTER INSERT ON PositionReports
+WHEN NEW.account_id IS NOT NULL
+BEGIN
+    UPDATE Accounts
+    SET earliest_instrument_last_updated_at = CURRENT_TIMESTAMP
+    WHERE account_id = NEW.account_id;
+END;
+
+CREATE TRIGGER tr_touch_account_last_updated_update
+AFTER UPDATE ON PositionReports
+WHEN NEW.account_id IS NOT NULL
+BEGIN
+    UPDATE Accounts
+    SET earliest_instrument_last_updated_at = CURRENT_TIMESTAMP
+    WHERE account_id = NEW.account_id;
 END;
 
 --=============================================================================

--- a/DragonShield/database/schema.txt
+++ b/DragonShield/database/schema.txt
@@ -29,7 +29,7 @@ INSERT INTO Configuration VALUES ('9', 'table_row_padding', '12.0', 'number', 'V
 INSERT INTO Configuration VALUES ('10', 'table_font_size', '14.0', 'number', 'Font size for text in data table rows (in points)', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('11', 'include_direct_re', 'true', 'boolean', 'Include direct real estate in allocation views', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('12', 'direct_re_target_chf', '0', 'number', 'Target CHF amount for direct real estate', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
-INSERT INTO Configuration VALUES ('13', 'db_version', '4.17', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
+INSERT INTO Configuration VALUES ('13', 'db_version', '4.18', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('CHF', 'Swiss Franc', 'CHF', '1', '0', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('EUR', 'Euro', '€', '1', '1', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('USD', 'US Dollar', '$', '1', '1', '2025-07-13 09:04:29', '2025-07-13 09:04:29');

--- a/DragonShield/python_scripts/stale_accounts.py
+++ b/DragonShield/python_scripts/stale_accounts.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 
 @dataclass
 class Account:
@@ -8,8 +8,21 @@ class Account:
     earliest_instrument_last_updated_at: datetime | None
 
 
-def top_stale_accounts(accounts: List[Account], limit: int = 10) -> List[Account]:
+def top_stale_accounts(accounts: List[Account], limit: Optional[int] = None) -> List[Account]:
     def sort_key(a: Account):
         return a.earliest_instrument_last_updated_at or datetime.max
 
-    return sorted(accounts, key=sort_key)[:limit]
+    sorted_accounts = sorted(accounts, key=sort_key)
+    return sorted_accounts[:limit] if limit else sorted_accounts
+
+
+def bucket_for(date: Optional[datetime], now: datetime | None = None) -> Optional[str]:
+    now = now or datetime.now()
+    if date is None:
+        return None
+    days = (now - date).days
+    if days > 60:
+        return "red"
+    if days > 30:
+        return "amber"
+    return "green"

--- a/DragonShield/test_data/reference_data.sql
+++ b/DragonShield/test_data/reference_data.sql
@@ -21,7 +21,7 @@ INSERT INTO Configuration VALUES ('9', 'table_row_padding', '12.0', 'number', 'V
 INSERT INTO Configuration VALUES ('10', 'table_font_size', '14.0', 'number', 'Font size for text in data table rows (in points)', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('11', 'include_direct_re', 'true', 'boolean', 'Include direct real estate in allocation views', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('12', 'direct_re_target_chf', '0', 'number', 'Target CHF amount for direct real estate', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
-INSERT INTO Configuration VALUES ('13', 'db_version', '4.17', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
+INSERT INTO Configuration VALUES ('13', 'db_version', '4.18', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 CREATE TABLE Currencies (
     currency_code TEXT PRIMARY KEY,
     currency_name TEXT NOT NULL,

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ This is a personal passion project, but issues and PRs are welcome. Please keep 
 
 ## Version History
 - 2.24: Search for Python interpreter in Homebrew locations or env var.
+- 2.25: Accounts timestamps auto-update via trigger; removed manual refresh UI.
 - 2.23: Run parser via /usr/bin/python3 to avoid sandbox xcrun error.
 - 2.22: Launch parser via /usr/bin/env and return exit codes.
 - 2.21: Add source-path fallback for locating parser module.

--- a/migrations/005_add_account_update_trigger.sql
+++ b/migrations/005_add_account_update_trigger.sql
@@ -1,0 +1,17 @@
+CREATE TRIGGER IF NOT EXISTS tr_touch_account_last_updated
+AFTER INSERT ON PositionReports
+WHEN NEW.account_id IS NOT NULL
+BEGIN
+    UPDATE Accounts
+    SET earliest_instrument_last_updated_at = CURRENT_TIMESTAMP
+    WHERE account_id = NEW.account_id;
+END;
+
+CREATE TRIGGER IF NOT EXISTS tr_touch_account_last_updated_update
+AFTER UPDATE ON PositionReports
+WHEN NEW.account_id IS NOT NULL
+BEGIN
+    UPDATE Accounts
+    SET earliest_instrument_last_updated_at = CURRENT_TIMESTAMP
+    WHERE account_id = NEW.account_id;
+END;

--- a/tests/test_refresh_button.py
+++ b/tests/test_refresh_button.py
@@ -1,9 +1,0 @@
-from pathlib import Path
-
-ACCOUNTS_VIEW = Path(__file__).resolve().parents[1] / 'DragonShield' / 'Views' / 'AccountsView.swift'
-
-
-def test_refresh_button_exists():
-    text = ACCOUNTS_VIEW.read_text(encoding='utf-8')
-    assert 'Refresh Instrument Timestamps' in text
-    assert 'refreshEarliestInstrumentTimestamps' in text

--- a/tests/test_refresh_timestamps.py
+++ b/tests/test_refresh_timestamps.py
@@ -2,7 +2,7 @@ import sqlite3
 
 
 def setup_db():
-    conn = sqlite3.connect(':memory:')
+    conn = sqlite3.connect(":memory:")
     conn.execute(
         """
         CREATE TABLE Accounts (
@@ -28,38 +28,69 @@ def setup_db():
         )
         """
     )
+    conn.executescript(
+        """
+        CREATE TRIGGER tr_touch_account_last_updated
+        AFTER INSERT ON PositionReports
+        WHEN NEW.account_id IS NOT NULL
+        BEGIN
+            UPDATE Accounts
+            SET earliest_instrument_last_updated_at = CURRENT_TIMESTAMP
+            WHERE account_id = NEW.account_id;
+        END;
+
+        CREATE TRIGGER tr_touch_account_last_updated_update
+        AFTER UPDATE ON PositionReports
+        WHEN NEW.account_id IS NOT NULL
+        BEGIN
+            UPDATE Accounts
+            SET earliest_instrument_last_updated_at = CURRENT_TIMESTAMP
+            WHERE account_id = NEW.account_id;
+        END;
+        """
+    )
     return conn
 
 
-def refresh(conn):
-    conn.execute(
-        """
-        UPDATE Accounts
-           SET earliest_instrument_last_updated_at = (
-                SELECT MIN(instrument_updated_at)
-                  FROM PositionReports pr
-                 WHERE pr.account_id = Accounts.account_id
-           );
-        """
-    )
-
-
-def test_refresh_min_date():
+def test_trigger_updates_timestamp_on_insert():
     conn = setup_db()
-    conn.execute("INSERT INTO Accounts (account_name, institution_id, account_type_id, currency_code) VALUES ('A',1,1,'CHF')")
+    conn.execute(
+        "INSERT INTO Accounts (account_name, institution_id, account_type_id, currency_code, earliest_instrument_last_updated_at) VALUES ('A',1,1,'CHF','2000-01-01 00:00:00')"
+    )
     acc_id = conn.execute("SELECT account_id FROM Accounts WHERE account_name='A'").fetchone()[0]
-    conn.execute("INSERT INTO PositionReports (account_id, institution_id, instrument_id, quantity, instrument_updated_at, report_date) VALUES (?,1,1,10,'2025-05-01','2025-01-01')", (acc_id,))
-    conn.execute("INSERT INTO PositionReports (account_id, institution_id, instrument_id, quantity, instrument_updated_at, report_date) VALUES (?,1,1,20,'2025-04-15','2025-01-02')", (acc_id,))
-    refresh(conn)
-    val = conn.execute("SELECT earliest_instrument_last_updated_at FROM Accounts WHERE account_id=?", (acc_id,)).fetchone()[0]
-    assert val == '2025-04-15'
+    conn.execute(
+        "INSERT INTO PositionReports (account_id, institution_id, instrument_id, quantity, instrument_updated_at, report_date) VALUES (?,1,1,10,'2025-05-01','2025-01-01')",
+        (acc_id,),
+    )
+    val = conn.execute(
+        "SELECT earliest_instrument_last_updated_at FROM Accounts WHERE account_id=?",
+        (acc_id,),
+    ).fetchone()[0]
+    assert val != "2000-01-01 00:00:00"
     conn.close()
 
 
-def test_refresh_null_when_no_reports():
+def test_trigger_updates_timestamp_on_update():
     conn = setup_db()
-    conn.execute("INSERT INTO Accounts (account_name, institution_id, account_type_id, currency_code) VALUES ('A',1,1,'CHF')")
-    refresh(conn)
-    val = conn.execute("SELECT earliest_instrument_last_updated_at FROM Accounts").fetchone()[0]
-    assert val is None
+    conn.execute(
+        "INSERT INTO Accounts (account_name, institution_id, account_type_id, currency_code) VALUES ('A',1,1,'CHF')"
+    )
+    acc_id = conn.execute("SELECT account_id FROM Accounts WHERE account_name='A'").fetchone()[0]
+    pos_id = conn.execute(
+        "INSERT INTO PositionReports (account_id, institution_id, instrument_id, quantity, instrument_updated_at, report_date) VALUES (?,1,1,10,'2025-05-01','2025-01-01')",
+        (acc_id,),
+    ).lastrowid
+    conn.execute(
+        "UPDATE Accounts SET earliest_instrument_last_updated_at='2000-01-01 00:00:00' WHERE account_id=?",
+        (acc_id,),
+    )
+    conn.execute(
+        "UPDATE PositionReports SET quantity=20 WHERE position_id=?",
+        (pos_id,),
+    )
+    val = conn.execute(
+        "SELECT earliest_instrument_last_updated_at FROM Accounts WHERE account_id=?",
+        (acc_id,),
+    ).fetchone()[0]
+    assert val != "2000-01-01 00:00:00"
     conn.close()

--- a/tests/test_schema_version.py
+++ b/tests/test_schema_version.py
@@ -8,4 +8,4 @@ from deploy_db import parse_version
 
 def test_schema_version_updated():
     schema_path = Path(__file__).resolve().parents[1] / 'DragonShield' / 'database' / 'schema.sql'
-    assert parse_version(str(schema_path)) == '4.17'
+    assert parse_version(str(schema_path)) == '4.18'

--- a/tests/test_stale_accounts.py
+++ b/tests/test_stale_accounts.py
@@ -1,9 +1,9 @@
 from datetime import datetime, timedelta
 
-from DragonShield.python_scripts.stale_accounts import Account, top_stale_accounts
+from DragonShield.python_scripts.stale_accounts import Account, top_stale_accounts, bucket_for
 
 
-def test_sort_and_limit():
+def test_sort_order():
     today = datetime(2025, 1, 1)
     accounts = [
         Account("A", today - timedelta(days=40)),
@@ -21,6 +21,14 @@ def test_sort_and_limit():
 
     result = top_stale_accounts(accounts)
 
-    assert len(result) == 10
+    assert len(result) == 11
     dates = [acc.earliest_instrument_last_updated_at for acc in result]
     assert dates == sorted(dates)
+
+
+def test_bucket_for_dates():
+    today = datetime(2025, 1, 1)
+    assert bucket_for(today - timedelta(days=10), now=today) == "green"
+    assert bucket_for(today - timedelta(days=40), now=today) == "amber"
+    assert bucket_for(today - timedelta(days=61), now=today) == "red"
+    assert bucket_for(None, now=today) is None


### PR DESCRIPTION
## Summary
- add triggers to update accounts when new PositionReports are inserted or updated
- remove manual refresh button and helper method
- expose all stale accounts and bucket by age
- bump database version to 4.18
- document trigger usage in README and changelog
- update tests for trigger behaviour and stale account buckets

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881f79ea8388323997c7508be78a6bc