### PR TITLE
feat(db): automate account timestamp updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 - Add macOS Kanban to-do board with drag-and-drop
 - Add sidebar link to the Kanban board
+- Automatically update account instrument timestamps via trigger and remove manual refresh button
 - Reorganize sidebar navigation with expandable sections and remove old transaction links
 - Combine Asset Class and SubClass management into one page with sortable rows
 - Prompt to confirm option quantity multiplier during position import

--- a/DragonShield/DatabaseManager+Accounts.swift
+++ b/DragonShield/DatabaseManager+Accounts.swift
@@ -458,25 +458,6 @@ extension DatabaseManager {
         return results
     }
 
-    /// Recalculates the earliest instrument update date for all accounts.
-    /// - Parameter completion: Called on the main thread with the number of
-    ///   rows updated or an error.
-    func refreshEarliestInstrumentTimestamps(completion: @escaping (Result<Int, Error>) -> Void) {
-        DispatchQueue.global(qos: .userInitiated).async {
-            let sql = """
-                UPDATE Accounts
-                   SET earliest_instrument_last_updated_at = (
-                        SELECT MIN(instrument_updated_at)
-                          FROM PositionReports pr
-                         WHERE pr.account_id = Accounts.account_id
-                   );
-                """
-            var stmt: OpaquePointer?
-            guard sqlite3_prepare_v2(self.db, sql, -1, &stmt, nil) == SQLITE_OK else {
-                let msg = String(cString: sqlite3_errmsg(self.db))
-                DispatchQueue.main.async {
-                    completion(.failure(NSError(domain: "SQLite", code: 1, userInfo: [NSLocalizedDescriptionKey: msg])))
-                }
                 return
             }
             let step = sqlite3_step(stmt)

--- a/DragonShield/ViewModels/StaleAccountsViewModel.swift
+++ b/DragonShield/ViewModels/StaleAccountsViewModel.swift
@@ -19,7 +19,6 @@ class StaleAccountsViewModel: ObservableObject {
         let accounts = dbManager.fetchAccounts()
         staleAccounts = accounts
             .sorted(by: Self.earliestFirst)
-            .prefix(10)
             .map { $0 }
     }
 

--- a/DragonShield/Views/AccountsView.swift
+++ b/DragonShield/Views/AccountsView.swift
@@ -23,9 +23,6 @@ struct AccountsView: View {
     @State private var accountToDelete: DatabaseManager.AccountData? = nil
     @State private var searchText = ""
 
-    @State private var isRefreshing = false
-    @State private var refreshMessage = ""
-    @State private var showRefreshAlert = false
 
     @State private var headerOpacity: Double = 0
     @State private var contentOffset: CGFloat = 30
@@ -89,10 +86,6 @@ struct AccountsView: View {
                 Text("Choose whether to disable or permanently delete '\(account.accountName)' (\(account.accountNumber)). Accounts can only be modified if no instruments are linked.")
             }
         }
-        .alert("Refresh", isPresented: $showRefreshAlert) {
-            Button("OK") { showRefreshAlert = false }
-        } message: {
-            Text(refreshMessage)
         }
     }
 
@@ -210,31 +203,6 @@ struct AccountsView: View {
             Rectangle().fill(Color.gray.opacity(0.2)).frame(height: 1)
             HStack(spacing: 16) {
                 Button { showAddAccountSheet = true } label: { HStack(spacing: 8) { Image(systemName: "plus"); Text("Add New Account") }.font(.system(size: 16, weight: .semibold)).foregroundColor(.white).padding(.horizontal, 20).padding(.vertical, 12).background(Color.blue).clipShape(Capsule()) .shadow(color: .blue.opacity(0.3), radius: 6, x: 0, y: 3) }.buttonStyle(ScaleButtonStyle())
-                Button {
-                    isRefreshing = true
-                    dbManager.refreshEarliestInstrumentTimestamps { result in
-                        isRefreshing = false
-                        switch result {
-                        case .success(let n):
-                            refreshMessage = "✅ Updated earliest timestamps for \(n) accounts."
-                        case .failure:
-                            refreshMessage = "❌ Failed to refresh timestamps."
-                        }
-                        showRefreshAlert = true
-                        loadAccounts()
-                    }
-                } label: {
-                    HStack(spacing: 6) {
-                        if isRefreshing { ProgressView().scaleEffect(0.7) } else { Image(systemName: "arrow.clockwise") }
-                        Text("Refresh Instrument Timestamps")
-                    }
-                    .font(.system(size: 14, weight: .medium))
-                    .foregroundColor(.purple)
-                    .padding(.horizontal, 16).padding(.vertical, 10)
-                    .background(Color.purple.opacity(0.1))
-                    .clipShape(Capsule())
-                    .overlay(Capsule().stroke(Color.purple.opacity(0.3), lineWidth: 1))
-                }.buttonStyle(ScaleButtonStyle()).disabled(isRefreshing)
                 if selectedAccount != nil {
                     Button { showEditAccountSheet = true } label: { HStack(spacing: 6) { Image(systemName: "pencil"); Text("Edit") }.font(.system(size: 14, weight: .medium)).foregroundColor(.orange) .padding(.horizontal, 16).padding(.vertical, 10).background(Color.orange.opacity(0.1)).clipShape(Capsule()).overlay(Capsule().stroke(Color.orange.opacity(0.3), lineWidth: 1)) }.buttonStyle(ScaleButtonStyle())
                     Button { if let acc = selectedAccount { accountToDelete = acc; showingDeleteAlert = true } } label: { HStack(spacing: 6) { Image(systemName: "trash"); Text("Delete") }.font(.system(size: 14, weight: .medium)).foregroundColor(.red).padding(.horizontal, 16).padding(.vertical, 10).background(Color.red.opacity(0.1)).clipShape(Capsule()).overlay(Capsule().stroke(Color.red.opacity(0.3), lineWidth: 1)) }.buttonStyle(ScaleButtonStyle())

--- a/DragonShield/database/schema.sql
+++ b/DragonShield/database/schema.sql
@@ -1,6 +1,6 @@
 -- DragonShield/docs/schema.sql
 -- Dragon Shield Database Creation Script
--- Version 4.17 - Add ImportSessionValueReports table
+-- Version 4.18 - Auto-update account timestamps trigger
 -- Created: 2025-05-24
 -- Updated: 2025-07-13
 --
@@ -415,6 +415,24 @@ BEGIN
 END;
 
 --=============================================================================
+CREATE TRIGGER tr_touch_account_last_updated_insert
+AFTER INSERT ON PositionReports
+WHEN NEW.account_id IS NOT NULL
+BEGIN
+    UPDATE Accounts
+    SET earliest_instrument_last_updated_at = CURRENT_TIMESTAMP
+    WHERE account_id = NEW.account_id;
+END;
+
+CREATE TRIGGER tr_touch_account_last_updated_update
+AFTER UPDATE ON PositionReports
+WHEN NEW.account_id IS NOT NULL
+BEGIN
+    UPDATE Accounts
+    SET earliest_instrument_last_updated_at = CURRENT_TIMESTAMP
+    WHERE account_id = NEW.account_id;
+END;
+
 -- PORTFOLIO CALCULATION VIEWS (AccountSummary MODIFIED)
 --=============================================================================
 

--- a/DragonShield/database/schema.txt
+++ b/DragonShield/database/schema.txt
@@ -29,7 +29,7 @@ INSERT INTO Configuration VALUES ('9', 'table_row_padding', '12.0', 'number', 'V
 INSERT INTO Configuration VALUES ('10', 'table_font_size', '14.0', 'number', 'Font size for text in data table rows (in points)', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('11', 'include_direct_re', 'true', 'boolean', 'Include direct real estate in allocation views', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('12', 'direct_re_target_chf', '0', 'number', 'Target CHF amount for direct real estate', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
-INSERT INTO Configuration VALUES ('13', 'db_version', '4.17', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
+INSERT INTO Configuration VALUES ('13', 'db_version', '4.18', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('CHF', 'Swiss Franc', 'CHF', '1', '0', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('EUR', 'Euro', '€', '1', '1', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('USD', 'US Dollar', '$', '1', '1', '2025-07-13 09:04:29', '2025-07-13 09:04:29');

--- a/DragonShield/python_scripts/stale_accounts.py
+++ b/DragonShield/python_scripts/stale_accounts.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 
 @dataclass
 class Account:
     name: str
-    earliest_instrument_last_updated_at: datetime | None
+    earliest_instrument_last_updated_at: Optional[datetime]
 
 
 def top_stale_accounts(accounts: List[Account], limit: int = 10) -> List[Account]:
@@ -13,3 +13,18 @@ def top_stale_accounts(accounts: List[Account], limit: int = 10) -> List[Account
         return a.earliest_instrument_last_updated_at or datetime.max
 
     return sorted(accounts, key=sort_key)[:limit]
+
+
+def age_bucket(date: Optional[datetime], now: Optional[datetime] = None) -> str:
+    if date is None:
+        return "red"
+    if now is None:
+        now = datetime.now()
+    delta = (now - date).days
+    if delta > 60:
+        return "red"
+    if delta > 30:
+        return "amber"
+    return "green"
+
+__all__ = ["Account", "top_stale_accounts", "age_bucket"]

--- a/DragonShield/test_data/reference_data.sql
+++ b/DragonShield/test_data/reference_data.sql
@@ -21,7 +21,7 @@ INSERT INTO Configuration VALUES ('9', 'table_row_padding', '12.0', 'number', 'V
 INSERT INTO Configuration VALUES ('10', 'table_font_size', '14.0', 'number', 'Font size for text in data table rows (in points)', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('11', 'include_direct_re', 'true', 'boolean', 'Include direct real estate in allocation views', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('12', 'direct_re_target_chf', '0', 'number', 'Target CHF amount for direct real estate', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
-INSERT INTO Configuration VALUES ('13', 'db_version', '4.17', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
+INSERT INTO Configuration VALUES ('13', 'db_version', '4.18', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 CREATE TABLE Currencies (
     currency_code TEXT PRIMARY KEY,
     currency_name TEXT NOT NULL,

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ DragonShield/
   - Backup directory: `Dragonshield DB Backup` (full, reference and transaction backups)
   - Generate the database with `python3 python_scripts/deploy_db.py`.
   - Full database backup/restore via `python3 python_scripts/backup_restore.py`
+  - Account timestamps update automatically when position reports are added.
 - **Encryption**: SQLCipher (AES-256)
 - **Schema**: `docs/schema.sql`
 - **Dev Key**: Temporary; do not use for production data

--- a/migrations/005_add_touch_account_last_updated_trigger.sql
+++ b/migrations/005_add_touch_account_last_updated_trigger.sql
@@ -1,0 +1,17 @@
+CREATE TRIGGER tr_touch_account_last_updated_insert
+AFTER INSERT ON PositionReports
+WHEN NEW.account_id IS NOT NULL
+BEGIN
+    UPDATE Accounts
+    SET earliest_instrument_last_updated_at = CURRENT_TIMESTAMP
+    WHERE account_id = NEW.account_id;
+END;
+
+CREATE TRIGGER tr_touch_account_last_updated_update
+AFTER UPDATE ON PositionReports
+WHEN NEW.account_id IS NOT NULL
+BEGIN
+    UPDATE Accounts
+    SET earliest_instrument_last_updated_at = CURRENT_TIMESTAMP
+    WHERE account_id = NEW.account_id;
+END;

--- a/tests/test_refresh_button.py
+++ b/tests/test_refresh_button.py
@@ -3,7 +3,7 @@ from pathlib import Path
 ACCOUNTS_VIEW = Path(__file__).resolve().parents[1] / 'DragonShield' / 'Views' / 'AccountsView.swift'
 
 
-def test_refresh_button_exists():
+def test_refresh_button_removed():
     text = ACCOUNTS_VIEW.read_text(encoding='utf-8')
-    assert 'Refresh Instrument Timestamps' in text
-    assert 'refreshEarliestInstrumentTimestamps' in text
+    assert 'Refresh Instrument Timestamps' not in text
+    assert 'refreshEarliestInstrumentTimestamps' not in text

--- a/tests/test_schema_version.py
+++ b/tests/test_schema_version.py
@@ -8,4 +8,4 @@ from deploy_db import parse_version
 
 def test_schema_version_updated():
     schema_path = Path(__file__).resolve().parents[1] / 'DragonShield' / 'database' / 'schema.sql'
-    assert parse_version(str(schema_path)) == '4.17'
+    assert parse_version(str(schema_path)) == '4.18'

--- a/tests/test_stale_accounts.py
+++ b/tests/test_stale_accounts.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 
-from DragonShield.python_scripts.stale_accounts import Account, top_stale_accounts
+from DragonShield.python_scripts.stale_accounts import Account, top_stale_accounts, age_bucket
 
 
 def test_sort_and_limit():
@@ -24,3 +24,11 @@ def test_sort_and_limit():
     assert len(result) == 10
     dates = [acc.earliest_instrument_last_updated_at for acc in result]
     assert dates == sorted(dates)
+
+
+def test_age_bucket_classification():
+    today = datetime(2025, 1, 1)
+    assert age_bucket(today - timedelta(days=10), today) == "green"
+    assert age_bucket(today - timedelta(days=40), today) == "amber"
+    assert age_bucket(today - timedelta(days=61), today) == "red"
+    assert age_bucket(None, today) == "red"


### PR DESCRIPTION
## Summary
- trigger automatic `earliest_instrument_last_updated_at` updates
- remove manual refresh button and related code
- adjust stale accounts list logic and expose age buckets in Python helper
- update schema version to 4.18 and document trigger
- revise tests for new trigger and UI removal

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881f79ea8388323997c7508be78a6bc