### PR TITLE
Add asset allocation dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Show institutions ranked by AUM in new dashboard tile
 - Document troubleshooting steps for missing `default.metallib` warning
 - Add Asset Allocation dashboard with interactive bubble chart
+- Restore link to legacy Asset Allocation view in sidebar
 - Mention language code console warnings and how to silence them
 - Log database version correctly at startup
 - Label green stale account range as "<1 month / today"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Prompt to confirm option quantity multiplier during position import
 - Show institutions ranked by AUM in new dashboard tile
 - Document troubleshooting steps for missing `default.metallib` warning
+- Add Asset Allocation dashboard with interactive bubble chart
 - Mention language code console warnings and how to silence them
 - Log database version correctly at startup
 - Label green stale account range as "<1 month / today"

--- a/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
+++ b/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+import Charts
+
+struct AllocationDashboardView: View {
+    @EnvironmentObject var dbManager: DatabaseManager
+    @StateObject private var viewModel = AllocationDashboardViewModel()
+
+    private let gridColumns = [GridItem(.adaptive(minimum: 320, maximum: 480), spacing: 24)]
+
+    var body: some View {
+        ScrollView {
+            LazyVGrid(columns: gridColumns, spacing: 24) {
+                overviewSection
+                treeSection
+                chartsSection
+                actionsSection
+            }
+            .padding(24)
+        }
+        .navigationTitle("Asset Allocation Targets")
+        .toolbar {
+            ToolbarItemGroup(placement: .automatic) {
+                Button("Import Targets") {}
+                Button("Auto-Rebalance") {}.disabled(true)
+            }
+        }
+        .onAppear { viewModel.load(using: dbManager) }
+    }
+
+    private var overviewSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                overviewTile(title: "Portfolio Total", value: viewModel.portfolioTotalFormatted, color: .primary)
+                overviewTile(title: "Assets Out of Range", value: "\(viewModel.outOfRangeCount)", color: .red)
+            }
+            HStack {
+                overviewTile(title: "Largest Deviation", value: String(format: "%.1f%%", viewModel.largestDeviation), color: .orange)
+                overviewTile(title: "Rebalancing Amount", value: viewModel.rebalanceAmountFormatted, color: .primary)
+            }
+        }
+    }
+
+    private func overviewTile(title: String, value: String, color: Color) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title).font(.caption)
+            Text(value).font(.title3.bold()).foregroundColor(color)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(Color.fieldGray)
+        .cornerRadius(8)
+    }
+
+    private var treeSection: some View {
+        VStack(alignment: .leading) {
+            HStack {
+                Text("Allocations (%)").font(.headline)
+                Spacer()
+                Text("Tolerance ±5%")
+                    .font(.caption)
+                    .padding(4)
+                    .background(Color.softBlue)
+                    .cornerRadius(4)
+            }
+            OutlineGroup(viewModel.assets, children: \.children) { asset in
+                allocationRow(asset)
+            }
+        }
+    }
+
+    private func allocationRow(_ asset: AllocationDashboardViewModel.Asset) -> some View {
+        HStack {
+            Text(asset.name).frame(width: 120, alignment: .leading)
+            Spacer()
+            Text(String(format: "%.1f%%", asset.targetPct)).frame(width: 60, alignment: .trailing)
+            Text(String(format: "%.1f%%", asset.actualPct)).frame(width: 60, alignment: .trailing)
+            deviationBar(for: asset).frame(width: 80, height: 8)
+            Text(String(format: "%+.1f%%", asset.deviationPct)).frame(width: 50, alignment: .trailing)
+        }
+        .padding(.vertical, 4)
+        .background(viewModel.highlightedId == asset.id ? Color.softBlue.opacity(0.3) : Color.clear)
+        .onTapGesture { viewModel.highlightedId = asset.id }
+    }
+
+    private func deviationBar(for asset: AllocationDashboardViewModel.Asset) -> some View {
+        GeometryReader { geo in
+            let width = geo.size.width
+            let pct = abs(asset.deviationPct)
+            let color: Color = pct > 10 ? .red : (pct > 5 ? .orange : .green)
+            HStack(spacing: 0) {
+                Spacer()
+                Rectangle().fill(color).frame(width: width * CGFloat(min(pct/10,1)))
+            }
+        }
+    }
+
+    private var chartsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Deviation Bubble Chart").font(.headline)
+            Chart(viewModel.bubbles) { bubble in
+                PointMark(x: .value("Deviation", bubble.deviation), y: .value("Allocation", bubble.allocation))
+                    .foregroundStyle(bubble.color)
+                    .symbolSize(bubble.size)
+            }
+            .frame(height: 240)
+        }
+    }
+
+    private var actionsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Top Rebalancing Actions").font(.headline)
+            ForEach(viewModel.actions.prefix(5)) { action in
+                HStack {
+                    Text(action.label)
+                    Spacer()
+                    Text(action.amount)
+                }
+            }
+            Button("Execute") {}.disabled(true)
+        }
+    }
+}
+
+struct AllocationDashboardView_Previews: PreviewProvider {
+    static var previews: some View {
+        AllocationDashboardView().environmentObject(DatabaseManager())
+    }
+}

