### PR TITLE
Polish asset allocation table UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Reorganize sidebar navigation with expandable sections and remove old transaction links
 - Combine Currencies and FX Rates maintenance into one tabbed view
 - Rework Asset Classes card header with inline picker
+- Polish Asset Allocation table layout with four-column grid
 - Combine Asset Class and SubClass management into one page with sortable rows
 - Add column filters, single-column sorting and double-click editing to Instruments and Positions tables
 - Display tolerance pills in Asset Allocation table rows

--- a/DragonShield/Views/AllocationDashboard/AllocationDashboardComponents.swift
+++ b/DragonShield/Views/AllocationDashboard/AllocationDashboardComponents.swift
@@ -17,7 +17,7 @@ struct Card<Content: View>: View {
             }
             content
         }
-        .padding(16)
+        .padding(24)
         .background(
             Group {
                 if scheme == .dark {


### PR DESCRIPTION
## Summary
- update Card padding to 24pt
- refactor Asset Allocation table with new column ratios
- embed delta label into deviation bar and add NameCell helper
- document the table polish in the changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885507390348323bc62271a367c0a24