### PR TITLE
feat(ui): open account detail windows from dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Show institutions ranked by AUM in new dashboard tile
 - Document troubleshooting steps for missing `default.metallib` warning
 - Show per-table row count comparison after restore in a modal window
+- Expand critical accounts by default and open account detail window on row click
 - Delete Asset SubClass instantly with toast feedback and error alert when in use
 - Display table details when Asset SubClass deletion fails
 - Widen Restore Comparison window to display all columns without scrolling

--- a/DragonShield/DragonShieldApp.swift
+++ b/DragonShield/DragonShieldApp.swift
@@ -23,5 +23,12 @@ struct DragonShieldApp: App {
                 }
             }
         }
+
+        WindowGroup(for: Int.self) { $accountId in
+            if let id = accountId {
+                AccountDetailWindowView(accountId: id)
+                    .environmentObject(databaseManager)
+            }
+        }
     }
 }

--- a/DragonShield/ViewModels/AccountDetailViewModel.swift
+++ b/DragonShield/ViewModels/AccountDetailViewModel.swift
@@ -1,0 +1,33 @@
+import Foundation
+import SwiftUI
+
+class AccountDetailViewModel: ObservableObject {
+    @Published var account: DatabaseManager.AccountData?
+    @Published var positions: [PositionReportData] = []
+
+    private let accountId: Int
+    private weak var db: DatabaseManager?
+
+    init(accountId: Int, db: DatabaseManager? = nil) {
+        self.accountId = accountId
+        self.db = db
+    }
+
+    func load(db: DatabaseManager? = nil) {
+        if let db { self.db = db }
+        guard let db = self.db else { return }
+        account = db.fetchAccountDetails(id: accountId)
+        positions = db.fetchPositionReports(accountId: accountId)
+            .sorted { ($0.currentPrice ?? 0) * $0.quantity > ($1.currentPrice ?? 0) * $1.quantity }
+    }
+
+    func update(position: PositionReportData) {
+        guard let db = db else { return }
+        _ = db.updatePositionValues(id: position.id,
+                                    quantity: position.quantity,
+                                    currentPrice: position.currentPrice,
+                                    instrumentUpdatedAt: position.instrumentUpdatedAt)
+        db.refreshEarliestInstrumentTimestamp(accountId: accountId)
+        load()
+    }
+}

--- a/DragonShield/Views/AccountDetailWindowView.swift
+++ b/DragonShield/Views/AccountDetailWindowView.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+struct AccountDetailWindowView: View {
+    @EnvironmentObject var dbManager: DatabaseManager
+    @StateObject private var viewModel: AccountDetailViewModel
+
+    init(accountId: Int) {
+        _viewModel = StateObject(wrappedValue: AccountDetailViewModel(accountId: accountId))
+    }
+
+    private static let numberFormatter: NumberFormatter = {
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        f.maximumFractionDigits = 4
+        return f
+    }()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if let acc = viewModel.account {
+                header(for: acc)
+                positionsTable
+            } else {
+                ProgressView()
+            }
+        }
+        .padding(16)
+        .frame(minWidth: 600, minHeight: 400)
+        .onAppear { viewModel.load(db: dbManager) }
+        .navigationTitle("Account Detail – \(viewModel.account?.accountName ?? "")")
+    }
+
+    private func header(for acc: DatabaseManager.AccountData) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(acc.accountName).font(.title2)
+            Text(acc.accountNumber)
+            Text(acc.institutionName)
+            if let d = acc.earliestInstrumentLastUpdatedAt {
+                Text("Earliest Update: " + DateFormatter.swissDate.string(from: d))
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var positionsTable: some View {
+        Table($viewModel.positions) {
+            TableColumn("Instrument") { $row in
+                Text(row.instrumentName)
+            }
+            TableColumn("Qty") { $row in
+                TextField("", value: $row.quantity, formatter: Self.numberFormatter)
+                    .onSubmit { viewModel.update(position: row) }
+            }
+            TableColumn("Price") { $row in
+                TextField("", value: Binding(get: { row.currentPrice ?? 0 }, set: { row.currentPrice = $0 }), formatter: Self.numberFormatter)
+                    .onSubmit { viewModel.update(position: row) }
+            }
+            TableColumn("Updated") { $row in
+                DatePicker("", selection: Binding(get: { row.instrumentUpdatedAt ?? Date() }, set: { row.instrumentUpdatedAt = $0 }), displayedComponents: .date)
+                    .datePickerStyle(.field)
+                    .onChange(of: row.instrumentUpdatedAt) { _ in viewModel.update(position: row) }
+            }
+        }
+    }
+}

--- a/DragonShield/Views/DashboardTiles/AccountsNeedingUpdateTile.swift
+++ b/DragonShield/Views/DashboardTiles/AccountsNeedingUpdateTile.swift
@@ -7,6 +7,7 @@ struct AccountsNeedingUpdateTile: DashboardTile {
     static let iconName = "exclamationmark.triangle"
 
     @EnvironmentObject var dbManager: DatabaseManager
+    @Environment(\.openWindow) private var openWindow
     @StateObject private var viewModel = StaleAccountsViewModel()
     @State private var showRed = false
     @State private var showAmber = false
@@ -62,6 +63,8 @@ struct AccountsNeedingUpdateTile: DashboardTile {
         }
         .onAppear {
             viewModel.loadStaleAccounts(db: dbManager)
+            showRed = true
+            showAmber = true
         }
         .alert("Error", isPresented: Binding(
             get: { refreshError != nil },
@@ -121,6 +124,9 @@ struct AccountsNeedingUpdateTile: DashboardTile {
                 .padding(.horizontal, 4)
                 .background(rowColor(for: account.earliestInstrumentLastUpdatedAt))
                 .cornerRadius(4)
+                .onTapGesture {
+                    openWindow(value: account.id)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- expand red & amber account groups by default
- open a new detail window when clicking a stale account
- show account details and editable positions in the new window
- support fetching and updating position values in the database

## Testing
- `pip install -r requirements.txt` *(fails: pysqlcipher3 not available)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883eca21ab883239aac125758a02b98