### PR TITLE
feat(ui): refine deviation column layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Align deviation column with center line, delta text and action icons
 - Polish Crypto Allocations tile visuals and reduce row spacing
 - Redesign Asset Allocation dashboard with modern cards
 - Fix compile errors in Asset Allocation dashboard views


### PR DESCRIPTION
## Summary
- align deviation table columns with constant widths
- add caption row and delta text
- show action icons for rebalancing suggestions
- draw center line in deviation bar

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688501743b448323adc9e8590a8a919f