### PR TITLE
Layout fix for asset allocation view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 - Polish Crypto Allocations tile visuals and reduce row spacing
 - Redesign Asset Allocation dashboard with modern cards
+- Fix Asset Allocation view padding and responsive table columns
 - Fix compile errors in Asset Allocation dashboard views
 - Redesign overview bar layout with dedicated tiles
 - Fix color scheme handling in overview bar and card components


### PR DESCRIPTION
## Summary
- make asset allocation dashboard responsive with symmetric padding
- adjust AllocationTreeCard columns proportionally
- cap deviation bars and simplify row layout
- document layout fix in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884fb48e7948323a72afd87540a8c83