### PR TITLE
Dashboard tiles adapt to window width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project will be documented in this file.
 - Label green stale account range as "<1 month / today"
 - Show per-table row count comparison after restore in a modal window
 - Auto-expand stale account sections and open editable account detail window from Dashboard
+- Allow dashboard tiles to resize adaptively with a responsive grid
+- Align dashboard tiles vertically without gaps for varied heights
 - Provide Save/Cancel buttons in Account Detail window with quick saved status
 - Polish Account Detail window layout with labeled fields and toolbar actions
 - Resolve progress indicator layout warning on macOS


### PR DESCRIPTION
## Summary
- use adaptive LazyVGrid for the dashboard layout
- compute columns from window width and animate layout changes
- cap grid width so cards wrap smoothly
- align dashboard tiles vertically without gaps
- note dashboard grid improvement in CHANGELOG

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68847fcd6dc883238e902079845ce466