### PR TITLE
fix(ui): rebuild overview bar layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Redesign Asset Allocation dashboard with modern cards
 - Fix compile errors in Asset Allocation dashboard views
 - Redesign overview bar layout with dedicated tiles
+- Fix dark-mode fill style causing build error in OverviewBar
 - Add macOS Kanban to-do board with drag-and-drop
 - Add sidebar link to the Kanban board
 - Reorganize sidebar navigation with expandable sections and remove old transaction links

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Polish Crypto Allocations tile visuals and reduce row spacing
+- Redesign Asset Allocation dashboard with modern cards
+- Fix compile errors in Asset Allocation dashboard views
+- Redesign overview bar layout with dedicated tiles
 - Add macOS Kanban to-do board with drag-and-drop
 - Add sidebar link to the Kanban board
 - Reorganize sidebar navigation with expandable sections and remove old transaction links

--- a/DragonShield/Views/AllocationDashboard/AllocationDashboardComponents.swift
+++ b/DragonShield/Views/AllocationDashboard/AllocationDashboardComponents.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+struct Card<Content: View>: View {
+    let title: String
+    let content: Content
+    init(_ title: String, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(.headline)
+            content
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color.white)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(Color.gray.opacity(0.25), lineWidth: 1)
+                )
+        )
+    }
+}

--- a/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
+++ b/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
@@ -69,11 +69,20 @@ struct OverviewBar: View {
         .padding(.vertical, 20)
         .background(
             RoundedRectangle(cornerRadius: 16)
-                .fill(scheme == .dark ? .ultraThinMaterial : .white)
+                .fill(
+                    scheme == .dark
+                        ? AnyShapeStyle(.ultraThinMaterial)
+                        : AnyShapeStyle(Color.white)
+                )
                 .shadow(color: .black.opacity(0.05), radius: 4, x: 0, y: 2)
                 .overlay(
                     RoundedRectangle(cornerRadius: 16)
-                        .stroke(scheme == .dark ? .tertiary : .quaternary, lineWidth: 1)
+                        .stroke(
+                            scheme == .dark
+                                ? Color.tertiary
+                                : Color.quaternary,
+                            lineWidth: 1
+                        )
                 )
         )
     }

