### PR TITLE
Implement two-column layout for allocation dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Fix compile errors in Asset Allocation dashboard views
 - Redesign overview bar layout with dedicated tiles
 - Fix color scheme handling in overview bar and card components
+- Convert Allocation dashboard to two-column layout with full-width overview bar
 - Add macOS Kanban to-do board with drag-and-drop
 - Add sidebar link to the Kanban board
 - Reorganize sidebar navigation with expandable sections and remove old transaction links

--- a/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
+++ b/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
@@ -5,24 +5,36 @@ struct AllocationDashboardView: View {
     @EnvironmentObject var dbManager: DatabaseManager
     @StateObject private var viewModel = AllocationDashboardViewModel()
 
-    private let columns = [GridItem(.adaptive(minimum: 320, maximum: 480), spacing: 24)]
+    // MARK: - Column width constants
+    private let leftWidth:  Double = 520
+    private let rightWidth: Double = 400
 
     var body: some View {
         ScrollView {
-            LazyVGrid(columns: columns, spacing: 24) {
+            VStack(alignment: .leading, spacing: 32) {
                 OverviewBar(portfolioTotal: viewModel.portfolioTotalFormatted,
                             outOfRange: "\(viewModel.outOfRangeCount)",
                             largestDev: String(format: "%.1f%%", viewModel.largestDeviation),
                             rebalAmount: viewModel.rebalanceAmountFormatted)
-                    .gridCellColumns(columns.count)
+                    .frame(maxWidth: .infinity)
+                    .padding(.top, 8)
 
-                AllocationTreeCard(viewModel: viewModel)
-                DeviationChartsCard(bubbles: viewModel.bubbles,
-                                   highlighted: $viewModel.highlightedId)
-                RebalanceListCard(actions: viewModel.actions)
+                HStack(alignment: .top, spacing: 32) {
+                    AllocationTreeCard(viewModel: viewModel)
+                        .frame(width: leftWidth)
+
+                    VStack(spacing: 32) {
+                        DeviationChartsCard(bubbles: viewModel.bubbles,
+                                           highlighted: $viewModel.highlightedId)
+                        RebalanceListCard(actions: viewModel.actions)
+                    }
+                    .frame(width: rightWidth)
+                }
             }
             .padding(.horizontal, 32)
+            .padding(.bottom, 40)
         }
+        .background(Color(NSColor.windowBackgroundColor))
         .navigationTitle("Asset Allocation Targets")
         .toolbar {
             ToolbarItemGroup(placement: .automatic) {


### PR DESCRIPTION
## Summary
- restructure `AllocationDashboardView` to use full-width `OverviewBar`
- arrange remaining cards in fixed-width two column layout
- update changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884a3c68404832386f8beaa54eabb26