### PR TITLE
feat(ui): refine asset allocation rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -406,3 +406,4 @@ All notable changes to this project will be documented in this file.
 - Replace blue Top 10 Positions tile with modern white card showing all positions
 - Reduce list row spacing in Top Positions card for denser display
 - Refine Asset Class card with captioned display toggle and color-coded deviation bars
+- Tweak Asset Allocation rows with caption header and uniform deviation bars

--- a/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
+++ b/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
@@ -159,20 +159,13 @@ struct AllocationTreeCard: View {
 
     var body: some View {
         Card {
-            HStack(alignment: .top) {
-                Text("Asset Classes")
-                    .font(.headline)
-                Spacer()
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Display mode")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                    SegmentedPicker
-                }
+            VStack(spacing: 0) {
+                HeaderBar()
+                Divider()
+                captionRow
+                Divider()
+                ScrollView { VStack(spacing: 0) { rows } }
             }
-            .padding(.horizontal, 24)
-            Divider()
-            ScrollView { VStack(spacing: 0) { rows } }
         }
         .onAppear { initializeExpanded() }
     }
@@ -184,6 +177,40 @@ struct AllocationTreeCard: View {
         }
         .pickerStyle(.segmented)
         .frame(width: 120)
+    }
+
+    private func HeaderBar() -> some View {
+        HStack(alignment: .top) {
+            Text("Asset Classes")
+                .font(.headline)
+            Spacer()
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Display mode")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                SegmentedPicker
+            }
+        }
+        .padding(.horizontal, 24)
+    }
+
+    private var captionRow: some View {
+        HStack {
+            Spacer().frame(width: 150)
+            Caption("TARGET")
+            Caption("ACTUAL")
+            Caption("DEVIATION")
+            Spacer().frame(width: 36)
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 4)
+    }
+
+    private func Caption(_ text: String) -> some View {
+        Text(text)
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: 80, alignment: .trailing)
     }
 
     @ViewBuilder
@@ -214,6 +241,10 @@ struct AssetRow: View {
     let node: AllocationDashboardViewModel.Asset
     @Binding var expanded: Bool
 
+    private let columnWidth: CGFloat = 60
+    private let barWidth: CGFloat = 72
+    private let maxDev: Double = 1.0
+
     var body: some View {
         HStack(spacing: 0) {
             if node.children != nil {
@@ -230,48 +261,54 @@ struct AssetRow: View {
 
             Text(node.name)
                 .font(node.children != nil ? .body.weight(.semibold) : .subheadline.weight(.regular))
-                .padding(.leading, 4)
 
             Spacer()
 
-            Text(String(format: "%.1f%%", node.targetPct))
-                .frame(width: 50, alignment: .trailing)
-                .font(.system(.footnote, design: .monospaced))
-            Text(String(format: "%.1f%%", node.actualPct))
-                .frame(width: 50, alignment: .trailing)
-                .font(.system(.footnote, design: .monospaced))
-            deviationBar
-            Text(String(format: "%+.1f%%", node.deviationPct))
-                .font(.system(.footnote, design: .monospaced))
-                .padding(.leading, 4)
+            HStack(spacing: 8) {
+                Spacer().frame(width: 16)
+                Text(formatPercent(node.targetPct))
+                    .frame(width: columnWidth, alignment: .trailing)
+                    .font(node.children != nil ? .body.weight(.bold) : .subheadline)
+                Text(formatPercent(node.actualPct))
+                    .frame(width: columnWidth, alignment: .trailing)
+                    .font(node.children != nil ? .body.weight(.bold) : .subheadline)
+                deviationBar(node.deviationPct)
+                    .padding(.horizontal, 4)
+                Text(formatSigned(node.deviationPct))
+                    .frame(width: 36, alignment: .trailing)
+                    .font(node.children != nil ? .body.weight(.bold) : .subheadline)
+            }
         }
         .padding(.vertical, 6)
-        .padding(.horizontal, 24)
+        .padding(.leading, 24)
         .background(node.children != nil ? Color.gray.opacity(0.07) : Color.white)
         .accessibilityElement(children: .combine)
     }
 
-    private var deviationBar: some View {
-        let tol = 5.0
-        let dev = node.deviationPct
-        let magnitude = abs(dev)
-        let maxWidth: CGFloat = 60
-        let fillWidth = CGFloat(min(100.0, magnitude) / 100) * maxWidth
-        let xpos: CGFloat = dev < 0 ? maxWidth : -fillWidth
-
-        return ZStack {
-            Capsule().fill(Color.quaternary)
-            Capsule().fill(fillColor(tol, magnitude))
-                .frame(width: fillWidth)
-                .offset(x: xpos)
+    private func deviationBar(_ dev: Double) -> some View {
+        ZStack {
+            Capsule().fill(.quaternary)
+            Capsule().fill(colorFor(dev))
+                .frame(width: min(barWidth / 2, abs(dev) * barWidth / maxDev))
+                .offset(x: dev < 0 ? barWidth / 2 : -barWidth / 2)
         }
-        .frame(width: maxWidth * 2, height: 6)
+        .frame(width: barWidth, height: 6)
     }
 
-    private func fillColor(_ tol: Double, _ mag: Double) -> Color {
+    private func colorFor(_ dev: Double) -> Color {
+        let tol = 5.0
+        let mag = abs(dev)
         if mag <= tol { return .numberGreen }
         if mag <= tol * 2 { return .numberAmber }
         return .numberRed
+    }
+
+    private func formatPercent(_ value: Double) -> String {
+        String(format: "%.1f%%", value)
+    }
+
+    private func formatSigned(_ value: Double) -> String {
+        String(format: "%+.1f%%", value)
     }
 }
 


### PR DESCRIPTION
## Summary
- add column captions under asset class card header
- bold parent row numbers and align numeric columns
- use uniform deviation bars with centered origin
- document asset allocation view tweaks in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884af3b09508323a96f2e61f603f525