### PR TITLE
Add account detail window and expand stale account sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - Confirm deletion of positions per account type with live count
 - Display stale accounts grouped by age with collapsible sections
 - Generate full instrument report from Database Management view
+- Auto-expand critical Accounts Needing Update sections and open account detail window
 - Use latest flagged FX rates for import value calculations and report applied rates
 - Store import session total value and add CLI summary report
 - Show imported position values in CHF after import completes

--- a/DragonShield/DatabaseManager+Accounts.swift
+++ b/DragonShield/DatabaseManager+Accounts.swift
@@ -492,4 +492,27 @@ extension DatabaseManager {
             }
         }
     }
+
+    /// Recalculates the earliest instrument update date for a single account.
+    func updateEarliestInstrumentTimestamp(accountId: Int) {
+        let sql = """
+            UPDATE Accounts
+               SET earliest_instrument_last_updated_at = (
+                    SELECT MIN(instrument_updated_at)
+                      FROM PositionReports pr
+                     WHERE pr.account_id = Accounts.account_id
+               )
+             WHERE account_id = ?;
+            """
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            print("❌ Failed to prepare updateEarliestInstrumentTimestamp: \(String(cString: sqlite3_errmsg(db)))")
+            return
+        }
+        sqlite3_bind_int(stmt, 1, Int32(accountId))
+        if sqlite3_step(stmt) != SQLITE_DONE {
+            print("❌ Failed to update earliest instrument timestamp: \(String(cString: sqlite3_errmsg(db)))")
+        }
+        sqlite3_finalize(stmt)
+    }
 }

--- a/DragonShield/DragonShieldApp.swift
+++ b/DragonShield/DragonShieldApp.swift
@@ -23,5 +23,9 @@ struct DragonShieldApp: App {
                 }
             }
         }
+        WindowGroup(for: Int.self) { accountId in
+            AccountDetailWindowView(accountId: accountId, db: databaseManager)
+                .environmentObject(databaseManager)
+        }
     }
 }

--- a/DragonShield/ViewModels/AccountDetailViewModel.swift
+++ b/DragonShield/ViewModels/AccountDetailViewModel.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+class AccountDetailViewModel: ObservableObject {
+    @Published var account: DatabaseManager.AccountData
+    @Published var positions: [AccountPositionData] = []
+
+    private let db: DatabaseManager
+    private let accountId: Int
+
+    init(accountId: Int, db: DatabaseManager) {
+        self.db = db
+        self.accountId = accountId
+        self.account = db.fetchAccountDetails(id: accountId) ?? DatabaseManager.AccountData(id: accountId, accountName: "", institutionId: 0, institutionName: "", institutionBic: nil, accountNumber: "", accountType: "", accountTypeId: 0, currencyCode: "", openingDate: nil, closingDate: nil, earliestInstrumentLastUpdatedAt: nil, includeInPortfolio: true, isActive: true, notes: nil)
+        load()
+    }
+
+    func load() {
+        positions = db.fetchAccountPositions(accountId: accountId)
+            .sorted { ($0.quantity * ($0.currentPrice ?? 0)) > ($1.quantity * ($1.currentPrice ?? 0)) }
+        if let acc = db.fetchAccountDetails(id: accountId) {
+            account = acc
+        }
+    }
+
+    func saveAll() {
+        for p in positions {
+            _ = db.updatePositionReport(
+                id: p.id,
+                importSessionId: p.importSessionId,
+                accountId: p.accountId,
+                institutionId: p.institutionId,
+                instrumentId: p.instrumentId,
+                quantity: p.quantity,
+                purchasePrice: p.purchasePrice,
+                currentPrice: p.currentPrice,
+                instrumentUpdatedAt: p.instrumentUpdatedAt,
+                notes: p.notes,
+                reportDate: p.reportDate
+            )
+        }
+        db.updateEarliestInstrumentTimestamp(accountId: accountId)
+        load()
+    }
+}

--- a/DragonShield/Views/AccountDetailWindowView.swift
+++ b/DragonShield/Views/AccountDetailWindowView.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+struct AccountDetailWindowView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.undoManager) private var undoManager
+
+    @StateObject private var viewModel: AccountDetailViewModel
+
+    init(accountId: Int, db: DatabaseManager) {
+        _viewModel = StateObject(wrappedValue: AccountDetailViewModel(accountId: accountId, db: db))
+    }
+
+    private static let numberFormatter: NumberFormatter = {
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        f.maximumFractionDigits = 4
+        return f
+    }()
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            header
+            Table($viewModel.positions) {
+                TableColumn("Instrument") { Text($0.wrappedValue.instrumentName) }
+                TableColumn("Quantity") {
+                    TextField(value: $0.quantity, formatter: Self.numberFormatter)
+                        .frame(width: 80)
+                }
+                TableColumn("Current Price") {
+                    TextField(value: Binding(get: { $0.currentPrice ?? 0 }, set: { $0.currentPrice = $0 == 0 ? nil : $0 }), formatter: Self.numberFormatter)
+                        .frame(width: 80)
+                }
+                TableColumn("Updated") {
+                    DatePicker("", selection: Binding(get: { $0.instrumentUpdatedAt ?? Date() }, set: { $0.instrumentUpdatedAt = $0 }), displayedComponents: .date)
+                        .labelsHidden()
+                }
+            }
+        }
+        .padding(16)
+        .frame(minWidth: 600, minHeight: 400)
+        .onDisappear { viewModel.saveAll() }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading) {
+            Text("Account Detail – \(viewModel.account.accountName)")
+                .font(.title2.bold())
+            if let date = viewModel.account.earliestInstrumentLastUpdatedAt {
+                Text("Earliest Instrument Update: " + DateFormatter.swissDate.string(from: date))
+            }
+            Text(viewModel.account.accountNumber)
+            Text(viewModel.account.institutionName)
+        }
+        .padding(.bottom, 8)
+    }
+
+}

--- a/DragonShield/Views/DashboardTiles/AccountsNeedingUpdateTile.swift
+++ b/DragonShield/Views/DashboardTiles/AccountsNeedingUpdateTile.swift
@@ -14,6 +14,7 @@ struct AccountsNeedingUpdateTile: DashboardTile {
     @State private var refreshing = false
     @State private var showCheckmark = false
     @State private var refreshError: String?
+    @Environment(\.openWindow) private var openWindow
 
     private static let displayFormatter: DateFormatter = {
         let f = DateFormatter()
@@ -62,6 +63,8 @@ struct AccountsNeedingUpdateTile: DashboardTile {
         }
         .onAppear {
             viewModel.loadStaleAccounts(db: dbManager)
+            showRed = true
+            showAmber = true
         }
         .alert("Error", isPresented: Binding(
             get: { refreshError != nil },
@@ -121,6 +124,9 @@ struct AccountsNeedingUpdateTile: DashboardTile {
                 .padding(.horizontal, 4)
                 .background(rowColor(for: account.earliestInstrumentLastUpdatedAt))
                 .cornerRadius(4)
+                .onTapGesture {
+                    openWindow(value: account.id)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- auto-expand red and amber account groups on Dashboard
- open a detail window when tapping a stale account row
- support fetching account positions with identifiers for editing
- allow editing linked positions in a new AccountDetailWindowView
- recalc earliest instrument date per account automatically
- document the UI changes in the changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883eca21ab883239aac125758a02b98