### PR TITLE
feat(ui): optimise asset class tile layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Reorganize sidebar navigation with expandable sections and remove old transaction links
 - Combine Currencies and FX Rates maintenance into one tabbed view
 - Rework Asset Classes card header with inline picker
+- Improve Asset Class tile layout with flexible widths and capped deviation bars
 - Combine Asset Class and SubClass management into one page with sortable rows
 - Add column filters, single-column sorting and double-click editing to Instruments and Positions tables
 - Prompt to confirm option quantity multiplier during position import

--- a/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
+++ b/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
@@ -5,13 +5,14 @@ struct AllocationDashboardView: View {
     @EnvironmentObject var dbManager: DatabaseManager
     @StateObject private var viewModel = AllocationDashboardViewModel()
 
-    // MARK: - Column width constants
-    private let leftWidth:  Double = 520
-    private let rightWidth: Double = 400
-
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 32) {
+        GeometryReader { geo in
+            let totalWidth = geo.size.width
+            let leftCol  = max(540, totalWidth * 0.55)
+            let rightCol = totalWidth - leftCol - 32
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 32) {
                 OverviewBar(portfolioTotal: viewModel.portfolioTotalFormatted,
                             outOfRange: "\(viewModel.outOfRangeCount)",
                             largestDev: String(format: "%.1f%%", viewModel.largestDeviation),
@@ -21,18 +22,21 @@ struct AllocationDashboardView: View {
 
                 HStack(alignment: .top, spacing: 32) {
                     AllocationTreeCard(viewModel: viewModel)
-                        .frame(width: leftWidth)
+                        .frame(width: leftCol)
 
                     VStack(spacing: 32) {
                         DeviationChartsCard(bubbles: viewModel.bubbles,
                                            highlighted: $viewModel.highlightedId)
+                            .frame(maxWidth: .infinity)
                         RebalanceListCard(actions: viewModel.actions)
+                            .frame(maxWidth: .infinity)
                     }
-                    .frame(width: rightWidth)
+                    .frame(width: rightCol)
                 }
+                }
+                .padding(.horizontal, 32)
+                .padding(.bottom, 40)
             }
-            .padding(.horizontal, 32)
-            .padding(.bottom, 40)
         }
         .background(Color(NSColor.windowBackgroundColor))
         .navigationTitle("Asset Allocation Targets")
@@ -216,10 +220,14 @@ struct AllocationTreeCard: View {
     @ViewBuilder
     private var rows: some View {
         ForEach(viewModel.assets) { parent in
-            AssetRow(node: parent, expanded: binding(for: parent.id))
+            AssetRow(node: parent,
+                     expanded: binding(for: parent.id),
+                     displayMode: displayMode)
             if expanded[parent.id] == true, let children = parent.children {
                 ForEach(children) { child in
-                    AssetRow(node: child, expanded: .constant(false))
+                    AssetRow(node: child,
+                             expanded: .constant(false),
+                             displayMode: displayMode)
                 }
             }
         }
@@ -240,13 +248,14 @@ struct AllocationTreeCard: View {
 struct AssetRow: View {
     let node: AllocationDashboardViewModel.Asset
     @Binding var expanded: Bool
+    let displayMode: DisplayMode
 
-    private let columnWidth: CGFloat = 60
-    private let barWidth: CGFloat = 72
+    private let columnWidth: CGFloat = 48
+    private let track: CGFloat = 96
     private let maxDev: Double = 1.0
 
     var body: some View {
-        HStack(spacing: 0) {
+        HStack(spacing: 6) {
             if node.children != nil {
                 Button(action: { expanded.toggle() }) {
                     Image(systemName: expanded ? "chevron.down" : "chevron.right")
@@ -261,38 +270,39 @@ struct AssetRow: View {
 
             Text(node.name)
                 .font(node.children != nil ? .body.weight(.semibold) : .subheadline.weight(.regular))
+                .frame(minWidth: 140, alignment: .leading)
 
-            Spacer()
+            Text(formatValue(node.targetPct, chf: node.targetChf))
+                .frame(width: columnWidth, alignment: .trailing)
+                .font(node.children != nil ? .body.weight(.bold) : .subheadline)
 
-            HStack(spacing: 8) {
-                Spacer().frame(width: 16)
-                Text(formatPercent(node.targetPct))
-                    .frame(width: columnWidth, alignment: .trailing)
-                    .font(node.children != nil ? .body.weight(.bold) : .subheadline)
-                Text(formatPercent(node.actualPct))
-                    .frame(width: columnWidth, alignment: .trailing)
-                    .font(node.children != nil ? .body.weight(.bold) : .subheadline)
-                deviationBar(node.deviationPct)
-                    .padding(.horizontal, 4)
-                Text(formatSigned(node.deviationPct))
-                    .frame(width: 36, alignment: .trailing)
-                    .font(node.children != nil ? .body.weight(.bold) : .subheadline)
-            }
+            Text(formatValue(node.actualPct, chf: node.actualChf))
+                .frame(width: columnWidth, alignment: .trailing)
+                .font(node.children != nil ? .body.weight(.bold) : .subheadline)
+
+            deviationBar(node.deviationPct)
+                .frame(width: track)
+
+            Text(formatSigned(node.deviationPct))
+                .frame(width: 36, alignment: .trailing)
+                .font(node.children != nil ? .body.weight(.bold) : .subheadline)
         }
-        .padding(.vertical, 6)
-        .padding(.leading, 24)
+        .padding(.vertical, node.children != nil ? 8 : 6)
+        .padding(.leading, 16)
         .background(node.children != nil ? Color.gray.opacity(0.07) : Color.white)
         .accessibilityElement(children: .combine)
     }
 
     private func deviationBar(_ dev: Double) -> some View {
-        ZStack {
+        let span = CGFloat(min(abs(dev), maxDev)) * (track / 2)
+        let offset = dev < 0 ? span : -span
+        return ZStack {
             Capsule().fill(.quaternary)
             Capsule().fill(colorFor(dev))
-                .frame(width: min(barWidth / 2, abs(dev) * barWidth / maxDev))
-                .offset(x: dev < 0 ? barWidth / 2 : -barWidth / 2)
+                .frame(width: span)
+                .offset(x: offset)
         }
-        .frame(width: barWidth, height: 6)
+        .frame(width: track, height: 6)
     }
 
     private func colorFor(_ dev: Double) -> Color {
@@ -303,12 +313,17 @@ struct AssetRow: View {
         return .numberRed
     }
 
-    private func formatPercent(_ value: Double) -> String {
-        String(format: "%.1f%%", value)
+    private func formatValue(_ pct: Double, chf: Double) -> String {
+        switch displayMode {
+        case .percent:
+            return String(format: "%.1f", pct)
+        case .chf:
+            return chf.formatted(.currency(code: "CHF"))
+        }
     }
 
     private func formatSigned(_ value: Double) -> String {
-        String(format: "%+.1f%%", value)
+        String(format: "%+.1f", value)
     }
 }
 

--- a/DragonShield/Views/AllocationDashboard/AllocationDashboardViewModel.swift
+++ b/DragonShield/Views/AllocationDashboard/AllocationDashboardViewModel.swift
@@ -117,13 +117,15 @@ final class AllocationDashboardViewModel: ObservableObject {
             let actualCHF = classActual[cls.id] ?? 0
             let actualPct = total > 0 ? actualCHF / total * 100 : 0
             let tPct = classTargetPct[cls.id] ?? 0
+            let targetCHF = total * tPct / 100
             let children = db.subAssetClasses(for: cls.id).map { sub in
                 let sChf = subActual[sub.id] ?? 0
                 let sPct = actualCHF > 0 ? sChf / actualCHF * 100 : 0
                 let tp = subTargetPct[sub.id] ?? 0
-                return Asset(id: "sub-\(sub.id)", name: sub.name, actualPct: sPct, actualChf: sChf, targetPct: tp, targetChf: 0, children: nil)
+                let subTargetCHF = targetCHF * tp / 100
+                return Asset(id: "sub-\(sub.id)", name: sub.name, actualPct: sPct, actualChf: sChf, targetPct: tp, targetChf: subTargetCHF, children: nil)
             }
-            return Asset(id: "class-\(cls.id)", name: cls.name, actualPct: actualPct, actualChf: actualCHF, targetPct: tPct, targetChf: 0, children: children)
+            return Asset(id: "class-\(cls.id)", name: cls.name, actualPct: actualPct, actualChf: actualCHF, targetPct: tPct, targetChf: targetCHF, children: children)
         }
 
         bubbles = assets.map { asset in


### PR DESCRIPTION
## Summary
- widen dashboard columns with GeometryReader
- adjust AssetRow layout and fonts
- cap deviation bars and format without percent sign
- compute CHF target amounts for allocation view
- update changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884dd340f00832397fc93c1821c39e7