### PR TITLE
feat(ui): restyle crypto allocations dashboard tile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -394,3 +394,4 @@ All notable changes to this project will be documented in this file.
 - Sort instrument Type and Currency filter menus alphabetically
 - Replace blue Top 10 Positions tile with modern white card showing all positions
 - Reduce list row spacing in Top Positions card for denser display
+- Restyle Crypto Allocations dashboard card with captions and percent bars


### PR DESCRIPTION
## Summary
- restyle Crypto Allocations card
- add captions and weight bars

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688472a2cab4832392b2acfae97432be