### PR TITLE
feat(ui): display all top positions with updated styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -392,3 +392,4 @@ All notable changes to this project will be documented in this file.
 - Place Actions column first in Positions table for quicker edits
 
 - Sort instrument Type and Currency filter menus alphabetically
+- Replace blue Top 10 Positions tile with modern white card showing all positions

--- a/DragonShield/ViewModels/PositionsViewModel.swift
+++ b/DragonShield/ViewModels/PositionsViewModel.swift
@@ -7,7 +7,8 @@ class PositionsViewModel: ObservableObject {
     @Published var currencySymbols: [String: String] = [:]
     @Published var calculating: Bool = false
     @Published var showErrorToast: Bool = false
-    @Published var top10PositionsCHF: [TopPosition] = []
+    /// All positions sorted by value in CHF descending.
+    @Published var topPositions: [TopPosition] = []
 
     struct TopPosition: Identifiable {
         let id: Int
@@ -71,7 +72,7 @@ class PositionsViewModel: ObservableObject {
                 self.positionValueCHF = chf
                 self.currencySymbols = symbolCache
                 self.totalAssetValueCHF = total
-                self.top10PositionsCHF = orig.keys.compactMap { id in
+                self.topPositions = orig.keys.compactMap { id in
                     if let value = chf[id], let v = value {
                         let name = positions.first { $0.id == id }?.instrumentName ?? ""
                         let currency = positions.first { $0.id == id }?.instrumentCurrency.uppercased() ?? "CHF"
@@ -80,15 +81,13 @@ class PositionsViewModel: ObservableObject {
                     return nil
                 }
                 .sorted { $0.valueCHF > $1.valueCHF }
-                .prefix(10)
-                .map { $0 }
                 self.calculating = false
                 self.showErrorToast = missingRate
             }
         }
     }
 
-    func calculateTop10Positions(db: DatabaseManager) {
+    func calculateTopPositions(db: DatabaseManager) {
         let positions = db.fetchPositionReports()
         calculateValues(positions: positions, db: db)
     }

--- a/DragonShield/Views/DashboardTiles/DashboardTiles.swift
+++ b/DragonShield/Views/DashboardTiles/DashboardTiles.swift
@@ -152,51 +152,60 @@ struct TotalValueTile: DashboardTile {
 struct TopPositionsTile: DashboardTile {
     @EnvironmentObject var dbManager: DatabaseManager
     @StateObject private var viewModel = PositionsViewModel()
+    @Environment(\.colorScheme) private var colorScheme
 
     init() {}
     static let tileID = "top_positions"
-    static let tileName = "Top 10 Positions by Asset Value (CHF)"
+    static let tileName = "Top Positions"
     static let iconName = "list.number"
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text(Self.tileName)
-                .font(.headline)
+                .font(.system(size: 18, weight: .bold))
             if viewModel.calculating {
                 ProgressView()
                     .frame(maxWidth: .infinity, alignment: .center)
             } else {
                 ScrollView {
-                    VStack(alignment: .leading, spacing: 4) {
-                        ForEach(Array(viewModel.top10PositionsCHF.enumerated()), id: \.element.id) { index, item in
-                            HStack {
-                                VStack(alignment: .leading, spacing: 2) {
-                                    Text(item.instrument)
-                                        .fontWeight(.semibold)
-                                        .lineLimit(1)
-                                    Text(String(format: "%.2f CHF", item.valueCHF))
-                                        .font(.caption)
-                                        .foregroundColor(Color(red: 30/255, green: 58/255, blue: 138/255))
-                                }
+                    LazyVStack(alignment: .leading, spacing: 20) {
+                        ForEach(Array(viewModel.topPositions.enumerated()), id: \.element.id) { index, item in
+                            HStack(alignment: .top) {
+                                Text(item.instrument)
+                                    .fontWeight(.semibold)
+                                    .multilineTextAlignment(.leading)
                                 Spacer()
-                                Text(item.currency)
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
+                                VStack(alignment: .trailing, spacing: 2) {
+                                    Text(String(format: "%.2f", item.valueCHF))
+                                        .font(.system(.body, design: .monospaced).bold())
+                                    Text(item.currency)
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
                             }
-                            .padding(4)
-                            .background(index == 0 ? Color(red: 191/255, green: 219/255, blue: 254/255) : Color.clear)
-                            .cornerRadius(6)
+                            if index != viewModel.topPositions.count - 1 {
+                                Divider().foregroundColor(Color(red: 226/255, green: 232/255, blue: 240/255))
+                            }
                         }
                     }
                 }
-                .frame(maxHeight: viewModel.top10PositionsCHF.count > 6 ? 220 : .infinity)
+                .frame(maxHeight: 400)
             }
         }
-        .padding(16)
-        .background(Color(red: 216/255, green: 236/255, blue: 248/255))
-        .cornerRadius(12)
+        .padding(.vertical, 16)
+        .padding(.horizontal, 24)
+        .background(
+            Group {
+                if colorScheme == .dark {
+                    Color(red: 30/255, green: 30/255, blue: 30/255)
+                } else {
+                    Color.white
+                }
+            }
+        )
+        .cornerRadius(16)
         .shadow(color: .black.opacity(0.1), radius: 3, x: 0, y: 2)
-        .onAppear { viewModel.calculateTop10Positions(db: dbManager) }
+        .onAppear { viewModel.calculateTopPositions(db: dbManager) }
         .accessibilityElement(children: .combine)
     }
 }


### PR DESCRIPTION
## Summary
- modernize Top Positions dashboard tile
- rename `top10PositionsCHF` to `topPositions`
- show unlimited positions in scrollable list
- update changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68846feaf88c8323992b0827a03a77d5