### PR TITLE
Add display mode toggle for Asset Classes tile

### DIFF
--- a/DragonShield/helpers/UserDefaultsKeys.swift
+++ b/DragonShield/helpers/UserDefaultsKeys.swift
@@ -21,4 +21,6 @@ struct UserDefaultsKeys {
     static let positionsFontSize = "positionsFontSize"
     /// Persist selected segment in Currencies & FX maintenance view.
     static let currenciesFxSegment = "currenciesFxSegment"
+    /// Persist display mode (percent or CHF) in Asset Classes tile.
+    static let assetDisplayMode = "assetDisplayMode"
 }


### PR DESCRIPTION
## Summary
- add user defaults key for asset display mode
- enable persistent percent/CHF toggle on Asset Classes tile
- compute target CHF values in dashboard view model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68854d489e9c83238f7f04b7b8cc339b