### PR TITLE
fix(ui): rework asset classes card layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Add sidebar link to the Kanban board
 - Reorganize sidebar navigation with expandable sections and remove old transaction links
 - Combine Currencies and FX Rates maintenance into one tabbed view
+- Rework Asset Classes card header with inline picker
 - Combine Asset Class and SubClass management into one page with sortable rows
 - Add column filters, single-column sorting and double-click editing to Instruments and Positions tables
 - Prompt to confirm option quantity multiplier during position import

--- a/DragonShield/Views/AllocationDashboard/AllocationDashboardComponents.swift
+++ b/DragonShield/Views/AllocationDashboard/AllocationDashboardComponents.swift
@@ -1,18 +1,20 @@
 import SwiftUI
 
 struct Card<Content: View>: View {
-    let title: String
+    let title: String?
     let content: Content
     @Environment(\.colorScheme) private var scheme
-    init(_ title: String, @ViewBuilder content: () -> Content) {
+    init(_ title: String? = nil, @ViewBuilder content: () -> Content) {
         self.title = title
         self.content = content()
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text(title)
-                .font(.headline)
+            if let title = title {
+                Text(title)
+                    .font(.headline)
+            }
             content
         }
         .padding(16)

--- a/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
+++ b/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
@@ -104,6 +104,8 @@ struct OverviewBar: View {
 
 enum TileStyle { case neutral, alert, warning }
 
+enum DisplayMode { case percent, chf }
+
 struct OverviewTile: View {
     var value: String
     var label: String
@@ -152,66 +154,101 @@ struct OverviewTile: View {
 
 struct AllocationTreeCard: View {
     @ObservedObject var viewModel: AllocationDashboardViewModel
+    @State private var displayMode: DisplayMode = .percent
+    @State private var expanded: [String: Bool] = [:]
 
     var body: some View {
-        Card("Asset Classes") {
-            Picker("Display", selection: .constant(0)) {
-                Text("%").tag(0)
-                Text("CHF").tag(1)
+        Card {
+            HStack {
+                Text("Asset Classes")
+                    .font(.headline)
+                Spacer()
+                SegmentedPicker
             }
-            .pickerStyle(.segmented)
+            .padding(.horizontal, 24)
+            Divider()
+            ScrollView { VStack(spacing: 0) { rows } }
+        }
+        .onAppear { initializeExpanded() }
+    }
 
-            ScrollView {
-                VStack(spacing: 0) {
-                    ForEach(viewModel.assets) { asset in
-                        AssetRowView(asset: asset, level: 0, highlighted: viewModel.highlightedId == asset.id)
-                        if let children = asset.children {
-                            ForEach(children) { child in
-                                AssetRowView(asset: child, level: 1, highlighted: viewModel.highlightedId == child.id)
-                            }
-                        }
-                    }
+    private var SegmentedPicker: some View {
+        Picker("", selection: $displayMode) {
+            Text("%").tag(DisplayMode.percent)
+            Text("CHF").tag(DisplayMode.chf)
+        }
+        .pickerStyle(.segmented)
+        .frame(width: 120)
+    }
+
+    @ViewBuilder
+    private var rows: some View {
+        ForEach(viewModel.assets) { parent in
+            AssetRow(node: parent, expanded: binding(for: parent.id))
+            if expanded[parent.id] == true, let children = parent.children {
+                ForEach(children) { child in
+                    AssetRow(node: child, expanded: .constant(false))
                 }
             }
         }
     }
+
+    private func binding(for id: String) -> Binding<Bool> {
+        return Binding(get: { expanded[id] ?? false },
+                       set: { expanded[id] = $0 })
+    }
+
+    private func initializeExpanded() {
+        for asset in viewModel.assets {
+            if expanded[asset.id] == nil { expanded[asset.id] = false }
+        }
+    }
 }
 
-struct AssetRowView: View {
-    let asset: AllocationDashboardViewModel.Asset
-    let level: Int
-    let highlighted: Bool
+struct AssetRow: View {
+    let node: AllocationDashboardViewModel.Asset
+    @Binding var expanded: Bool
 
     var body: some View {
-        HStack(spacing: 12) {
-            Text(asset.name)
-                .frame(width: level == 0 ? 140 : 120, alignment: .leading)
+        HStack(spacing: 0) {
+            if node.children != nil {
+                Button(action: { expanded.toggle() }) {
+                    Image(systemName: expanded ? "chevron.down" : "chevron.right")
+                        .font(.caption2)
+                }
+                .buttonStyle(.plain)
+                .frame(width: 16)
+                .keyboardShortcut(.space, modifiers: [])
+            } else {
+                Spacer().frame(width: 16)
+            }
+
+            Text(node.name)
+                .font(node.children != nil ? .body.weight(.semibold) : .subheadline.weight(.regular))
+                .padding(.leading, 4)
+
             Spacer()
-            Text(String(format: "%.1f%%", asset.targetPct))
+
+            Text(String(format: "%.1f%%", node.targetPct))
                 .frame(width: 50, alignment: .trailing)
                 .font(.system(.footnote, design: .monospaced))
-            Text(String(format: "%.1f%%", asset.actualPct))
+            Text(String(format: "%.1f%%", node.actualPct))
                 .frame(width: 50, alignment: .trailing)
                 .font(.system(.footnote, design: .monospaced))
             deviationBar
                 .frame(width: 60)
-            Text(String(format: "%+.1f%%", asset.deviationPct))
+            Text(String(format: "%+.1f%%", node.deviationPct))
                 .frame(width: 50, alignment: .trailing)
                 .font(.system(.footnote, design: .monospaced))
         }
-        .padding(.vertical, 4)
-        .background(highlighted ? Color.blue.opacity(0.1) : (level == 0 ? Color.fieldGray.opacity(0.4) : Color.clear))
-        .overlay(alignment: .leading) {
-            if highlighted {
-                Rectangle()
-                    .fill(Color.accentColor)
-                    .frame(width: 3)
-            }
-        }
+        .padding(.vertical, 6)
+        .padding(.horizontal, 24)
+        .background(node.children != nil ? Color.gray.opacity(0.07) : Color.white)
+        .accessibilityElement(children: .combine)
     }
 
     private var deviationBar: some View {
-        let dev = asset.deviationPct
+        let dev = node.deviationPct
         let devColor = dev > 0 ? Color.numberRed : Color.numberGreen
         return ZStack(alignment: .leading) {
             Capsule().fill(Color.gray.opacity(0.25))


### PR DESCRIPTION
## Summary
- allow Card component without a title
- add DisplayMode enum
- rebuild Asset Classes card header with inline segmented picker
- implement expandable AssetRow
- document UI tweak in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884a5fb812883239490077154441ddf