### PR TITLE
feat(ui): remove deviation icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ All notable changes to this project will be documented in this file.
 - Combine Asset Class and SubClass management into one page with sortable rows
 - Add column filters, single-column sorting and double-click editing to Instruments and Positions tables
 - Refine deviation bar logic in Asset Allocation view
+- Update deviation bar display in Asset Allocation tile
+- Shorten deviation bars to half length in Asset Allocation tile
+- Remove plus/minus icons from deviation column in Asset Allocation tile
 - Prompt to confirm option quantity multiplier during position import
 - Show institutions ranked by AUM in new dashboard tile
 - Document troubleshooting steps for missing `default.metallib` warning


### PR DESCRIPTION
## Summary
- remove the icon column in Asset Allocation dashboard rows
- update column width logic accordingly
- document deviation icon removal in changelog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68852526069483238a0246a7be8de039