### PR TITLE
feat(ui): scale deviation bar by target weight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Polish Crypto Allocations tile visuals and reduce row spacing
+- Scale deviation bars relative to target weight for accurate offsets
 - Redesign Asset Allocation dashboard with modern cards
 - Fix compile errors in Asset Allocation dashboard views
 - Redesign overview bar layout with dedicated tiles


### PR DESCRIPTION
## Summary
- compute deviation relative to the target weight
- adjust DeviationBar to use target/actual values
- update delta formatting and colors
- document change in the changelog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885093f941c832390f40163a971e4a9