### PR TITLE
Add save flow to account detail window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,14 @@ All notable changes to this project will be documented in this file.
 - Prompt to confirm option quantity multiplier during position import
 - Show institutions ranked by AUM in new dashboard tile
 - Document troubleshooting steps for missing `default.metallib` warning
+- Mention language code console warnings and how to silence them
+- Log database version correctly at startup
+- Label green stale account range as "<1 month / today"
 - Show per-table row count comparison after restore in a modal window
+- Auto-expand stale account sections and open editable account detail window from Dashboard
+- Provide Save/Cancel buttons in Account Detail window with quick saved status
+- Resolve progress indicator layout warning on macOS
+- Display all stale accounts sorted by earliest update and account name
 - Delete Asset SubClass instantly with toast feedback and error alert when in use
 - Display table details when Asset SubClass deletion fails
 - Widen Restore Comparison window to display all columns without scrolling

--- a/DragonShield/DatabaseManager.swift
+++ b/DragonShield/DatabaseManager.swift
@@ -85,9 +85,10 @@ class DatabaseManager: ObservableObject {
         
         openDatabase()
         let version = loadConfiguration()
+        self.dbVersion = version
         DispatchQueue.main.async { self.dbVersion = version }
         updateFileMetadata()
-        print("📂 Database path: \(dbPath) | version: \(dbVersion)")
+        print("📂 Database path: \(dbPath) | version: \(version)")
     }
     
     func openDatabase() {

--- a/DragonShield/DragonShieldApp.swift
+++ b/DragonShield/DragonShieldApp.swift
@@ -23,5 +23,14 @@ struct DragonShieldApp: App {
                 }
             }
         }
+        WindowGroup(id: "accountDetail", for: Int.self) { $accountId in
+            if let id = accountId,
+               let account = databaseManager.fetchAccountDetails(id: id) {
+                AccountDetailWindowView(account: account)
+                    .environmentObject(databaseManager)
+            } else {
+                Text("Account not found")
+            }
+        }
     }
 }

--- a/DragonShield/ViewModels/AccountDetailWindowViewModel.swift
+++ b/DragonShield/ViewModels/AccountDetailWindowViewModel.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+final class AccountDetailWindowViewModel: ObservableObject {
+    @Published var account: DatabaseManager.AccountData
+    @Published var positions: [DatabaseManager.EditablePositionData] = []
+    @Published var showSaved = false
+
+    private var dbManager: DatabaseManager?
+    private var originalPositions: [DatabaseManager.EditablePositionData] = []
+
+    init(account: DatabaseManager.AccountData) {
+        self.account = account
+    }
+
+    func configure(db: DatabaseManager) {
+        self.dbManager = db
+        loadData()
+    }
+
+    func loadData() {
+        guard let db = dbManager else { return }
+        positions = db.fetchEditablePositions(accountId: account.id)
+        originalPositions = positions
+        if let updated = db.fetchAccountDetails(id: account.id) {
+            account = updated
+        }
+    }
+
+    func saveChanges() {
+        guard let db = dbManager else { return }
+        for pos in positions {
+            _ = db.updatePositionReport(
+                id: pos.id,
+                importSessionId: pos.importSessionId,
+                accountId: pos.accountId,
+                institutionId: pos.institutionId,
+                instrumentId: pos.instrumentId,
+                quantity: pos.quantity,
+                purchasePrice: pos.purchasePrice,
+                currentPrice: pos.currentPrice,
+                instrumentUpdatedAt: pos.instrumentUpdatedAt,
+                notes: pos.notes,
+                reportDate: pos.reportDate
+            )
+        }
+        db.refreshEarliestInstrumentTimestamp(accountId: account.id)
+        loadData()
+        showSaved = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+            self.showSaved = false
+        }
+    }
+
+    func discardChanges() {
+        positions = originalPositions
+    }
+}

--- a/DragonShield/ViewModels/StaleAccountsViewModel.swift
+++ b/DragonShield/ViewModels/StaleAccountsViewModel.swift
@@ -18,16 +18,17 @@ class StaleAccountsViewModel: ObservableObject {
         guard let dbManager else { return }
         let accounts = dbManager.fetchAccounts()
         staleAccounts = accounts
-            .sorted(by: Self.earliestFirst)
-            .prefix(10)
-            .map { $0 }
+            .sorted(by: Self.earliestThenName)
     }
 
