### PR TITLE
feat(ui): show account detail window from dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Show institutions ranked by AUM in new dashboard tile
 - Document troubleshooting steps for missing `default.metallib` warning
 - Show per-table row count comparison after restore in a modal window
+- Auto-expand stale account groups and open account detail window from dashboard
 - Delete Asset SubClass instantly with toast feedback and error alert when in use
 - Display table details when Asset SubClass deletion fails
 - Widen Restore Comparison window to display all columns without scrolling

--- a/DragonShield/DragonShieldApp.swift
+++ b/DragonShield/DragonShieldApp.swift
@@ -23,5 +23,13 @@ struct DragonShieldApp: App {
                 }
             }
         }
+        WindowGroup(id: "accountDetail", for: Int.self) { $accountId in
+            if let accId = accountId {
+                AccountDetailWindowView(viewModel: AccountDetailWindowViewModel(accountId: accId, dbManager: databaseManager))
+                    .environmentObject(databaseManager)
+            } else {
+                Text("No Account")
+            }
+        }
     }
 }

--- a/DragonShield/ViewModels/AccountDetailWindowViewModel.swift
+++ b/DragonShield/ViewModels/AccountDetailWindowViewModel.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+class AccountDetailWindowViewModel: ObservableObject {
+    @Published var account: DatabaseManager.AccountData?
+    @Published var positions: [EditablePosition] = []
+    @Published var saveError: String?
+
+    struct EditablePosition: Identifiable {
+        let id: Int
+        let instrument: String
+        var quantity: Double
+        var currentPrice: Double?
+        var instrumentDate: Date?
+    }
+
+    private var accountId: Int
+    private unowned var dbManager: DatabaseManager
+
+    init(accountId: Int, dbManager: DatabaseManager) {
+        self.accountId = accountId
+        self.dbManager = dbManager
+        load()
+    }
+
+    func load() {
+        account = dbManager.fetchAccountDetails(id: accountId)
+        positions = dbManager.fetchPositionReports(accountId: accountId).map {
+            EditablePosition(id: $0.id,
+                              instrument: $0.instrumentName,
+                              quantity: $0.quantity,
+                              currentPrice: $0.currentPrice,
+                              instrumentDate: $0.instrumentUpdatedAt)
+        }.sorted { ($0.quantity * ($0.currentPrice ?? 0)) > ($1.quantity * ($1.currentPrice ?? 0)) }
+    }
+
+    func save() {
+        for pos in positions {
+            let ok = dbManager.updatePositionValues(id: pos.id,
+                                                    quantity: pos.quantity,
+                                                    currentPrice: pos.currentPrice,
+                                                    instrumentUpdatedAt: pos.instrumentDate)
+            if !ok { saveError = "Failed to save position \(pos.id)" }
+        }
+        _ = dbManager.refreshEarliestInstrumentTimestamp(accountId: accountId)
+        load()
+    }
+}

--- a/DragonShield/Views/AccountDetailWindowView.swift
+++ b/DragonShield/Views/AccountDetailWindowView.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+struct AccountDetailWindowView: View {
+    @ObservedObject var viewModel: AccountDetailWindowViewModel
+
+    private static let numberFormatter: NumberFormatter = {
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        f.maximumFractionDigits = 4
+        return f
+    }()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            header
+            positionsList
+        }
+        .padding(20)
+        .frame(minWidth: 520, minHeight: 420)
+        .onDisappear { viewModel.save() }
+    }
+
+    @ViewBuilder
+    private var header: some View {
+        if let acc = viewModel.account {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(acc.accountName).font(.title2.bold())
+                Text("\(acc.accountNumber) – \(acc.institutionName)")
+                    .font(.subheadline)
+                if let date = acc.earliestInstrumentLastUpdatedAt {
+                    Text("Earliest Updated: \(date.formatted(date: .abbreviated, time: .omitted))")
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var positionsList: some View {
+        List {
+            ForEach($viewModel.positions) { $pos in
+                HStack {
+                    Text(pos.instrument)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    TextField("Qty", value: $pos.quantity, formatter: Self.numberFormatter)
+                        .frame(width: 80)
+                    TextField("Price", value: Binding(get: { pos.currentPrice ?? 0 }, set: { pos.currentPrice = $0 }), formatter: Self.numberFormatter)
+                        .frame(width: 80)
+                    DatePicker("", selection: Binding(get: { pos.instrumentDate ?? Date() }, set: { pos.instrumentDate = $0 }), displayedComponents: .date)
+                        .labelsHidden()
+                        .frame(width: 150)
+                }
+                .textFieldStyle(.roundedBorder)
+            }
+        }
+    }
+}

--- a/DragonShield/Views/DashboardTiles/AccountsNeedingUpdateTile.swift
+++ b/DragonShield/Views/DashboardTiles/AccountsNeedingUpdateTile.swift
@@ -7,6 +7,7 @@ struct AccountsNeedingUpdateTile: DashboardTile {
     static let iconName = "exclamationmark.triangle"
 
     @EnvironmentObject var dbManager: DatabaseManager
+    @Environment(\.openWindow) private var openWindow
     @StateObject private var viewModel = StaleAccountsViewModel()
     @State private var showRed = false
     @State private var showAmber = false
@@ -62,6 +63,9 @@ struct AccountsNeedingUpdateTile: DashboardTile {
         }
         .onAppear {
             viewModel.loadStaleAccounts(db: dbManager)
+            showRed = true
+            showAmber = true
+            showGreen = false
         }
         .alert("Error", isPresented: Binding(
             get: { refreshError != nil },
@@ -121,6 +125,9 @@ struct AccountsNeedingUpdateTile: DashboardTile {
                 .padding(.horizontal, 4)
                 .background(rowColor(for: account.earliestInstrumentLastUpdatedAt))
                 .cornerRadius(4)
+                .onTapGesture {
+                    openWindow(id: "accountDetail", value: account.id)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- auto-expand stale account sections on Dashboard
- open account detail window when clicking stale account row
- add AccountDetailWindowView to edit positions inline
- support fetching and updating positions by account ID

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883eca21ab883239aac125758a02b98