### PR TITLE
Polish Crypto Allocations tile visuals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Polish Crypto Allocations tile visuals with percentage labels and captions
 - Add macOS Kanban to-do board with drag-and-drop
 - Add sidebar link to the Kanban board
 - Reorganize sidebar navigation with expandable sections and remove old transaction links

--- a/DragonShield/Views/DashboardTiles/CryptoTop5Tile.swift
+++ b/DragonShield/Views/DashboardTiles/CryptoTop5Tile.swift
@@ -14,6 +14,7 @@ struct CryptoTop5Tile: DashboardTile {
     }
 
     @EnvironmentObject var dbManager: DatabaseManager
+    @Environment(\.colorScheme) private var colorScheme
     @State private var rows: [CryptoRow] = []
     @State private var loading = false
 
@@ -27,42 +28,93 @@ struct CryptoTop5Tile: DashboardTile {
     }()
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: 16) {
             Text(Self.tileName)
                 .font(.system(size: 17, weight: .semibold))
             if loading {
                 ProgressView()
                     .frame(maxWidth: .infinity, alignment: .center)
             } else {
+                headerRow
                 ScrollView {
-                    VStack(spacing: 0) {
-                        ForEach(rows) { item in
+                    LazyVStack(spacing: 16) {
+                        ForEach(Array(rows.enumerated()), id: \.element.id) { index, item in
                             rowView(item)
-                                .padding(.vertical, 4)
+                            if index != rows.count - 1 {
+                                Divider()
+                                    .foregroundColor(Color(red: 226/255, green: 232/255, blue: 240/255))
+                            }
                         }
                     }
+                    .padding(.vertical, 4)
                 }
                 .frame(maxHeight: rows.count > 6 ? 200 : .infinity)
             }
         }
-        .padding(16)
+        .padding(24)
         .background(Color.white)
-        .cornerRadius(12)
+        .cornerRadius(16)
         .shadow(color: .black.opacity(0.1), radius: 3, x: 0, y: 2)
         .onAppear(perform: calculate)
         .accessibilityElement(children: .combine)
     }
 
     private func rowView(_ item: CryptoRow) -> some View {
-        HStack {
+        HStack(alignment: .top) {
             Text(item.symbol)
+                .fontWeight(.semibold)
                 .frame(maxWidth: .infinity, alignment: .leading)
-            Text(Self.chfFormatter.string(from: NSNumber(value: item.valueCHF)) ?? "0")
+                .multilineTextAlignment(.leading)
+                .lineLimit(2)
+
+            Text(Self.chfFormatter.string(from: NSNumber(value: item.valueCHF)) ?? "—")
+                .font(.system(.body, design: .monospaced))
                 .frame(width: 80, alignment: .trailing)
-            Text(String(format: "%.1f%%", item.percentage))
-                .frame(width: 50, alignment: .trailing)
+
+            VStack(alignment: .trailing, spacing: 4) {
+                Text(String(format: "%.1f %%", item.percentage))
+                    .font(.system(size: 13, weight: .bold))
+                weightBar(percent: item.percentage)
+            }
+            .frame(width: 60, alignment: .trailing)
         }
         .font(.system(size: 13))
+    }
+
+    private var headerRow: some View {
+        HStack {
+            Text("Asset")
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Text("Value (CHF)")
+                .frame(width: 80, alignment: .trailing)
+            Text("Weight")
+                .frame(width: 60, alignment: .trailing)
+        }
+        .font(.system(size: 11))
+        .foregroundColor(Color(red: 100/255, green: 116/255, blue: 139/255))
+        .textCase(.uppercase)
+        .padding(.vertical, 2)
+    }
+
+    private func weightBar(percent: Double) -> some View {
+        let trackColor = colorScheme == .dark ? Color(red: 46/255, green: 46/255, blue: 46/255) : Color(red: 241/255, green: 245/255, blue: 249/255)
+        let fillWidth = max(CGFloat(percent / 100) * 60, 2)
+        return ZStack(alignment: .leading) {
+            Capsule()
+                .fill(trackColor)
+                .frame(height: 4)
+            Capsule()
+                .fill(
+                    LinearGradient(
+                        gradient: Gradient(colors: [Color(red: 59/255, green: 130/255, blue: 246/255), Color(red: 6/255, green: 182/255, blue: 212/255)]),
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    )
+                )
+                .frame(width: fillWidth, height: 4)
+        }
+        .frame(width: 60, height: 4)
+        .accessibilityLabel(String(format: "%.1f%% weight", percent))
     }
 
     private func calculate() {


### PR DESCRIPTION
## Summary
- improve Crypto Allocations dashboard tile styling
- add caption header row and percentage labels with weight bar
- document change in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688472a2cab4832392b2acfae97432be