### PR TITLE
Dashboard grid layout responsive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Polish Crypto Allocations tile visuals and reduce row spacing
+- Make dashboard grid responsive with adaptive columns and 24pt spacing
 - Add macOS Kanban to-do board with drag-and-drop
 - Add sidebar link to the Kanban board
 - Reorganize sidebar navigation with expandable sections and remove old transaction links

--- a/DragonShield/Views/DashboardView.swift
+++ b/DragonShield/Views/DashboardView.swift
@@ -3,7 +3,15 @@ import SwiftUI
 private let layoutKey = "dashboardTileLayout"
 
 struct DashboardView: View {
-    private let columns = Array(repeating: GridItem(.flexible(), spacing: 16), count: 3)
+    private enum Layout {
+        static let spacing: CGFloat = 24
+        static let minWidth: CGFloat = 260
+        static let maxWidth: CGFloat = 400
+    }
+
+    private var columns: [GridItem] {
+        [GridItem(.adaptive(minimum: Layout.minWidth, maximum: Layout.maxWidth), spacing: Layout.spacing)]
+    }
 
     @State private var tileIDs: [String] = []
     @State private var showingPicker = false
@@ -11,7 +19,7 @@ struct DashboardView: View {
 
     var body: some View {
         ScrollView {
-            LazyVGrid(columns: columns, spacing: 16) {
+            LazyVGrid(columns: columns, spacing: Layout.spacing) {
                 ForEach(tileIDs, id: \.self) { id in
                     if let tile = TileRegistry.view(for: id) {
                         tile
@@ -24,7 +32,8 @@ struct DashboardView: View {
                     }
                 }
             }
-            .padding()
+            .padding(Layout.spacing)
+            .animation(.easeInOut(duration: 0.2), value: columns.count)
         }
         .navigationTitle("Dashboard")
         .toolbar {


### PR DESCRIPTION
## Summary
- make dashboard grid use adaptive tiles with 24pt spacing
- document the dashboard layout improvement in the changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68847fcd6dc883238e902079845ce466