### PR TITLE
feat(ui): tweak asset classes layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Polish Crypto Allocations tile visuals and reduce row spacing
+- Add caption row and uniform deviation bars to Asset Classes tile
 - Redesign Asset Allocation dashboard with modern cards
 - Fix compile errors in Asset Allocation dashboard views
 - Redesign overview bar layout with dedicated tiles


### PR DESCRIPTION
## Summary
- add caption row and header helper views to AllocationTreeCard
- unify deviation bar width and right-align percentage columns
- update CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884af3b09508323a96f2e61f603f525