### PR TITLE
Add account detail window & expand stale sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Show institutions ranked by AUM in new dashboard tile
 - Document troubleshooting steps for missing `default.metallib` warning
 - Show per-table row count comparison after restore in a modal window
+- Auto-expand stale account sections and open editable account detail window from Dashboard
 - Delete Asset SubClass instantly with toast feedback and error alert when in use
 - Display table details when Asset SubClass deletion fails
 - Widen Restore Comparison window to display all columns without scrolling

--- a/DragonShield/DragonShieldApp.swift
+++ b/DragonShield/DragonShieldApp.swift
@@ -23,5 +23,14 @@ struct DragonShieldApp: App {
                 }
             }
         }
+        WindowGroup(id: "accountDetail", for: Int.self) { $accountId in
+            if let id = accountId,
+               let account = databaseManager.fetchAccountDetails(id: id) {
+                AccountDetailWindowView(account: account)
+                    .environmentObject(databaseManager)
+            } else {
+                Text("Account not found")
+            }
+        }
     }
 }

--- a/DragonShield/ViewModels/AccountDetailWindowViewModel.swift
+++ b/DragonShield/ViewModels/AccountDetailWindowViewModel.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+final class AccountDetailWindowViewModel: ObservableObject {
+    @Published var account: DatabaseManager.AccountData
+    @Published var positions: [DatabaseManager.EditablePositionData] = []
+
+    private var dbManager: DatabaseManager?
+
+    init(account: DatabaseManager.AccountData) {
+        self.account = account
+    }
+
+    func configure(db: DatabaseManager) {
+        self.dbManager = db
+        loadData()
+    }
+
+    func loadData() {
+        guard let db = dbManager else { return }
+        positions = db.fetchEditablePositions(accountId: account.id)
+        if let updated = db.fetchAccountDetails(id: account.id) {
+            account = updated
+        }
+    }
+
+    func update(position: DatabaseManager.EditablePositionData) {
+        guard let db = dbManager else { return }
+        _ = db.updatePositionReport(
+            id: position.id,
+            importSessionId: position.importSessionId,
+            accountId: position.accountId,
+            institutionId: position.institutionId,
+            instrumentId: position.instrumentId,
+            quantity: position.quantity,
+            purchasePrice: position.purchasePrice,
+            currentPrice: position.currentPrice,
+            instrumentUpdatedAt: position.instrumentUpdatedAt,
+            notes: position.notes,
+            reportDate: position.reportDate
+        )
+        db.refreshEarliestInstrumentTimestamp(accountId: account.id)
+        loadData()
+    }
+}

--- a/DragonShield/Views/AccountDetailWindowView.swift
+++ b/DragonShield/Views/AccountDetailWindowView.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+struct AccountDetailWindowView: View {
+    @EnvironmentObject var dbManager: DatabaseManager
+    @Environment(\.undoManager) private var undoManager
+    @StateObject private var viewModel: AccountDetailWindowViewModel
+
+    private static let numberFormatter: NumberFormatter = {
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        f.maximumFractionDigits = 4
+        f.minimumFractionDigits = 0
+        return f
+    }()
+
+    init(account: DatabaseManager.AccountData) {
+        _viewModel = StateObject(wrappedValue: AccountDetailWindowViewModel(account: account))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            header
+            positionsTable
+        }
+        .padding(16)
+        .frame(minWidth: 600, minHeight: 400)
+        .onAppear { viewModel.configure(db: dbManager) }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Account Detail – \(viewModel.account.accountName)")
+                .font(.title2)
+            Text("Account Number: \(viewModel.account.accountNumber)")
+            Text("Institution: \(viewModel.account.institutionName)")
+            if let d = viewModel.account.earliestInstrumentLastUpdatedAt {
+                Text("Earliest Update: \(DateFormatter.swissDate.string(from: d))")
+            }
+        }
+    }
+
+    private var positionsTable: some View {
+        ScrollView {
+            VStack(alignment: .leading) {
+                ForEach($viewModel.positions) { $item in
+                    HStack {
+                        Text(item.instrumentName)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        TextField("Qty", value: $item.quantity, formatter: Self.numberFormatter)
+                            .frame(width: 80)
+                            .onSubmit { viewModel.update(position: item) }
+                        TextField("Price", value: Binding(
+                            get: { item.currentPrice ?? 0 },
+                            set: { item.currentPrice = $0 }
+                        ), formatter: Self.numberFormatter)
+                            .frame(width: 80)
+                            .onSubmit { viewModel.update(position: item) }
+                        DatePicker("", selection: Binding(
+                            get: { item.instrumentUpdatedAt ?? Date() },
+                            set: { item.instrumentUpdatedAt = $0; viewModel.update(position: item) }
+                        ), displayedComponents: .date)
+                            .labelsHidden()
+                    }
+                    .padding(4)
+                }
+            }
+        }
+    }
+}

--- a/DragonShield/Views/DashboardTiles/AccountsNeedingUpdateTile.swift
+++ b/DragonShield/Views/DashboardTiles/AccountsNeedingUpdateTile.swift
@@ -7,6 +7,7 @@ struct AccountsNeedingUpdateTile: DashboardTile {
     static let iconName = "exclamationmark.triangle"
 
     @EnvironmentObject var dbManager: DatabaseManager
+    @Environment(\.openWindow) private var openWindow
     @StateObject private var viewModel = StaleAccountsViewModel()
     @State private var showRed = false
     @State private var showAmber = false
@@ -62,6 +63,8 @@ struct AccountsNeedingUpdateTile: DashboardTile {
         }
         .onAppear {
             viewModel.loadStaleAccounts(db: dbManager)
+            showRed = true
+            showAmber = true
         }
         .alert("Error", isPresented: Binding(
             get: { refreshError != nil },
@@ -121,6 +124,9 @@ struct AccountsNeedingUpdateTile: DashboardTile {
                 .padding(.horizontal, 4)
                 .background(rowColor(for: account.earliestInstrumentLastUpdatedAt))
                 .cornerRadius(4)
+                .onTapGesture {
+                    openWindow(id: "accountDetail", value: account.id)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- open stale account sections by default
- allow opening a new Account Detail window from the dashboard
- show and edit positions for a single account in the new window
- refresh earliest timestamps for individual accounts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883eca21ab883239aac125758a02b98