### PR TITLE
feat(allocation): show tolerance pills in asset table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - Combine Asset Class and SubClass management into one page with sortable rows
 - Add column filters, single-column sorting and double-click editing to Instruments and Positions tables
 - Display tolerance pills in Asset Allocation table rows
+- Fix compile error referencing systemGray6 in tolerance pill background
 - Refine deviation bar logic in Asset Allocation view
 - Update deviation bar display in Asset Allocation tile
 - Shorten deviation bars to half length in Asset Allocation tile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Rework Asset Classes card header with inline picker
 - Combine Asset Class and SubClass management into one page with sortable rows
 - Add column filters, single-column sorting and double-click editing to Instruments and Positions tables
+- Display tolerance pills in Asset Allocation table rows
 - Refine deviation bar logic in Asset Allocation view
 - Update deviation bar display in Asset Allocation tile
 - Shorten deviation bars to half length in Asset Allocation tile

--- a/DragonShield/DatabaseManager+PortfolioTargets.swift
+++ b/DragonShield/DatabaseManager+PortfolioTargets.swift
@@ -129,9 +129,9 @@ extension DatabaseManager {
     // MARK: - New persistence helpers
 
     /// Returns stored target percentages aggregated by asset class or sub-class.
-    func fetchPortfolioTargetRecords(portfolioId: Int) -> [(classId: Int?, subClassId: Int?, percent: Double, amountCHF: Double?)] {
-        var results: [(classId: Int?, subClassId: Int?, percent: Double, amountCHF: Double?)] = []
-        let query = "SELECT asset_class_id, sub_class_id, COALESCE(target_percent,0), target_amount_chf FROM TargetAllocation;"
+    func fetchPortfolioTargetRecords(portfolioId: Int) -> [(classId: Int?, subClassId: Int?, percent: Double, amountCHF: Double?, tolerance: Double)] {
+        var results: [(classId: Int?, subClassId: Int?, percent: Double, amountCHF: Double?, tolerance: Double)] = []
+        let query = "SELECT asset_class_id, sub_class_id, COALESCE(target_percent,0), target_amount_chf, tolerance_percent FROM TargetAllocation;"
         var statement: OpaquePointer?
         if sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK {
             while sqlite3_step(statement) == SQLITE_ROW {
@@ -139,7 +139,8 @@ extension DatabaseManager {
                 let subId = sqlite3_column_type(statement, 1) == SQLITE_NULL ? nil : Int(sqlite3_column_int(statement, 1))
                 let pct = sqlite3_column_double(statement, 2)
                 let amount = sqlite3_column_type(statement, 3) == SQLITE_NULL ? nil : sqlite3_column_double(statement, 3)
-                results.append((classId: classId, subClassId: subId, percent: pct, amountCHF: amount))
+                let tolerance = sqlite3_column_double(statement, 4)
+                results.append((classId: classId, subClassId: subId, percent: pct, amountCHF: amount, tolerance: tolerance))
             }
         } else {
             LoggingService.shared.log("Failed to prepare fetchPortfolioTargetRecords: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)

--- a/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
+++ b/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
@@ -302,9 +302,18 @@ struct AssetRow: View {
                 Spacer().frame(width: 16)
             }
 
-            Text(node.name)
-                .font(node.children != nil ? .body.bold() : .subheadline)
-                .frame(width: nameWidth - 16, alignment: .leading)
+            HStack(spacing: 4) {
+                Text(node.name)
+                    .font(node.children != nil ? .body.bold() : .subheadline)
+
+                Text("±\(Int(node.tolerancePercent))%")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Capsule().fill(Color(.systemGray6)))
+            }
+            .frame(width: nameWidth - 16, alignment: .leading)
 
             Text(formatPercent(node.targetPct))
                 .frame(width: targetWidth, alignment: .trailing)

--- a/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
+++ b/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
@@ -311,7 +311,7 @@ struct AssetRow: View {
                     .foregroundStyle(.secondary)
                     .padding(.horizontal, 6)
                     .padding(.vertical, 2)
-                    .background(Capsule().fill(Color(.systemGray6)))
+                    .background(Capsule().fill(Color.fieldGray))
             }
             .frame(width: nameWidth - 16, alignment: .leading)
 

--- a/DragonShield/Views/AllocationDashboard/AllocationDashboardViewModel.swift
+++ b/DragonShield/Views/AllocationDashboard/AllocationDashboardViewModel.swift
@@ -8,6 +8,7 @@ final class AllocationDashboardViewModel: ObservableObject {
         let actualChf: Double
         let targetPct: Double
         let targetChf: Double
+        let tolerancePercent: Double
         var children: [Asset]? = nil
 
         var deviationPct: Double { actualPct - targetPct }
@@ -83,12 +84,16 @@ final class AllocationDashboardViewModel: ObservableObject {
 
         let targets = db.fetchPortfolioTargetRecords(portfolioId: 1)
         var classTargetPct: [Int: Double] = [:]
+        var classTolerance: [Int: Double] = [:]
         var subTargetPct: [Int: Double] = [:]
+        var subTolerance: [Int: Double] = [:]
         for row in targets {
             if let sub = row.subClassId {
                 subTargetPct[sub] = row.percent
+                subTolerance[sub] = row.tolerance
             } else if let cls = row.classId {
                 classTargetPct[cls] = row.percent
+                classTolerance[cls] = row.tolerance
             }
         }
 
@@ -121,13 +126,15 @@ final class AllocationDashboardViewModel: ObservableObject {
             let actualCHF = classActual[cls.id] ?? 0
             let actualPct = total > 0 ? actualCHF / total * 100 : 0
             let tPct = classTargetPct[cls.id] ?? 0
+            let tol = classTolerance[cls.id] ?? 5.0
             let children = db.subAssetClasses(for: cls.id).map { sub in
                 let sChf = subActual[sub.id] ?? 0
                 let sPct = actualCHF > 0 ? sChf / actualCHF * 100 : 0
                 let tp = subTargetPct[sub.id] ?? 0
-                return Asset(id: "sub-\(sub.id)", name: sub.name, actualPct: sPct, actualChf: sChf, targetPct: tp, targetChf: 0, children: nil)
+                let st = subTolerance[sub.id] ?? tol
+                return Asset(id: "sub-\(sub.id)", name: sub.name, actualPct: sPct, actualChf: sChf, targetPct: tp, targetChf: 0, tolerancePercent: st, children: nil)
             }
-            return Asset(id: "class-\(cls.id)", name: cls.name, actualPct: actualPct, actualChf: actualCHF, targetPct: tPct, targetChf: 0, children: children)
+            return Asset(id: "class-\(cls.id)", name: cls.name, actualPct: actualPct, actualChf: actualCHF, targetPct: tPct, targetChf: 0, tolerancePercent: tol, children: children)
         }
 
         bubbles = assets.map { asset in


### PR DESCRIPTION
## Summary
- fetch tolerance_percent in `fetchPortfolioTargetRecords`
- keep tolerance info in dashboard view model assets
- display tolerance pill next to each asset name
- update changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68854514ccec8323a41fe06af62233a5