### PR TITLE
Add resize handle to dashboard cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Auto-expand stale account sections and open editable account detail window from Dashboard
 - Allow dashboard tiles to resize adaptively with a responsive grid
 - Arrange dashboard tiles in a masonry layout with half-spacing gaps vertically
+- Show resize handle on each dashboard tile to hint drag area
 - Provide Save/Cancel buttons in Account Detail window with quick saved status
 - Polish Account Detail window layout with labeled fields and toolbar actions
 - Resolve progress indicator layout warning on macOS

--- a/DragonShield/Views/DashboardTiles/DashboardTiles.swift
+++ b/DragonShield/Views/DashboardTiles/DashboardTiles.swift
@@ -11,11 +11,13 @@ struct DashboardCard<Content: View>: View {
     let title: String
     let headerIcon: Image?
     let content: Content
+    var resizable: Bool = true
 
-    init(title: String, headerIcon: Image? = nil, @ViewBuilder content: () -> Content) {
+    init(title: String, headerIcon: Image? = nil, resizable: Bool = true, @ViewBuilder content: () -> Content) {
         self.title = title
         self.headerIcon = headerIcon
         self.content = content()
+        self.resizable = resizable
     }
 
     var body: some View {
@@ -36,6 +38,11 @@ struct DashboardCard<Content: View>: View {
         .background(Theme.surface)
         .cornerRadius(8)
         .shadow(color: .black.opacity(0.1), radius: 3, x: 0, y: 2)
+        .overlay(alignment: .bottomTrailing) {
+            if resizable {
+                ResizeHandle(title: title)
+            }
+        }
     }
 }
 

--- a/DragonShield/Views/ResizeHandle.swift
+++ b/DragonShield/Views/ResizeHandle.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct ResizeHandle: View {
+    let title: String
+    var enabled: Bool = true
+    @State private var hovering = false
+
+    var body: some View {
+        let baseOpacity = enabled ? 0.4 : 0.2
+        Image(systemName: "square.and.arrow.up.right")
+            .resizable()
+            .rotationEffect(.degrees(45))
+            .frame(width: 12, height: 12)
+            .foregroundColor(.secondary)
+            .opacity(hovering ? 1.0 : baseOpacity)
+            .padding(16)
+            .contentShape(Rectangle())
+            .frame(width: 44, height: 44, alignment: .bottomTrailing)
+            .onHover { hovering = $0 }
+            .accessibilityLabel("Resize handle for \(title)")
+            .cursor(.resizeUpDown)
+    }
+}


### PR DESCRIPTION
## Summary
- show a resize grip in the bottom-right corner of dashboard tiles
- document the new UI affordance in the changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688487b26d008323a6f1af950adfd3fa