-    private static func earliestFirst(_ a: DatabaseManager.AccountData,
-                                      _ b: DatabaseManager.AccountData) -> Bool {
-        let lhs = a.earliestInstrumentLastUpdatedAt ?? Date.distantFuture
-        let rhs = b.earliestInstrumentLastUpdatedAt ?? Date.distantFuture
-        return lhs < rhs
+    private static func earliestThenName(_ a: DatabaseManager.AccountData,
+                                         _ b: DatabaseManager.AccountData) -> Bool {
+        let lhsDate = a.earliestInstrumentLastUpdatedAt ?? Date.distantFuture
+        let rhsDate = b.earliestInstrumentLastUpdatedAt ?? Date.distantFuture
+        if lhsDate == rhsDate {
+            return a.accountName.localizedCaseInsensitiveCompare(b.accountName) == .orderedAscending
+        }
+        return lhsDate < rhsDate
     }
 
     func daysSince(_ date: Date) -> Int {

--- a/DragonShield/Views/AccountDetailWindowView.swift
+++ b/DragonShield/Views/AccountDetailWindowView.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+
+struct AccountDetailWindowView: View {
+    @EnvironmentObject var dbManager: DatabaseManager
+    @Environment(\.undoManager) private var undoManager
+    @Environment(\.dismiss) private var dismiss
+    @StateObject private var viewModel: AccountDetailWindowViewModel
+
+    private static let numberFormatter: NumberFormatter = {
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        f.maximumFractionDigits = 4
+        f.minimumFractionDigits = 0
+        return f
+    }()
+
+    init(account: DatabaseManager.AccountData) {
+        _viewModel = StateObject(wrappedValue: AccountDetailWindowViewModel(account: account))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            header
+            positionsTable
+            Spacer()
+            actionButtons
+        }
+        .padding(16)
+        .frame(minWidth: 600, minHeight: 400)
+        .overlay(alignment: .topTrailing) {
+            if viewModel.showSaved {
+                Text("Saved")
+                    .padding(6)
+                    .background(Color.green.opacity(0.8))
+                    .foregroundColor(.white)
+                    .cornerRadius(6)
+                    .transition(.opacity)
+            }
+        }
+        .onAppear { viewModel.configure(db: dbManager) }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Account Detail – \(viewModel.account.accountName)")
+                .font(.title2)
+            Text("Account Number: \(viewModel.account.accountNumber)")
+            Text("Institution: \(viewModel.account.institutionName)")
+            if let d = viewModel.account.earliestInstrumentLastUpdatedAt {
+                Text("Earliest Update: \(DateFormatter.swissDate.string(from: d))")
+            }
+        }
+    }
+
+    private var positionsTable: some View {
+        ScrollView {
+            VStack(alignment: .leading) {
+                ForEach($viewModel.positions) { $item in
+                    HStack {
+                        Text(item.instrumentName)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        TextField("Qty", value: $item.quantity, formatter: Self.numberFormatter)
+                            .frame(width: 80)
+                        TextField("Price", value: Binding(
+                            get: { item.currentPrice ?? 0 },
+                            set: { item.currentPrice = $0 }
+                        ), formatter: Self.numberFormatter)
+                            .frame(width: 80)
+                        DatePicker("", selection: Binding(
+                            get: { item.instrumentUpdatedAt ?? Date() },
+                            set: { item.instrumentUpdatedAt = $0 }
+                        ), displayedComponents: .date)
+                            .labelsHidden()
+                    }
+                    .padding(4)
+                }
+            }
+        }
+    }
+
+    private var actionButtons: some View {
+        HStack {
+            Spacer()
+            Button("Cancel") {
+                viewModel.discardChanges()
+                dismiss()
+            }
+            Button("OK") {
+                viewModel.saveChanges()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                    dismiss()
+                }
+            }
+            .keyboardShortcut(.defaultAction)
+        }
+    }
+}