--- a/DragonShield/Views/AllocationDashboard/AllocationDashboardViewModel.swift
+++ b/DragonShield/Views/AllocationDashboard/AllocationDashboardViewModel.swift
@@ -1,0 +1,150 @@
+import SwiftUI
+
+final class AllocationDashboardViewModel: ObservableObject {
+    struct Asset: Identifiable {
+        let id: String
+        let name: String
+        let actualPct: Double
+        let actualChf: Double
+        let targetPct: Double
+        let targetChf: Double
+        var children: [Asset]? = nil
+
+        var deviationPct: Double { actualPct - targetPct }
+        var deviationChf: Double { actualChf - targetChf }
+    }
+
+    struct Bubble: Identifiable {
+        let id: String
+        let name: String
+        let deviation: Double
+        let allocation: Double
+        let size: Double
+        let color: Color
+    }
+
+    struct Action: Identifiable {
+        let id = UUID()
+        let label: String
+        let amount: String
+    }
+
+    @Published var assets: [Asset] = []
+    @Published var bubbles: [Bubble] = []
+    @Published var actions: [Action] = []
+    @Published var highlightedId: String?
+
+    private(set) var portfolioValue: Double = 0
+
+    private let tolerance: Double = 5.0
+
+    var outOfRangeCount: Int {
+        assets.flatMap { [$0] + ($0.children ?? []) }
+            .filter { abs($0.deviationPct) > tolerance }
+            .count
+    }
+
+    var largestDeviation: Double {
+        assets.flatMap { [$0] + ($0.children ?? []) }
+            .map { abs($0.deviationPct) }
+            .max() ?? 0
+    }
+
+    var rebalanceAmount: Double {
+        assets.flatMap { [$0] + ($0.children ?? []) }
+            .map { abs($0.deviationChf) }
+            .reduce(0, +)
+    }
+
+    var portfolioTotalFormatted: String {
+        NumberFormatter.localizedString(from: NSNumber(value: portfolioValue), number: .decimal)
+    }
+
+    var rebalanceAmountFormatted: String {
+        NumberFormatter.localizedString(from: NSNumber(value: rebalanceAmount), number: .decimal)
+    }
+
+    func load(using db: DatabaseManager) {
+        let classes = db.fetchAssetClassesDetailed()
+        var classIdMap: [String: Int] = [:]
+        var subIdMap: [String: Int] = [:]
+        var subToClass: [Int: Int] = [:]
+        for cls in classes {
+            classIdMap[cls.name] = cls.id
+            for sub in db.subAssetClasses(for: cls.id) {
+                subIdMap[sub.name] = sub.id
+                subToClass[sub.id] = cls.id
+            }
+        }
+
+        let targets = db.fetchPortfolioTargetRecords(portfolioId: 1)
+        var classTargetPct: [Int: Double] = [:]
+        var subTargetPct: [Int: Double] = [:]
+        for row in targets {
+            if let sub = row.subClassId {
+                subTargetPct[sub] = row.percent
+            } else if let cls = row.classId {
+                classTargetPct[cls] = row.percent
+            }
+        }
+
+        var subActual: [Int: Double] = [:]
+        var classActual: [Int: Double] = [:]
+        var total: Double = 0
+        var rateCache: [String: Double] = [:]
+        for p in db.fetchPositionReports() {
+            guard let subName = p.assetSubClass,
+                  let subId = subIdMap[subName],
+                  let price = p.currentPrice else { continue }
+            var value = p.quantity * price
+            let currency = p.instrumentCurrency.uppercased()
+            if currency != "CHF" {
+                if rateCache[currency] == nil {
+                    rateCache[currency] = db.fetchExchangeRates(currencyCode: currency, upTo: nil).first?.rateToChf
+                }
+                guard let r = rateCache[currency] else { continue }
+                value *= r
+            }
+            subActual[subId, default: 0] += value
+            if let clsId = subToClass[subId] {
+                classActual[clsId, default: 0] += value
+            }
+            total += value
+        }
+        portfolioValue = total
+
+        assets = classes.map { cls in
+            let actualCHF = classActual[cls.id] ?? 0
+            let actualPct = total > 0 ? actualCHF / total * 100 : 0
+            let tPct = classTargetPct[cls.id] ?? 0
+            let children = db.subAssetClasses(for: cls.id).map { sub in
+                let sChf = subActual[sub.id] ?? 0
+                let sPct = actualCHF > 0 ? sChf / actualCHF * 100 : 0
+                let tp = subTargetPct[sub.id] ?? 0
+                return Asset(id: "sub-\(sub.id)", name: sub.name, actualPct: sPct, actualChf: sChf, targetPct: tp, targetChf: 0, children: nil)
+            }
+            return Asset(id: "class-\(cls.id)", name: cls.name, actualPct: actualPct, actualChf: actualCHF, targetPct: tPct, targetChf: 0, children: children)
+        }
+
+        bubbles = assets.map { asset in
+            Bubble(id: asset.id,
+                   name: asset.name,
+                   deviation: asset.deviationPct,
+                   allocation: asset.actualPct,
+                   size: asset.actualPct * 8,
+                   color: bubbleColor(for: asset.deviationPct))
+        }
+
+        actions = assets.map { asset in
+            let amount = asset.deviationChf
+            return Action(label: asset.name, amount: NumberFormatter.localizedString(from: NSNumber(value: amount), number: .decimal))
+        }
+    }
+
+    private func bubbleColor(for deviation: Double) -> Color {
+        let absDev = abs(deviation)
+        if absDev > tolerance * 2 { return .red }
+        if absDev > tolerance { return .orange }
+        return .green
+    }
+}

