### PR TITLE
Apply layout tweaks to Asset Classes card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Reorganize sidebar navigation with expandable sections and remove old transaction links
 - Combine Currencies and FX Rates maintenance into one tabbed view
 - Rework Asset Classes card header with inline picker
+- Fine-tune Asset Class card layout with caption row and uniform deviation bars
 - Combine Asset Class and SubClass management into one page with sortable rows
 - Add column filters, single-column sorting and double-click editing to Instruments and Positions tables
 - Prompt to confirm option quantity multiplier during position import

--- a/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
+++ b/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
@@ -172,6 +172,16 @@ struct AllocationTreeCard: View {
             }
             .padding(.horizontal, 24)
             Divider()
+            HStack {
+                Spacer().frame(width: 150)
+                Caption("TARGET")
+                Caption("ACTUAL")
+                Caption("DEVIATION")
+                Spacer().frame(width: 36)
+            }
+            .padding(.horizontal, 24)
+            .padding(.vertical, 4)
+            Divider()
             ScrollView { VStack(spacing: 0) { rows } }
         }
         .onAppear { initializeExpanded() }
@@ -208,14 +218,22 @@ struct AllocationTreeCard: View {
             if expanded[asset.id] == nil { expanded[asset.id] = false }
         }
     }
+
+    private func Caption(_ text: String) -> some View {
+        Text(text)
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: 80, alignment: .trailing)
+    }
 }
 
 struct AssetRow: View {
     let node: AllocationDashboardViewModel.Asset
     @Binding var expanded: Bool
+    private let barWidth: CGFloat = 72
 
     var body: some View {
-        HStack(spacing: 0) {
+        HStack(spacing: 8) {
             if node.children != nil {
                 Button(action: { expanded.toggle() }) {
                     Image(systemName: expanded ? "chevron.down" : "chevron.right")
@@ -230,47 +248,48 @@ struct AssetRow: View {
 
             Text(node.name)
                 .font(node.children != nil ? .body.weight(.semibold) : .subheadline.weight(.regular))
-                .padding(.leading, 4)
 
-            Spacer()
+            Spacer().frame(width: 16)
 
             Text(String(format: "%.1f%%", node.targetPct))
-                .frame(width: 50, alignment: .trailing)
-                .font(.system(.footnote, design: .monospaced))
+                .frame(width: 60, alignment: .trailing)
+                .font(numberFont)
             Text(String(format: "%.1f%%", node.actualPct))
-                .frame(width: 50, alignment: .trailing)
-                .font(.system(.footnote, design: .monospaced))
-            deviationBar
+                .frame(width: 60, alignment: .trailing)
+                .font(numberFont)
+            deviationBar(node.deviationPct / 100)
+                .frame(width: barWidth)
             Text(String(format: "%+.1f%%", node.deviationPct))
-                .font(.system(.footnote, design: .monospaced))
-                .padding(.leading, 4)
+                .frame(width: 60, alignment: .trailing)
+                .font(numberFont)
         }
         .padding(.vertical, 6)
-        .padding(.horizontal, 24)
+        .padding(.leading, 24)
         .background(node.children != nil ? Color.gray.opacity(0.07) : Color.white)
         .accessibilityElement(children: .combine)
     }
 
-    private var deviationBar: some View {
-        let tol = 5.0
-        let dev = node.deviationPct
-        let magnitude = abs(dev)
-        let maxWidth: CGFloat = 60
-        let fillWidth = CGFloat(min(100.0, magnitude) / 100) * maxWidth
-        let xpos: CGFloat = dev < 0 ? maxWidth : -fillWidth
-
-        return ZStack {
-            Capsule().fill(Color.quaternary)
-            Capsule().fill(fillColor(tol, magnitude))
-                .frame(width: fillWidth)
-                .offset(x: xpos)
-        }
-        .frame(width: maxWidth * 2, height: 6)
+    private var numberFont: Font {
+        node.children != nil ? .body.weight(.bold) : .subheadline
     }
 
-    private func fillColor(_ tol: Double, _ mag: Double) -> Color {
-        if mag <= tol { return .numberGreen }
-        if mag <= tol * 2 { return .numberAmber }
+    private func deviationBar(_ dev: Double) -> some View {
+        let maxDev = 1.0
+        let fillWidth = min(barWidth / 2, abs(dev) * barWidth / maxDev)
+        return ZStack {
+            Capsule().fill(Color.quaternary)
+            Capsule().fill(colorFor(dev))
+                .frame(width: fillWidth)
+                .offset(x: dev < 0 ? barWidth / 2 : -barWidth / 2)
+        }
+        .frame(width: barWidth, height: 6)
+        .padding(.horizontal, 4)
+    }
+
+    private func colorFor(_ dev: Double) -> Color {
+        let mag = abs(dev)
+        if mag <= 0.05 { return .numberGreen }
+        if mag <= 0.10 { return .numberAmber }
         return .numberRed
     }
 }


### PR DESCRIPTION
## Summary
- fine-tune Asset Class card layout with a caption row and uniform deviation bars
- bold parent asset numbers and right-align all numeric columns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884af3b09508323a96f2e61f603f525