### PR TITLE
Add new Asset Allocation Targets UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Show institutions ranked by AUM in new dashboard tile
 - Document troubleshooting steps for missing `default.metallib` warning
 - Add Asset Allocation dashboard with interactive bubble chart
+- Introduce phase I of new Asset Allocation Targets UI
 - Restore link to legacy Asset Allocation view in sidebar
 - Mention language code console warnings and how to silence them
 - Log database version correctly at startup

--- a/DragonShield/helpers/CardView.swift
+++ b/DragonShield/helpers/CardView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct Card<Content: View>: View {
+    let title: String
+    let content: Content
+
+    init(_ title: String, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(.headline)
+            content
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color.white)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(Color.quaternary, lineWidth: 1)
+                )
+        )
+    }
+}
+

--- a/DragonShield/helpers/Color+Palette.swift
+++ b/DragonShield/helpers/Color+Palette.swift
@@ -13,6 +13,11 @@ extension Color {
     /// Soft blue highlight used for segmented controls and headers.
     static let softBlue = Color(red: 229/255, green: 241/255, blue: 255/255)
 
+    /// Numeric color tokens for allocation UI
+    static let numericGreen = Color(red: 22/255, green: 163/255, blue: 74/255)
+    static let numericAmber = Color(red: 245/255, green: 158/255, blue: 11/255)
+    static let numericRed = Color(red: 220/255, green: 38/255, blue: 38/255)
+
     /// Neutral gray used for text field backgrounds across platforms.
     static var fieldGray: Color {
 #if os(macOS)


### PR DESCRIPTION
## Summary
- introduce numeric color tokens and `Card` helper
- implement phase I of new Asset Allocation Targets view with overview, tree, charts and actions
- document new feature in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68849b5a61308323873ed7a611c9d0fb