### PR TITLE
Polish Asset Class table UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Convert Allocation dashboard to two-column layout with full-width overview bar
 - Correct side padding and responsive columns in Asset Allocation view
 - Add macOS Kanban to-do board with drag-and-drop
+- Polish asset-class table layout and typography
 - Optimise Asset Class tile layout and cap deviation bars in Allocation dashboard
 - Add sidebar link to the Kanban board
 - Reorganize sidebar navigation with expandable sections and remove old transaction links
@@ -22,6 +23,8 @@ All notable changes to this project will be documented in this file.
 - Add column filters, single-column sorting and double-click editing to Instruments and Positions tables
 - Display tolerance pills in Asset Allocation table rows
 - Fix compile error referencing systemGray6 in tolerance pill background
+- Fix compile errors referencing system gray colours and deprecated onChange API
+- Silence onChange deprecation warning when saving Allocation display mode
 - Refine deviation bar logic in Asset Allocation view
 - Update deviation bar display in Asset Allocation tile
 - Shorten deviation bars to half length in Asset Allocation tile

--- a/DragonShield/Views/AllocationDashboard/AllocationDashboardComponents.swift
+++ b/DragonShield/Views/AllocationDashboard/AllocationDashboardComponents.swift
@@ -17,7 +17,7 @@ struct Card<Content: View>: View {
             }
             content
         }
-        .padding(16)
+        .padding(24)
         .background(
             Group {
                 if scheme == .dark {

--- a/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
+++ b/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
@@ -186,7 +186,7 @@ struct AllocationTreeCard: View {
         }
         .frame(width: width)
         .onAppear { initializeExpanded() }
-        .onChange(of: displayMode) { _ in saveMode() }
+        .onChange(of: displayMode) { saveMode() }
     }
 
     private var SegmentedPicker: some View {
@@ -210,7 +210,7 @@ struct AllocationTreeCard: View {
                 SegmentedPicker
             }
         }
-        .padding(.horizontal, 24)
+        .padding(.horizontal, 16)
     }
 
     @ViewBuilder
@@ -276,19 +276,27 @@ struct AllocationTreeCard: View {
             HStack(spacing: gap) {
                 Spacer().frame(width: nameWidth + 16)
                 Text("TARGET")
-                    .font(.caption2)
+                    .font(.caption2.weight(.semibold))
                     .foregroundStyle(.secondary)
                     .frame(width: targetWidth, alignment: .trailing)
+                    .lineLimit(1)
                 Text("ACTUAL")
-                    .font(.caption2)
+                    .font(.caption2.weight(.semibold))
                     .foregroundStyle(.secondary)
                     .frame(width: actualWidth, alignment: .trailing)
+                    .lineLimit(1)
                 Text("DEVIATION")
                     .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
                     .frame(width: trackWidth + gap + deltaWidth, alignment: .center)
+                    .lineLimit(1)
             }
-            .padding(.horizontal, 24)
+            .padding(.horizontal, 16)
             .padding(.vertical, 4)
+        }
+        .overlay(alignment: .bottom) {
+            Divider()
+                .background(Color.systemGray4)
         }
     }
 }
