### PR TITLE
Polish Account Detail window layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Show per-table row count comparison after restore in a modal window
 - Auto-expand stale account sections and open editable account detail window from Dashboard
 - Provide Save/Cancel buttons in Account Detail window with quick saved status
+- Polish Account Detail window layout with labeled fields and toolbar actions
 - Resolve progress indicator layout warning on macOS
 - Display all stale accounts sorted by earliest update and account name
 - Delete Asset SubClass instantly with toast feedback and error alert when in use

--- a/DragonShield/Views/AccountDetailWindowView.swift
+++ b/DragonShield/Views/AccountDetailWindowView.swift
@@ -23,10 +23,26 @@ struct AccountDetailWindowView: View {
             header
             positionsTable
             Spacer()
-            actionButtons
         }
         .padding(16)
         .frame(minWidth: 600, minHeight: 400)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel") {
+                    viewModel.discardChanges()
+                    dismiss()
+                }
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button("OK") {
+                    viewModel.saveChanges()
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                        dismiss()
+                    }
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+        }
         .overlay(alignment: .topTrailing) {
             if viewModel.showSaved {
                 Text("Saved")
@@ -42,56 +58,64 @@ struct AccountDetailWindowView: View {
 
     private var header: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text("Account Detail – \(viewModel.account.accountName)")
-                .font(.title2)
+            Text(viewModel.account.accountName)
+                .font(.system(size: 20, weight: .bold))
+                .foregroundColor(.accentColor)
             Text("Account Number: \(viewModel.account.accountNumber)")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
             Text("Institution: \(viewModel.account.institutionName)")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
             if let d = viewModel.account.earliestInstrumentLastUpdatedAt {
                 Text("Earliest Update: \(DateFormatter.swissDate.string(from: d))")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
             }
         }
     }
 
     private var positionsTable: some View {
         ScrollView {
-            VStack(alignment: .leading) {
+            Grid(horizontalSpacing: 16, verticalSpacing: 16) {
                 ForEach($viewModel.positions) { $item in
-                    HStack {
+                    GridRow {
                         Text(item.instrumentName)
                             .frame(maxWidth: .infinity, alignment: .leading)
-                        TextField("Qty", value: $item.quantity, formatter: Self.numberFormatter)
-                            .frame(width: 80)
-                        TextField("Price", value: Binding(
-                            get: { item.currentPrice ?? 0 },
-                            set: { item.currentPrice = $0 }
-                        ), formatter: Self.numberFormatter)
-                            .frame(width: 80)
-                        DatePicker("", selection: Binding(
-                            get: { item.instrumentUpdatedAt ?? Date() },
-                            set: { item.instrumentUpdatedAt = $0 }
-                        ), displayedComponents: .date)
-                            .labelsHidden()
-                    }
-                    .padding(4)
-                }
-            }
-        }
-    }
 
-    private var actionButtons: some View {
-        HStack {
-            Spacer()
-            Button("Cancel") {
-                viewModel.discardChanges()
-                dismiss()
-            }
-            Button("OK") {
-                viewModel.saveChanges()
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
-                    dismiss()
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("Quantity")
+                                .font(.caption2)
+                                .foregroundColor(.secondary)
+                            TextField("", value: $item.quantity, formatter: Self.numberFormatter)
+                                .frame(width: 80)
+                        }
+
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("Current Price")
+                                .font(.caption2)
+                                .foregroundColor(.secondary)
+                            TextField("", value: Binding(
+                                get: { item.currentPrice ?? 0 },
+                                set: { item.currentPrice = $0 }
+                            ), formatter: Self.numberFormatter)
+                                .frame(width: 80)
+                        }
+
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("Updated At")
+                                .font(.caption2)
+                                .foregroundColor(.secondary)
+                            DatePicker("", selection: Binding(
+                                get: { item.instrumentUpdatedAt ?? Date() },
+                                set: { item.instrumentUpdatedAt = $0 }
+                            ), displayedComponents: .date)
+                                .labelsHidden()
+                        }
+                    }
                 }
             }
-            .keyboardShortcut(.defaultAction)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 }


### PR DESCRIPTION
## Summary
- restyle Account Detail pop-up with an accented title
- add captions for quantity, price and update date
- align editable fields using `Grid`
- move OK and Cancel buttons into the window toolbar

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68846b66924c83239bb4896e28d2a83f