### PR TITLE
Add resize handle to dashboard tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Auto-expand stale account sections and open editable account detail window from Dashboard
 - Allow dashboard tiles to resize adaptively with a responsive grid
 - Arrange dashboard tiles in a masonry layout with half-spacing gaps vertically
+- Add resize handle grip to dashboard tiles for easier resizing
 - Provide Save/Cancel buttons in Account Detail window with quick saved status
 - Polish Account Detail window layout with labeled fields and toolbar actions
 - Resolve progress indicator layout warning on macOS

--- a/DragonShield/Views/DashboardTiles/DashboardTiles.swift
+++ b/DragonShield/Views/DashboardTiles/DashboardTiles.swift
@@ -36,6 +36,9 @@ struct DashboardCard<Content: View>: View {
         .background(Theme.surface)
         .cornerRadius(8)
         .shadow(color: .black.opacity(0.1), radius: 3, x: 0, y: 2)
+        .overlay(alignment: .bottomTrailing) {
+            ResizeHandle(title: title)
+        }
     }
 }
 

--- a/DragonShield/Views/ResizeHandle.swift
+++ b/DragonShield/Views/ResizeHandle.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct ResizeHandle: View {
+    let title: String
+    @State private var hovering = false
+
+    var body: some View {
+        Image(systemName: "square.and.arrow.up.right")
+            .rotationEffect(.degrees(45))
+            .frame(width: 12, height: 12)
+            .padding(16) // ensures 44x44 hit area
+            .contentShape(Rectangle())
+            .foregroundColor(.secondary)
+            .opacity(hovering ? 1.0 : 0.4)
+            .animation(.easeInOut(duration: 0.15), value: hovering)
+            .onHover { hovering = $0 }
+            .cursor(.resizeUpDown)
+            .accessibilityLabel("Resize handle for \(title)")
+    }
+}

--- a/tests/test_resize_handle.py
+++ b/tests/test_resize_handle.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+HANDLE_FILE = Path(__file__).resolve().parents[1] / 'DragonShield' / 'Views' / 'ResizeHandle.swift'
+
+def test_resize_handle_icon():
+    text = HANDLE_FILE.read_text(encoding='utf-8')
+    assert 'square.and.arrow.up.right' in text


### PR DESCRIPTION
## Summary
- add a new `ResizeHandle` view showing a subtle diagonal arrow
- overlay `ResizeHandle` in each `DashboardCard`
- document the new handle in the changelog
- test presence of the handle symbol

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688487b26d008323a6f1af950adfd3fa