--- a/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
+++ b/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
@@ -5,17 +5,23 @@ struct AllocationDashboardView: View {
     @EnvironmentObject var dbManager: DatabaseManager
     @StateObject private var viewModel = AllocationDashboardViewModel()
 
-    private let gridColumns = [GridItem(.adaptive(minimum: 320, maximum: 480), spacing: 24)]
+    private let columns = [GridItem(.adaptive(minimum: 320, maximum: 480), spacing: 24)]
 
     var body: some View {
         ScrollView {
-            LazyVGrid(columns: gridColumns, spacing: 24) {
-                overviewSection
-                treeSection
-                chartsSection
-                actionsSection
+            LazyVGrid(columns: columns, spacing: 24) {
+                OverviewBar(portfolioTotal: viewModel.portfolioTotalFormatted,
+                            outOfRange: "\(viewModel.outOfRangeCount)",
+                            largestDev: String(format: "%.1f%%", viewModel.largestDeviation),
+                            rebalAmount: viewModel.rebalanceAmountFormatted)
+                    .gridCellColumns(columns.count)
+
+                AllocationTreeCard(viewModel: viewModel)
+                DeviationChartsCard(bubbles: viewModel.bubbles,
+                                   highlighted: $viewModel.highlightedId)
+                RebalanceListCard(actions: viewModel.actions)
             }
-            .padding(24)
+            .padding(.horizontal, 32)
         }
         .navigationTitle("Asset Allocation Targets")
         .toolbar {
@@ -27,96 +33,208 @@ struct AllocationDashboardView: View {
         .onAppear { viewModel.load(using: dbManager) }
     }
 
-    private var overviewSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack {
-                overviewTile(title: "Portfolio Total", value: viewModel.portfolioTotalFormatted, color: .primary)
-                overviewTile(title: "Assets Out of Range", value: "\(viewModel.outOfRangeCount)", color: .red)
-            }
-            HStack {
-                overviewTile(title: "Largest Deviation", value: String(format: "%.1f%%", viewModel.largestDeviation), color: .orange)
-                overviewTile(title: "Rebalancing Amount", value: viewModel.rebalanceAmountFormatted, color: .primary)
-            }
+}
+
+// MARK: - Components
+
+struct OverviewBar: View {
+    let portfolioTotal: String
+    let outOfRange: String
+    let largestDev: String
+    let rebalAmount: String
+    @Environment(\.colorScheme) private var scheme
+
+    var body: some View {
+        HStack(spacing: 0) {
+            OverviewTile(value: portfolioTotal, label: "Portfolio Total")
+
+            Divider().frame(width: 1, height: 40)
+
+            OverviewTile(value: outOfRange,
+                         label: "Assets Out of Range",
+                         style: .alert)
+
+            Divider().frame(width: 1, height: 40)
+
+            OverviewTile(value: largestDev,
+                         label: "Largest Deviation",
+                         style: .warning)
+
+            Divider().frame(width: 1, height: 40)
+
+            OverviewTile(value: rebalAmount,
+                         label: "Rebalancing Amount")
+        }
+        .padding(.horizontal, 32)
+        .padding(.vertical, 20)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(scheme == .dark ? .ultraThinMaterial : .white)
+                .shadow(color: .black.opacity(0.05), radius: 4, x: 0, y: 2)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16)
+                        .stroke(scheme == .dark ? .tertiary : .quaternary, lineWidth: 1)
+                )
+        )
+    }
+}
+
+enum TileStyle { case neutral, alert, warning }
+
+struct OverviewTile: View {
+    var value: String
+    var label: String
+    var style: TileStyle = .neutral
+
+    var body: some View {
+        VStack(spacing: 2) {
+            Text(value)
+                .font(.system(size: 20, weight: .bold, design: .monospaced))
+                .foregroundStyle(valueColor)
+
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 4)
+        .background(tileBackground)
+    }
+
+    private var valueColor: Color {
+        switch style {
+        case .alert:    return .red
+        case .warning:  return .orange
+        case .neutral:  return .primary
         }
     }
 
-    private func overviewTile(title: String, value: String, color: Color) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(title).font(.caption)
-            Text(value).font(.title3.bold()).foregroundColor(color)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(12)
-        .background(Color.fieldGray)
-        .cornerRadius(8)
-    }
-
-    private var treeSection: some View {
-        VStack(alignment: .leading) {
-            HStack {
-                Text("Allocations (%)").font(.headline)
-                Spacer()
-                Text("Tolerance ±5%")
-                    .font(.caption)
-                    .padding(4)
-                    .background(Color.softBlue)
-                    .cornerRadius(4)
-            }
-            OutlineGroup(viewModel.assets, children: \.children) { asset in
-                allocationRow(asset)
+    private var tileBackground: some View {
+        Group {
+            switch style {
+            case .alert:
+                LinearGradient(colors: [.red.opacity(0.08), .white],
+                               startPoint: .topLeading,
+                               endPoint: .bottomTrailing)
+            case .warning:
+                LinearGradient(colors: [.orange.opacity(0.08), .white],
+                               startPoint: .topLeading,
+                               endPoint: .bottomTrailing)
+            case .neutral:
+                Color.clear
             }
         }
     }
+}
 
-    private func allocationRow(_ asset: AllocationDashboardViewModel.Asset) -> some View {
-        HStack {
-            Text(asset.name).frame(width: 120, alignment: .leading)
+struct AllocationTreeCard: View {
+    @ObservedObject var viewModel: AllocationDashboardViewModel
+
+    var body: some View {
+        Card("Asset Classes") {
+            Picker("Display", selection: .constant(0)) {
+                Text("%").tag(0)
+                Text("CHF").tag(1)
+            }
+            .pickerStyle(.segmented)
+
+            ScrollView {
+                VStack(spacing: 0) {
+                    ForEach(viewModel.assets) { asset in
+                        AssetRowView(asset: asset, level: 0, highlighted: viewModel.highlightedId == asset.id)
+                        if let children = asset.children {
+                            ForEach(children) { child in
+                                AssetRowView(asset: child, level: 1, highlighted: viewModel.highlightedId == child.id)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct AssetRowView: View {
+    let asset: AllocationDashboardViewModel.Asset
+    let level: Int
+    let highlighted: Bool
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Text(asset.name)
+                .frame(width: level == 0 ? 140 : 120, alignment: .leading)
             Spacer()
-            Text(String(format: "%.1f%%", asset.targetPct)).frame(width: 60, alignment: .trailing)
-            Text(String(format: "%.1f%%", asset.actualPct)).frame(width: 60, alignment: .trailing)
-            deviationBar(for: asset).frame(width: 80, height: 8)
-            Text(String(format: "%+.1f%%", asset.deviationPct)).frame(width: 50, alignment: .trailing)
+            Text(String(format: "%.1f%%", asset.targetPct))
+                .frame(width: 50, alignment: .trailing)
+                .font(.system(.footnote, design: .monospaced))
+            Text(String(format: "%.1f%%", asset.actualPct))
+                .frame(width: 50, alignment: .trailing)
+                .font(.system(.footnote, design: .monospaced))
+            deviationBar
+                .frame(width: 60)
+            Text(String(format: "%+.1f%%", asset.deviationPct))
+                .frame(width: 50, alignment: .trailing)
+                .font(.system(.footnote, design: .monospaced))
         }
         .padding(.vertical, 4)
-        .background(viewModel.highlightedId == asset.id ? Color.softBlue.opacity(0.3) : Color.clear)
-        .onTapGesture { viewModel.highlightedId = asset.id }
-    }
-
-    private func deviationBar(for asset: AllocationDashboardViewModel.Asset) -> some View {
-        GeometryReader { geo in
-            let width = geo.size.width
-            let pct = abs(asset.deviationPct)
-            let color: Color = pct > 10 ? .red : (pct > 5 ? .orange : .green)
-            HStack(spacing: 0) {
-                Spacer()
-                Rectangle().fill(color).frame(width: width * CGFloat(min(pct/10,1)))
+        .background(highlighted ? Color.blue.opacity(0.1) : (level == 0 ? Color.fieldGray.opacity(0.4) : Color.clear))
+        .overlay(alignment: .leading) {
+            if highlighted {
+                Rectangle()
+                    .fill(Color.accentColor)
+                    .frame(width: 3)
             }
         }
     }
 
-    private var chartsSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Deviation Bubble Chart").font(.headline)
-            Chart(viewModel.bubbles) { bubble in
-                PointMark(x: .value("Deviation", bubble.deviation), y: .value("Allocation", bubble.allocation))
-                    .foregroundStyle(bubble.color)
-                    .symbolSize(bubble.size)
+    private var deviationBar: some View {
+        let dev = asset.deviationPct
+        let devColor = dev > 0 ? Color.numberRed : Color.numberGreen
+        return ZStack(alignment: .leading) {
+            Capsule().fill(Color.gray.opacity(0.25))
+            Capsule().fill(devColor).frame(width: abs(dev) * 60)
+        }
+        .frame(height: 6)
+        .offset(x: dev >= 0 ? 30 : -30)
+    }
+}
+
+struct DeviationChartsCard: View {
+    let bubbles: [AllocationDashboardViewModel.Bubble]
+    @Binding var highlighted: String?
+
+    var body: some View {
+        Card("Deviation Bubble Chart") {
+            Chart(bubbles) { bubble in
+                PointMark(
+                    x: .value("Deviation", bubble.deviation),
+                    y: .value("Allocation", bubble.allocation)
+                )
+                .symbolSize(by: .value("Allocation %", bubble.allocation))
+                .foregroundStyle(bubble.color)
             }
+            .chartXScale(domain: -25...25)
+            .chartYScale(domain: 0...40)
             .frame(height: 240)
         }
     }
+}
 
-    private var actionsSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Top Rebalancing Actions").font(.headline)
-            ForEach(viewModel.actions.prefix(5)) { action in
+struct RebalanceListCard: View {
+    let actions: [AllocationDashboardViewModel.Action]
+
+    var body: some View {
+        Card("Top Rebalancing Actions") {
+            ForEach(actions.prefix(5)) { action in
                 HStack {
                     Text(action.label)
                     Spacer()
                     Text(action.amount)
+                        .font(.system(.body, design: .monospaced))
                 }
             }
-            Button("Execute") {}.disabled(true)
+            Button("Execute") {}
+                .disabled(true)
         }
     }
 }

--- a/DragonShield/helpers/Color+Palette.swift
+++ b/DragonShield/helpers/Color+Palette.swift
@@ -21,4 +21,8 @@ extension Color {
         Color(UIColor.systemGray6)
 #endif
     }
+    /// Numeric value colors
+    static let numberGreen = Color(red: 0x16/255, green: 0xA3/255, blue: 0x4A/255)
+    static let numberAmber = Color(red: 0xF5/255, green: 0x9E/255, blue: 0x0B/255)
+    static let numberRed = Color(red: 0xDC/255, green: 0x26/255, blue: 0x26/255)
 }


### PR DESCRIPTION
## Summary
- rebuild overview bar with dedicated `OverviewTile` component
- span overview bar across all grid columns
- document overview bar redesign in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68849b5a61308323873ed7a611c9d0fb