### PR TITLE
feat(ui): show tolerance pill in allocation table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -415,3 +415,4 @@ All notable changes to this project will be documented in this file.
 - Tweak Asset Allocation rows with caption header and uniform deviation bars
 - Enhance deviation column with centre line, delta numbers and action icons
 - Add target_kind and tolerance_percent columns to TargetAllocation table
+- Display tolerance pill next to asset names in Allocation Dashboard table

--- a/DragonShield/DatabaseManager+PortfolioTargets.swift
+++ b/DragonShield/DatabaseManager+PortfolioTargets.swift
@@ -129,9 +129,9 @@ extension DatabaseManager {
     // MARK: - New persistence helpers
 
     /// Returns stored target percentages aggregated by asset class or sub-class.
-    func fetchPortfolioTargetRecords(portfolioId: Int) -> [(classId: Int?, subClassId: Int?, percent: Double, amountCHF: Double?)] {
-        var results: [(classId: Int?, subClassId: Int?, percent: Double, amountCHF: Double?)] = []
-        let query = "SELECT asset_class_id, sub_class_id, COALESCE(target_percent,0), target_amount_chf FROM TargetAllocation;"
+    func fetchPortfolioTargetRecords(portfolioId: Int) -> [(classId: Int?, subClassId: Int?, percent: Double, amountCHF: Double?, tolerance: Double)] {
+        var results: [(classId: Int?, subClassId: Int?, percent: Double, amountCHF: Double?, tolerance: Double)] = []
+        let query = "SELECT asset_class_id, sub_class_id, COALESCE(target_percent,0), target_amount_chf, tolerance_percent FROM TargetAllocation;"
         var statement: OpaquePointer?
         if sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK {
             while sqlite3_step(statement) == SQLITE_ROW {
@@ -139,7 +139,8 @@ extension DatabaseManager {
                 let subId = sqlite3_column_type(statement, 1) == SQLITE_NULL ? nil : Int(sqlite3_column_int(statement, 1))
                 let pct = sqlite3_column_double(statement, 2)
                 let amount = sqlite3_column_type(statement, 3) == SQLITE_NULL ? nil : sqlite3_column_double(statement, 3)
-                results.append((classId: classId, subClassId: subId, percent: pct, amountCHF: amount))
+                let tol = sqlite3_column_double(statement, 4)
+                results.append((classId: classId, subClassId: subId, percent: pct, amountCHF: amount, tolerance: tol))
             }
         } else {
             LoggingService.shared.log("Failed to prepare fetchPortfolioTargetRecords: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)

--- a/DragonShield/ViewModels/TargetAllocationViewModel.swift
+++ b/DragonShield/ViewModels/TargetAllocationViewModel.swift
@@ -61,6 +61,7 @@ class TargetAllocationViewModel: ObservableObject {
                 // direct real estate stored via configuration separately
                 directRealEstateTargetCHF = amount
             }
+            _ = row.tolerance
         }
         subClassTargets = subMap
         classTargets = classMap

--- a/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
+++ b/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
@@ -302,9 +302,17 @@ struct AssetRow: View {
                 Spacer().frame(width: 16)
             }
 
-            Text(node.name)
-                .font(node.children != nil ? .body.bold() : .subheadline)
-                .frame(width: nameWidth - 16, alignment: .leading)
+            HStack(spacing: 4) {
+                Text(node.name)
+                    .font(node.children != nil ? .body.bold() : .subheadline)
+                Text("±\(Int(node.tolerancePercent))%")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Capsule().fill(Color(.systemGray6)))
+            }
+            .frame(width: nameWidth - 16, alignment: .leading)
 
             Text(formatPercent(node.targetPct))
                 .frame(width: targetWidth, alignment: .trailing)

--- a/DragonShield/Views/AllocationDashboard/AllocationDashboardViewModel.swift
+++ b/DragonShield/Views/AllocationDashboard/AllocationDashboardViewModel.swift
@@ -8,6 +8,7 @@ final class AllocationDashboardViewModel: ObservableObject {
         let actualChf: Double
         let targetPct: Double
         let targetChf: Double
+        let tolerancePercent: Double
         var children: [Asset]? = nil
 
         var deviationPct: Double { actualPct - targetPct }
@@ -83,12 +84,16 @@ final class AllocationDashboardViewModel: ObservableObject {
 
         let targets = db.fetchPortfolioTargetRecords(portfolioId: 1)
         var classTargetPct: [Int: Double] = [:]
+        var classTolerance: [Int: Double] = [:]
         var subTargetPct: [Int: Double] = [:]
+        var subTolerance: [Int: Double] = [:]
         for row in targets {
             if let sub = row.subClassId {
                 subTargetPct[sub] = row.percent
+                subTolerance[sub] = row.tolerance
             } else if let cls = row.classId {
                 classTargetPct[cls] = row.percent
+                classTolerance[cls] = row.tolerance
             }
         }
 
@@ -121,13 +126,15 @@ final class AllocationDashboardViewModel: ObservableObject {
             let actualCHF = classActual[cls.id] ?? 0
             let actualPct = total > 0 ? actualCHF / total * 100 : 0
             let tPct = classTargetPct[cls.id] ?? 0
+            let tTol = classTolerance[cls.id] ?? 5.0
             let children = db.subAssetClasses(for: cls.id).map { sub in
                 let sChf = subActual[sub.id] ?? 0
                 let sPct = actualCHF > 0 ? sChf / actualCHF * 100 : 0
                 let tp = subTargetPct[sub.id] ?? 0
-                return Asset(id: "sub-\(sub.id)", name: sub.name, actualPct: sPct, actualChf: sChf, targetPct: tp, targetChf: 0, children: nil)
+                let tol = subTolerance[sub.id] ?? tTol
+                return Asset(id: "sub-\(sub.id)", name: sub.name, actualPct: sPct, actualChf: sChf, targetPct: tp, targetChf: 0, tolerancePercent: tol, children: nil)
             }
-            return Asset(id: "class-\(cls.id)", name: cls.name, actualPct: actualPct, actualChf: actualCHF, targetPct: tPct, targetChf: 0, children: children)
+            return Asset(id: "class-\(cls.id)", name: cls.name, actualPct: actualPct, actualChf: actualCHF, targetPct: tPct, targetChf: 0, tolerancePercent: tTol, children: children)
         }
 
         bubbles = assets.map { asset in

--- a/DragonShield/Views/AllocationTargetsTableView.swift
+++ b/DragonShield/Views/AllocationTargetsTableView.swift
@@ -250,9 +250,11 @@ final class AllocationTargetsTableViewModel: ObservableObject {
             if let sub = row.subClassId {
                 subTargetPct[sub] = row.percent
                 if let amt = row.amountCHF { subTargetChf[sub] = amt }
+                _ = row.tolerance
             } else if let cls = row.classId {
                 classTargetPct[cls] = row.percent
                 if let amt = row.amountCHF { classTargetChf[cls] = amt }
+                _ = row.tolerance
             }
         }
 


### PR DESCRIPTION
## Summary
- fetch tolerance_percent with target data
- expose tolerance to AllocationDashboard assets
- display tolerance pill next to asset names
- ignore tolerance value in legacy views

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68854514ccec8323a41fe06af62233a5