### PR TITLE
feat(ui): polish asset class table layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Add segmented display mode toggle for Asset Classes tile
+- Refine Asset-Class table layout with four-column grid
 - Show database schema version in Database Management view and include it in backup file names
 - Polish Crypto Allocations tile visuals and reduce row spacing
 - Redesign Asset Allocation dashboard with modern cards


### PR DESCRIPTION
## Summary
- refine layout constants for asset class table
- update column header styling
- rework row layout and fonts
- implement deviation bar with inline delta label
- tweak tolerance pill style
- note table layout refinement in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885507390348323bc62271a367c0a24