### PR TITLE
Alphabetize instrument filter menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -390,3 +390,5 @@ All notable changes to this project will be documented in this file.
 - Distinct colors for each risk bucket segment and matching legend
 - Quick refresh icon on Accounts Needing Update dashboard tile
 - Place Actions column first in Positions table for quicker edits
+
+- Sort instrument Type and Currency filter menus alphabetically

--- a/DragonShield/Views/PortfolioView.swift
+++ b/DragonShield/Views/PortfolioView.swift
@@ -384,7 +384,13 @@ struct PortfolioView: View {
     }
 
     private func headerCell(title: String, column: SortColumn, filterValues: [String] = [], filterSelection: Binding<Set<String>>? = nil) -> some View {
-        HStack(spacing: 4) {
+        let sortedValues = filterValues.sorted { a, b in
+            if a == "—" { return false }
+            if b == "—" { return true }
+            return a.localizedCaseInsensitiveCompare(b) == .orderedAscending
+        }
+
+        return HStack(spacing: 4) {
             Button(action: {
                 if sortColumn == column {
                     sortAscending.toggle()
@@ -404,7 +410,7 @@ struct PortfolioView: View {
 
             if let binding = filterSelection {
                 Menu {
-                    ForEach(filterValues, id: \.self) { val in
+                    ForEach(sortedValues, id: \.self) { val in
                         Button(action: {
                             if binding.wrappedValue.contains(val) {
                                 binding.wrappedValue.remove(val)


### PR DESCRIPTION
## Summary
- sort dropdown values for instrument type and currency menus

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68846e59b8188323aa29ee112b567e2f