### PR TITLE
Add basic table filtering and sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -377,3 +377,4 @@ All notable changes to this project will be documented in this file.
 - Close SQLite connection before file moves and update dbVersion on main thread
 - Ensure published properties update on main thread and migrate onChange syntax
 - Distinct colors for each risk bucket segment and matching legend
+- Enable stacked column filters with single-column sorting and double-click editing in Instruments and Positions views

--- a/DragonShield/ViewModels/InstrumentFilterViewModel.swift
+++ b/DragonShield/ViewModels/InstrumentFilterViewModel.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+enum InstrumentSortKey: String, CaseIterable {
+    case name, type, currency
+}
+
+class InstrumentFilterViewModel: ObservableObject {
+    @Published var selectedTypes: Set<String> = []
+    @Published var selectedCurrencies: Set<String> = []
+    @Published var sortKey: InstrumentSortKey = .name
+    @Published var ascending: Bool = true
+
+    func toggleType(_ type: String) {
+        if selectedTypes.contains(type) { selectedTypes.remove(type) } else { selectedTypes.insert(type) }
+    }
+
+    func toggleCurrency(_ cur: String) {
+        if selectedCurrencies.contains(cur) { selectedCurrencies.remove(cur) } else { selectedCurrencies.insert(cur) }
+    }
+
+    var hasFilters: Bool { !selectedTypes.isEmpty || !selectedCurrencies.isEmpty }
+}

--- a/DragonShield/ViewModels/PositionsViewModel.swift
+++ b/DragonShield/ViewModels/PositionsViewModel.swift
@@ -8,12 +8,34 @@ class PositionsViewModel: ObservableObject {
     @Published var calculating: Bool = false
     @Published var showErrorToast: Bool = false
     @Published var top10PositionsCHF: [TopPosition] = []
+    @Published var selectedCurrencies: Set<String> = []
+    @Published var sortColumn: PositionsView.Column = .account
+    @Published var ascending: Bool = true
 
     struct TopPosition: Identifiable {
         let id: Int
         let instrument: String
         let valueCHF: Double
         let currency: String
+    }
+
+    var hasFilters: Bool { !selectedCurrencies.isEmpty }
+
+    func toggleCurrency(_ code: String) {
+        if selectedCurrencies.contains(code) {
+            selectedCurrencies.remove(code)
+        } else {
+            selectedCurrencies.insert(code)
+        }
+    }
+
+    func toggleSort(_ column: PositionsView.Column) {
+        if sortColumn == column {
+            ascending.toggle()
+        } else {
+            sortColumn = column
+            ascending = true
+        }
     }
 
     func calculateValues(positions: [PositionReportData], db: DatabaseManager) {


### PR DESCRIPTION
## Summary
- add view-model for instrument table filters
- support sorting/filtering badges in Portfolio view
- implement filter and sort state in Positions view model
- add UI controls for column filters and sorting in both tables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883269f39c48323a5e530051cd9f625