--- a/DragonShield/Views/SidebarView.swift
+++ b/DragonShield/Views/SidebarView.swift
@@ -35,7 +35,7 @@ struct SidebarView: View {
             }
 
             DisclosureGroup("Management", isExpanded: $showManagement) {
-                NavigationLink(destination: TargetAllocationMaintenanceView()) {
+                NavigationLink(destination: AllocationDashboardView()) {
                     Label("Asset Allocation", systemImage: "chart.pie")
                 }
 

--- a/DragonShield/Views/SidebarView.swift
+++ b/DragonShield/Views/SidebarView.swift
@@ -39,6 +39,10 @@ struct SidebarView: View {
                     Label("Asset Allocation", systemImage: "chart.pie")
                 }
 
+                NavigationLink(destination: TargetAllocationMaintenanceView()) {
+                    Label("Legacy Asset Allocation", systemImage: "clock.arrow.circlepath")
+                }
+
                 NavigationLink(destination: RebalancingView()) {
                     Label("Rebalancing", systemImage: "arrow.left.arrow.right")
                 }

--- a/DragonShield/python_scripts/allocation_deviation.py
+++ b/DragonShield/python_scripts/allocation_deviation.py
@@ -1,0 +1,19 @@
+"""Utility functions for asset allocation deviation checks."""
+
+from typing import Literal
+
+Classification = Literal["on_track", "warning", "critical"]
+
+
+def classify_deviation(deviation_pct: float, tolerance: float) -> Classification:
+    """Return deviation classification string."""
+    if abs(deviation_pct) > tolerance * 2:
+        return "critical"
+    if abs(deviation_pct) > tolerance:
+        return "warning"
+    return "on_track"
+
+
+def out_of_range(deviation_pct: float, tolerance: float) -> bool:
+    """Return True if deviation exceeds tolerance."""
+    return abs(deviation_pct) > tolerance

--- a/tests/test_allocation_deviation.py
+++ b/tests/test_allocation_deviation.py
@@ -1,0 +1,12 @@
+from DragonShield.python_scripts.allocation_deviation import classify_deviation, out_of_range
+
+
+def test_classify_deviation():
+    assert classify_deviation(0.0, 5) == "on_track"
+    assert classify_deviation(5.1, 5) == "warning"
+    assert classify_deviation(-11.0, 5) == "critical"
+
+
+def test_out_of_range():
+    assert not out_of_range(4.9, 5)
+    assert out_of_range(5.0001, 5)


### PR DESCRIPTION
## Summary
- add Asset Allocation dashboard with bubble chart and tree view
- provide deviation helper functions with tests
- hook Asset Allocation navigation to new dashboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688493aa99e883239faecf737aefe260