@@ -320,10 +328,15 @@ struct AssetRow: View {
     }
 
     var body: some View {
+        let diffPct = relativeDeviation * 100
+        let span = trackWidth * CGFloat(min(abs(diffPct), 100)) / 100 * 0.5
+        let labelInside = span >= trackWidth * 0.25
+
         HStack(spacing: gap) {
             if node.children != nil {
                 Button(action: { expanded.toggle() }) {
-                    Image(systemName: expanded ? "chevron.down" : "chevron.right")
+                    Image(systemName: "chevron.right")
+                        .rotationEffect(.degrees(expanded ? 90 : 0))
                         .font(.caption2)
                 }
                 .buttonStyle(.plain)
@@ -336,34 +349,56 @@ struct AssetRow: View {
             HStack(spacing: 4) {
                 Text(node.name)
                     .font(node.children != nil ? .body.bold() : .subheadline)
+                    .lineLimit(1)
 
                 Text("±\(Int(node.tolerancePercent))%")
                     .font(.caption2.weight(.semibold))
                     .foregroundStyle(.secondary)
                     .padding(.horizontal, 6)
                     .padding(.vertical, 2)
-                    .background(Capsule().fill(Color.fieldGray))
+                    .background(Capsule().fill(Color.systemGray5))
             }
             .frame(width: nameWidth - 16, alignment: .leading)
 
             Text(formatValue(target))
                 .frame(width: targetWidth, alignment: .trailing)
                 .font(node.children != nil ? .body.bold() : .subheadline)
+                .lineLimit(1)
             Text(formatValue(actual))
                 .frame(width: actualWidth, alignment: .trailing)
                 .font(node.children != nil ? .body.bold() : .subheadline)
-            DeviationBar(target: target,
-                         actual: actual,
-                         trackWidth: trackWidth)
-                .frame(width: trackWidth)
+                .lineLimit(1)
 
-            Text(formatDeviation(deviation))
-                .frame(width: deltaWidth, alignment: .trailing)
-                .foregroundStyle(barColor(relativeDeviation * 100))
+            HStack(spacing: labelInside ? 0 : 4) {
+                ZStack(alignment: diffPct >= 0 ? .trailing : .leading) {
+                    DeviationBar(target: target,
+                                 actual: actual,
+                                 trackWidth: trackWidth)
+                        .frame(width: trackWidth)
+                    if labelInside {
+                        Text(formatDeviation(deviation))
+                            .font(.caption2)
+                            .foregroundStyle(barColor(diffPct))
+                            .padding(.horizontal, 2)
+                            .lineLimit(1)
+                    }
+                }
+                if !labelInside {
+                    Text(formatDeviation(deviation))
+                        .font(.caption2)
+                        .foregroundStyle(barColor(diffPct))
+                        .frame(width: deltaWidth, alignment: .trailing)
+                        .lineLimit(1)
+                } else {
+                    Spacer().frame(width: deltaWidth)
+                }
+            }
 
         }
-        .padding(.vertical, node.children != nil ? 8 : 6)
-        .background(node.children != nil ? Color.gray.opacity(0.07) : .clear)
+        .frame(height: node.children != nil ? 28 : 24)
+        .padding(.vertical, node.children != nil ? 6 : 4)
+        .padding(.horizontal, 16)
+        .background(node.children != nil ? Color.systemGray6 : .clear)
         .accessibilityElement(children: .combine)
     }
 
@@ -429,9 +464,11 @@ struct DeviationBar: View {
         return (actual - target) / target * 100
     }
 
+    private var track: CGFloat { trackWidth - 24 }
+
     private var span: CGFloat {
         let mag = min(abs(diffPercent), 100)
-        return trackWidth * CGFloat(mag) / 100 * 0.5
+        return track * CGFloat(mag) / 100 * 0.5
     }
 
     private var offset: CGFloat {
@@ -442,14 +479,17 @@ struct DeviationBar: View {
 
     var body: some View {
         ZStack {
-            Capsule().fill(.quaternary)
-                .frame(width: trackWidth, height: 6)
-            Rectangle().fill(Color.black.opacity(0.6))
+            Capsule().fill(Color.systemGray5)
+                .frame(height: 6)
+                .padding(.horizontal, 12)
+            Rectangle().fill(Color.black)
                 .frame(width: 1, height: 8)
             Capsule().fill(barColor(diffPercent))
                 .frame(width: span, height: 6)
                 .offset(x: offset)
+                .padding(.horizontal, 12)
         }
+        .frame(width: trackWidth)
     }
 }
 

--- a/DragonShield/Views/DashboardView.swift
+++ b/DragonShield/Views/DashboardView.swift
@@ -36,7 +36,7 @@ struct DashboardView: View {
                 .animation(.easeInOut(duration: 0.2), value: columnCount)
             }
             .onAppear { updateColumns(width: geo.size.width) }
-            .onChange(of: geo.size.width) { updateColumns(width: $0) }
+            .onChange(of: geo.size.width) { _, newValue in updateColumns(width: newValue) }
         }
         .navigationTitle("Dashboard")
         .toolbar {
@@ -49,7 +49,7 @@ struct DashboardView: View {
                 .onDisappear { saveLayout() }
         }
         .onAppear(perform: loadLayout)
-        .onChange(of: tileIDs) {
+        .onChange(of: tileIDs) { _, _ in
             saveLayout()
         }
     }

--- a/DragonShield/helpers/Color+Palette.swift
+++ b/DragonShield/helpers/Color+Palette.swift
@@ -42,4 +42,29 @@ extension Color {
         Color(uiColor: .quaternaryLabel)
         #endif
     }
+
+    /// System gray colours cross-platform
+    static var systemGray4: Color {
+        #if os(macOS)
+        Color(nsColor: .systemGray4)
+        #else
+        Color(uiColor: .systemGray4)
+        #endif
+    }
+
+    static var systemGray5: Color {
+        #if os(macOS)
+        Color(nsColor: .systemGray5)
+        #else
+        Color(uiColor: .systemGray5)
+        #endif
+    }
+
+    static var systemGray6: Color {
+        #if os(macOS)
+        Color(nsColor: .systemGray6)
+        #else
+        Color(uiColor: .systemGray6)
+        #endif
+    }
 }


### PR DESCRIPTION
## Summary
- tweak card padding for dashboard tiles
- update asset class table headers and row styling
- enhance deviation bar visuals and delta placement
- fix system gray references and update onChange usage
- silence remaining onChange deprecation warning

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885507390348323bc62271a367c0a24