### PR TITLE
Add instrument filter tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -377,3 +377,4 @@ All notable changes to this project will be documented in this file.
 - Close SQLite connection before file moves and update dbVersion on main thread
 - Ensure published properties update on main thread and migrate onChange syntax
 - Distinct colors for each risk bucket segment and matching legend
+- Add unit tests for Instruments stacked filter logic

--- a/DragonShield/python_scripts/instrument_filters.py
+++ b/DragonShield/python_scripts/instrument_filters.py
@@ -1,0 +1,21 @@
+from typing import Iterable, Mapping, MutableMapping, Sequence, Any, Dict, Set, List
+
+
+def filter_instruments(
+    instruments: Iterable[Mapping[str, Any]],
+    filters: Mapping[str, Set[Any]],
+) -> List[Mapping[str, Any]]:
+    """Return instruments matching stacked column filters."""
+    result: List[Mapping[str, Any]] = []
+    for inst in instruments:
+        include = True
+        for column, allowed in filters.items():
+            if allowed and inst.get(column) not in allowed:
+                include = False
+                break
+        if include:
+            result.append(dict(inst))
+    return result
+
+
+__all__ = ["filter_instruments"]

--- a/tests/test_instrument_filters.py
+++ b/tests/test_instrument_filters.py
@@ -1,0 +1,27 @@
+from DragonShield.python_scripts.instrument_filters import filter_instruments
+
+
+SAMPLE_DATA = [
+    {"name": "A", "type": "Equity ETF", "currency": "USD"},
+    {"name": "B", "type": "Bond", "currency": "CHF"},
+    {"name": "C", "type": "Equity ETF", "currency": "CHF"},
+    {"name": "D", "type": "Equity ETF", "currency": "EUR"},
+]
+
+
+def test_or_logic_single_column():
+    result = filter_instruments(SAMPLE_DATA, {"currency": {"USD", "CHF"}})
+    names = {r["name"] for r in result}
+    assert names == {"A", "B", "C"}
+
+
+def test_and_logic_across_columns():
+    filters = {"currency": {"USD", "CHF"}, "type": {"Equity ETF"}}
+    result = filter_instruments(SAMPLE_DATA, filters)
+    names = {r["name"] for r in result}
+    assert names == {"A", "C"}
+
+
+def test_no_results_placeholder():
+    result = filter_instruments(SAMPLE_DATA, {"currency": {"JPY"}})
+    assert result == []


### PR DESCRIPTION
## Summary
- add python filter helper for Instruments view filters
- test stacked OR/AND filter behaviour
- document tests in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883269f39c48323a5e530051cd9f625