--- a/DragonShield/Views/AccountsView.swift
+++ b/DragonShield/Views/AccountsView.swift
@@ -225,7 +225,7 @@ struct AccountsView: View {
                     }
                 } label: {
                     HStack(spacing: 6) {
-                        if isRefreshing { ProgressView().scaleEffect(0.7) } else { Image(systemName: "arrow.clockwise") }
+                        if isRefreshing { ProgressView().controlSize(.small) } else { Image(systemName: "arrow.clockwise") }
                         Text("Refresh Instrument Timestamps")
                     }
                     .font(.system(size: 14, weight: .medium))

--- a/DragonShield/Views/DashboardTiles/AccountsNeedingUpdateTile.swift
+++ b/DragonShield/Views/DashboardTiles/AccountsNeedingUpdateTile.swift
@@ -7,6 +7,7 @@ struct AccountsNeedingUpdateTile: DashboardTile {
     static let iconName = "exclamationmark.triangle"
 
     @EnvironmentObject var dbManager: DatabaseManager
+    @Environment(\.openWindow) private var openWindow
     @StateObject private var viewModel = StaleAccountsViewModel()
     @State private var showRed = false
     @State private var showAmber = false
@@ -62,6 +63,8 @@ struct AccountsNeedingUpdateTile: DashboardTile {
         }
         .onAppear {
             viewModel.loadStaleAccounts(db: dbManager)
+            showRed = true
+            showAmber = true
         }
         .alert("Error", isPresented: Binding(
             get: { refreshError != nil },
@@ -98,7 +101,7 @@ struct AccountsNeedingUpdateTile: DashboardTile {
                     DisclosureGroup(isExpanded: $showGreen) {
                         listBody(greenRows)
                     } label: {
-                        summaryRow(title: "<1 month", count: greenRows.count, color: .success)
+                        summaryRow(title: "<1 month / today", count: greenRows.count, color: .success)
                     }
                 }
             }
@@ -121,6 +124,9 @@ struct AccountsNeedingUpdateTile: DashboardTile {
                 .padding(.horizontal, 4)
                 .background(rowColor(for: account.earliestInstrumentLastUpdatedAt))
                 .cornerRadius(4)
+                .onTapGesture {
+                    openWindow(id: "accountDetail", value: account.id)
+                }
             }
         }
     }
@@ -140,7 +146,7 @@ struct AccountsNeedingUpdateTile: DashboardTile {
             Group {
                 if refreshing {
                     ProgressView()
-                        .scaleEffect(0.7)
+                        .controlSize(.small)
                 } else if showCheckmark {
                     Image(systemName: "checkmark")
                         .transition(.scale)

--- a/DragonShield/python_scripts/stale_accounts.py
+++ b/DragonShield/python_scripts/stale_accounts.py
@@ -8,8 +8,11 @@ class Account:
     earliest_instrument_last_updated_at: datetime | None
 
 
-def top_stale_accounts(accounts: List[Account], limit: int = 10) -> List[Account]:
+def top_stale_accounts(accounts: List[Account]) -> List[Account]:
     def sort_key(a: Account):
-        return a.earliest_instrument_last_updated_at or datetime.max
+        return (
+            a.earliest_instrument_last_updated_at or datetime.max,
+            a.name.lower(),
+        )
 
-    return sorted(accounts, key=sort_key)[:limit]
+    return sorted(accounts, key=sort_key)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,3 +11,15 @@ Unable to open mach-O at path: /AppleInternal/Library/.../RenderBox.framework/..
 This originates from macOS attempting to load a Metal shader library that is not present on non-internal systems. The warning is harmless and does not prevent the application from running.
 
 If the message appears repeatedly or the app fails to start, reinstall the Xcode Command Line Tools (`xcode-select --install`) or the full Xcode application to restore missing system resources.
+
+## Language code warnings
+
+When running on macOS you may see console output similar to:
+
+```
+GenerativeModelsAvailability.Parameters: Initialized with invalid language code: en-GB. Expected to receive two-letter ISO 639 code.
+AFIsDeviceGreymatterEligible Missing entitlements for os_eligibility lookup
+-[AFPreferences _languageCodeWithFallback:] No language code saved, but Assistant is enabled - returning: en-GB
+```
+
+These messages are emitted by Apple's Siri frameworks and do not affect DragonShield. Setting the environment variable `LANG=en` or ensuring your system language is configured correctly will silence the warnings.

--- a/tests/test_stale_accounts.py
+++ b/tests/test_stale_accounts.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from DragonShield.python_scripts.stale_accounts import Account, top_stale_accounts
 
 
-def test_sort_and_limit():
+def test_sort_and_order():
     today = datetime(2025, 1, 1)
     accounts = [
         Account("A", today - timedelta(days=40)),
@@ -19,8 +19,14 @@ def test_sort_and_limit():
         Account("K", today - timedelta(days=55)),
     ]
 
+    accounts.append(Account("AA", today - timedelta(days=10)))
+
     result = top_stale_accounts(accounts)
 
-    assert len(result) == 10
+    assert len(result) == len(accounts)
     dates = [acc.earliest_instrument_last_updated_at for acc in result]
     assert dates == sorted(dates)
+    # ensure tie-breaking by name when dates match
+    b_index = next(i for i, acc in enumerate(result) if acc.name == "B")
+    aa_index = next(i for i, acc in enumerate(result) if acc.name == "AA")
+    assert aa_index < b_index


### PR DESCRIPTION
## Summary
- provide Save and Cancel buttons in Account Detail window
- show a temporary "Saved" badge after persisting edits
- fix layout warning by sizing refresh progress indicators
- show all stale accounts sorted by earliest update then account name

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883eca21ab883239aac125758a02b98