### PR TITLE
feat(ui): apply accurate deviation bar design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -410,3 +410,4 @@ All notable changes to this project will be documented in this file.
 - Refine Asset Class card with captioned display toggle and color-coded deviation bars
 - Tweak Asset Allocation rows with caption header and uniform deviation bars
 - Enhance deviation column with centre line, delta numbers and action icons
+- Implement accurate centre-based deviation bars in Asset Allocation view


### PR DESCRIPTION
## Summary
- implement deviation bar math based on target and actual
- update action icon logic for buy/sell cues
- color rebalance icons using green when outside tolerance

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885093f941c832390f40163a971e4a9