### PR TITLE
Move Actions column to first position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -389,3 +389,4 @@ All notable changes to this project will be documented in this file.
 - Ensure published properties update on main thread and migrate onChange syntax
 - Distinct colors for each risk bucket segment and matching legend
 - Quick refresh icon on Accounts Needing Update dashboard tile
+- Place Actions column first in Positions table for quicker edits

--- a/DragonShield/Views/PositionsView.swift
+++ b/DragonShield/Views/PositionsView.swift
@@ -318,6 +318,19 @@ struct PositionsView: View {
     private var positionsContent: some View {
         let data = sortedPositions
         return Table(data, selection: $selectedRows, sortOrder: $sortOrder) {
+            if visibleColumns.contains(.actions) {
+                TableColumn("Actions") { (position: PositionReportData) in
+                    HStack(spacing: 8) {
+                        Button(action: { positionToEdit = position }) { Image(systemName: "pencil") }
+                            .buttonStyle(PlainButtonStyle())
+                        Button(action: { positionToDelete = position; showDeleteSingleAlert = true }) { Image(systemName: "trash") }
+                            .buttonStyle(PlainButtonStyle())
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+                .width(min: 45, ideal: 45)
+            }
+
             if visibleColumns.contains(.notes) {
                 TableColumn("") { (position: PositionReportData) in
                     if let notes = position.notes, !notes.isEmpty {
@@ -502,19 +515,6 @@ struct PositionsView: View {
                         .frame(maxWidth: .infinity, alignment: .center)
                     }
                     .width(min: 120, ideal: 140)
-                }
-
-                if visibleColumns.contains(.actions) {
-                    TableColumn("Actions") { (position: PositionReportData) in
-                        HStack(spacing: 8) {
-                            Button(action: { positionToEdit = position }) { Image(systemName: "pencil") }
-                                .buttonStyle(PlainButtonStyle())
-                            Button(action: { positionToDelete = position; showDeleteSingleAlert = true }) { Image(systemName: "trash") }
-                                .buttonStyle(PlainButtonStyle())
-                        }
-                        .frame(maxWidth: .infinity)
-                    }
-                    .width(min: 60, ideal: 60)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- display Actions icons in the first column of Positions table
- document the change in the changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68846d2f44e4832392d8baae36f500b5