### PR TITLE
Add resize handle to dashboard cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -397,3 +397,4 @@ All notable changes to this project will be documented in this file.
 - Sort instrument Type and Currency filter menus alphabetically
 - Replace blue Top 10 Positions tile with modern white card showing all positions
 - Reduce list row spacing in Top Positions card for denser display
+- Show resize handle on dashboard tiles for easier resizing

--- a/DragonShield/Views/DashboardTiles/DashboardTiles.swift
+++ b/DragonShield/Views/DashboardTiles/DashboardTiles.swift
@@ -36,6 +36,32 @@ struct DashboardCard<Content: View>: View {
         .background(Theme.surface)
         .cornerRadius(8)
         .shadow(color: .black.opacity(0.1), radius: 3, x: 0, y: 2)
+        .overlay(alignment: .bottomTrailing) {
+            ResizeHandle(title: title)
+                .padding(4)
+        }
+    }
+}
+
+private struct ResizeHandle: View {
+    let title: String
+    @State private var hovering = false
+
+    var body: some View {
+        Image(systemName: "square.and.arrow.up.right")
+            .resizable()
+            .scaledToFit()
+            .frame(width: 12, height: 12)
+            .rotationEffect(.degrees(45))
+            .foregroundColor(.secondary)
+            .opacity(hovering ? 1 : 0.4)
+            .frame(width: 44, height: 44, alignment: .bottomTrailing)
+            .contentShape(Rectangle())
+            .onHover { over in
+                withAnimation(.easeInOut(duration: 0.15)) { hovering = over }
+            }
+            .cursor(.resizeUpDown)
+            .accessibilityLabel("Resize handle for \(title)")
     }
 }
 

--- a/tests/test_dashboard_resize_handle.py
+++ b/tests/test_dashboard_resize_handle.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+FILE = Path(__file__).resolve().parents[1] / 'DragonShield' / 'Views' / 'DashboardTiles' / 'DashboardTiles.swift'
+
+def test_resize_handle_icon():
+    text = FILE.read_text(encoding='utf-8')
+    assert 'square.and.arrow.up.right' in text
+    assert 'Resize handle for' in text


### PR DESCRIPTION
## Summary
- add resize handle overlay in DashboardCard
- test for handle presence
- document UI improvement in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688489830cb48323986a3dd4fe410146