### PR TITLE
Dashboard tiles adapt to window width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Label green stale account range as "<1 month / today"
 - Show per-table row count comparison after restore in a modal window
 - Auto-expand stale account sections and open editable account detail window from Dashboard
+- Allow dashboard tiles to resize adaptively with a responsive grid
 - Provide Save/Cancel buttons in Account Detail window with quick saved status
 - Polish Account Detail window layout with labeled fields and toolbar actions
 - Resolve progress indicator layout warning on macOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - Show per-table row count comparison after restore in a modal window
 - Auto-expand stale account sections and open editable account detail window from Dashboard
 - Allow dashboard tiles to resize adaptively with a responsive grid
+- Align dashboard tiles vertically so cards of different heights no longer leave gaps
 - Provide Save/Cancel buttons in Account Detail window with quick saved status
 - Polish Account Detail window layout with labeled fields and toolbar actions
 - Resolve progress indicator layout warning on macOS

--- a/DragonShield/Views/DashboardView.swift
+++ b/DragonShield/Views/DashboardView.swift
@@ -12,7 +12,8 @@ struct DashboardView: View {
     private let gridItems = [
         GridItem(
             .adaptive(minimum: Layout.minWidth, maximum: Layout.maxWidth),
-            spacing: Layout.spacing
+            spacing: Layout.spacing,
+            alignment: .top
         )
     ]
 

--- a/DragonShield/Views/DashboardView.swift
+++ b/DragonShield/Views/DashboardView.swift
@@ -3,28 +3,46 @@ import SwiftUI
 private let layoutKey = "dashboardTileLayout"
 
 struct DashboardView: View {
-    private let columns = Array(repeating: GridItem(.flexible(), spacing: 16), count: 3)
+    private enum Layout {
+        static let spacing: CGFloat = 24
+        static let minWidth: CGFloat = 260
+        static let maxWidth: CGFloat = 400
+    }
+
+    private let gridItems = [
+        GridItem(
+            .adaptive(minimum: Layout.minWidth, maximum: Layout.maxWidth),
+            spacing: Layout.spacing
+        )
+    ]
 
     @State private var tileIDs: [String] = []
     @State private var showingPicker = false
     @State private var draggedID: String?
+    @State private var columnCount = 3
 
     var body: some View {
-        ScrollView {
-            LazyVGrid(columns: columns, spacing: 16) {
-                ForEach(tileIDs, id: \.self) { id in
-                    if let tile = TileRegistry.view(for: id) {
-                        tile
-                            .onDrag {
-                                draggedID = id
-                                return NSItemProvider(object: id as NSString)
-                            }
-                            .onDrop(of: [.text], delegate: TileDropDelegate(item: id, tiles: $tileIDs, dragged: $draggedID))
-                            .accessibilityLabel(TileRegistry.info(for: id).name)
+        GeometryReader { geo in
+            ScrollView {
+                LazyVGrid(columns: gridItems, spacing: Layout.spacing) {
+                    ForEach(tileIDs, id: \.self) { id in
+                        if let tile = TileRegistry.view(for: id) {
+                            tile
+                                .onDrag {
+                                    draggedID = id
+                                    return NSItemProvider(object: id as NSString)
+                                }
+                                .onDrop(of: [.text], delegate: TileDropDelegate(item: id, tiles: $tileIDs, dragged: $draggedID))
+                                .accessibilityLabel(TileRegistry.info(for: id).name)
+                        }
                     }
                 }
+                .frame(maxWidth: gridWidth(for: columnCount), alignment: .topLeading)
+                .padding(Layout.spacing)
+                .animation(.easeInOut(duration: 0.2), value: columnCount)
             }
-            .padding()
+            .onAppear { updateColumns(width: geo.size.width) }
+            .onChange(of: geo.size.width) { updateColumns(width: $0) }
         }
         .navigationTitle("Dashboard")
         .toolbar {
@@ -58,6 +76,25 @@ struct DashboardView: View {
 
     private func saveLayout() {
         UserDefaults.standard.set(tileIDs, forKey: layoutKey)
+    }
+
+    private func updateColumns(width: CGFloat) {
+        let available = width - Layout.spacing * 2
+        let fitByMax = Int(available / (Layout.maxWidth + Layout.spacing))
+        switch fitByMax {
+        case 4...:
+            columnCount = 4
+        case 3:
+            columnCount = 3
+        case 2:
+            columnCount = 2
+        default:
+            columnCount = 1
+        }
+    }
+
+    private func gridWidth(for columns: Int) -> CGFloat {
+        Layout.maxWidth * CGFloat(columns) + Layout.spacing * CGFloat(columns - 1)
     }
 }
 


### PR DESCRIPTION
## Summary
- use adaptive LazyVGrid for the dashboard layout
- compute columns from window width and animate layout changes
- cap grid width so cards wrap smoothly
- note dashboard grid improvement in CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68847fcd6dc883238e902079845ce466