### PR TITLE
Add resize handle to dashboard tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project will be documented in this file.
 - Fix Import Values window closing when pressing the Close button
 - Present value report in a table window after import
 - Document production folder path and backups in README
+- Add bottom-right resize handle to dashboard tiles for discoverable resizing
 - Compute value report from positions when stored data is missing
 - Fix unused variable warning when computing position values
 - Display consolidated crypto allocations with scrolling in Dashboard (#PR)

--- a/DragonShield/Views/DashboardTiles/DashboardTiles.swift
+++ b/DragonShield/Views/DashboardTiles/DashboardTiles.swift
@@ -36,6 +36,10 @@ struct DashboardCard<Content: View>: View {
         .background(Theme.surface)
         .cornerRadius(8)
         .shadow(color: .black.opacity(0.1), radius: 3, x: 0, y: 2)
+        .overlay(alignment: .bottomTrailing) {
+            ResizeHandle(tileName: title)
+                .padding(4)
+        }
     }
 }
 

--- a/DragonShield/Views/ResizeHandle.swift
+++ b/DragonShield/Views/ResizeHandle.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct ResizeHandle: View {
+    let tileName: String
+    var disabled: Bool = false
+    @State private var hovering = false
+
+    private var idleOpacity: Double { disabled ? 0.2 : 0.4 }
+    private var hoverOpacity: Double { disabled ? 0.2 : 1.0 }
+
+    var body: some View {
+        Image(systemName: "square.and.arrow.up.right")
+            .rotationEffect(.degrees(45))
+            .font(.system(size: 12, weight: .semibold))
+            .frame(width: 12, height: 12)
+            .padding(16)
+            .frame(width: 44, height: 44)
+            .contentShape(Rectangle())
+            .foregroundColor(.secondary)
+            .opacity(hovering ? hoverOpacity : idleOpacity)
+            .animation(.easeInOut(duration: 0.15), value: hovering)
+            .onHover { hovering = $0 }
+            .cursor(.resizeUpDown)
+            .accessibilityLabel("Resize handle for \(tileName)")
+    }
+}


### PR DESCRIPTION
## Summary
- add new `ResizeHandle` SwiftUI view for resizing affordance
- overlay resize handle in `DashboardCard`
- document feature in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688489830cb48323986a3dd4fe410146