### PR TITLE
Polish Asset Class table UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,16 @@ All notable changes to this project will be documented in this file.
 - Polish Crypto Allocations tile visuals and reduce row spacing
 - Redesign Asset Allocation dashboard with modern cards
 - Fix compile errors in Asset Allocation dashboard views
+- Fix caption row overlay placement in Asset Allocation table
 - Redesign overview bar layout with dedicated tiles
 - Fix color scheme handling in overview bar and card components
 - Convert Allocation dashboard to two-column layout with full-width overview bar
 - Correct side padding and responsive columns in Asset Allocation view
 - Add macOS Kanban to-do board with drag-and-drop
+- Polish asset-class table layout and typography
+- Refine deviation label placement in asset allocation table
 - Optimise Asset Class tile layout and cap deviation bars in Allocation dashboard
+- Make Asset Class table columns flexible and shorten CHF numbers when needed
 - Add sidebar link to the Kanban board
 - Reorganize sidebar navigation with expandable sections and remove old transaction links
 - Combine Currencies and FX Rates maintenance into one tabbed view
@@ -22,6 +26,8 @@ All notable changes to this project will be documented in this file.
 - Add column filters, single-column sorting and double-click editing to Instruments and Positions tables
 - Display tolerance pills in Asset Allocation table rows
 - Fix compile error referencing systemGray6 in tolerance pill background
+- Fix compile errors referencing system gray colours and deprecated onChange API
+- Provide fallback colours for systemGray4-6 on macOS to resolve compile errors
 - Refine deviation bar logic in Asset Allocation view
 - Update deviation bar display in Asset Allocation tile
 - Shorten deviation bars to half length in Asset Allocation tile

--- a/DragonShield/Views/AllocationDashboard/AllocationDashboardComponents.swift
+++ b/DragonShield/Views/AllocationDashboard/AllocationDashboardComponents.swift
@@ -17,7 +17,7 @@ struct Card<Content: View>: View {
             }
             content
         }
-        .padding(16)
+        .padding(24)
         .background(
             Group {
                 if scheme == .dark {

--- a/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
+++ b/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
@@ -7,11 +7,8 @@ struct AllocationDashboardView: View {
 
     var body: some View {
         GeometryReader { geo in
-            let sidePad: CGFloat = 32
-            let usableWidth = geo.size.width - sidePad * 2
-
             ScrollView {
-                VStack(spacing: 32) {
+                VStack(spacing: 24) {
                     OverviewBar(portfolioTotal: viewModel.portfolioTotalFormatted,
                                 outOfRange: "\(viewModel.outOfRangeCount)",
                                 largestDev: String(format: "%.1f%%", viewModel.largestDeviation),
@@ -19,18 +16,20 @@ struct AllocationDashboardView: View {
                         .frame(maxWidth: .infinity)
                         .padding(.top, 8)
 
-                    HStack(alignment: .top, spacing: 32) {
-                        AllocationTreeCard(width: usableWidth * 0.45, viewModel: viewModel)
+                    HStack(alignment: .top, spacing: 24) {
+                        AllocationTreeCard(viewModel: viewModel)
+                            .frame(minWidth: 340)
+                            .layoutPriority(1)
 
-                        VStack(spacing: 32) {
+                        VStack(spacing: 24) {
                             DeviationChartsCard(bubbles: viewModel.bubbles,
                                                highlighted: $viewModel.highlightedId)
                             RebalanceListCard(actions: viewModel.actions)
                         }
-                        .frame(width: usableWidth * 0.55)
+                        .frame(minWidth: 300)
                     }
                 }
-                .padding(.horizontal, sidePad)
+                .padding(.horizontal, 24)
                 .padding(.bottom, 40)
             }
         }
@@ -154,39 +153,35 @@ struct OverviewTile: View {
 }
 
 struct AllocationTreeCard: View {
-    let width: CGFloat
     @ObservedObject var viewModel: AllocationDashboardViewModel
     @State private var displayMode: DisplayMode = Self.loadMode()
     @State private var expanded: [String: Bool] = [:]
 
-    // Final column layout based on 640pt reference width
-    private let targetCol: CGFloat = 52
-    private let actualCol: CGFloat = 52
-    private let trackCol:  CGFloat = 128
-    private let deltaCol:  CGFloat = 40
-    private let gap:       CGFloat = 10
-
-    private var nameCol: CGFloat {
-        max(width - 16 - gap * 5 - targetCol - actualCol - trackCol - deltaCol, 160)
-    }
+    private let deltaCol: CGFloat = 40
+    private let gap: CGFloat = 8
 
     var body: some View {
         Card {
-            VStack(spacing: 0) {
-                HeaderBar()
-                CaptionRow(nameWidth: nameCol,
-                           targetWidth: targetCol,
-                           actualWidth: actualCol,
-                           trackWidth: trackCol,
-                           deltaWidth: deltaCol,
-                           gap: gap)
-                Divider()
-                ScrollView { VStack(spacing: 0) { rows } }
+            GeometryReader { geo in
+                let nameW = geo.size.width * 0.34
+                let targetW = geo.size.width * 0.18
+                let actualW = geo.size.width * 0.18
+                let devW = geo.size.width * 0.30
+
+                VStack(spacing: 0) {
+                    HeaderBar()
+                    CaptionRow(nameWidth: nameW - 16,
+                               targetWidth: targetW,
+                               actualWidth: actualW,
+                               deviationWidth: devW,
+                               gap: gap)
+                    Divider()
+                    ScrollView { VStack(spacing: 0) { rows(nameW - 16, targetW, actualW, devW) } }
+                }
             }
         }
-        .frame(width: width)
         .onAppear { initializeExpanded() }
-        .onChange(of: displayMode) { _ in saveMode() }
+        .onChange(of: displayMode) { _, _ in saveMode() }
     }
 
     private var SegmentedPicker: some View {
@@ -210,31 +205,29 @@ struct AllocationTreeCard: View {
                 SegmentedPicker
             }
         }
-        .padding(.horizontal, 24)
+        .padding(.horizontal, 16)
     }
 
     @ViewBuilder
-    private var rows: some View {
+    private func rows(_ nameW: CGFloat, _ targetW: CGFloat, _ actualW: CGFloat, _ devW: CGFloat) -> some View {
         ForEach(viewModel.assets) { parent in
             AssetRow(node: parent,
                      mode: displayMode,
                      expanded: binding(for: parent.id),
-                     nameWidth: nameCol,
-                     targetWidth: targetCol,
-                     actualWidth: actualCol,
-                     trackWidth: trackCol,
-                     deltaWidth: deltaCol,
+                     nameWidth: nameW,
+                     targetWidth: targetW,
+                     actualWidth: actualW,
+                     deviationWidth: devW,
                      gap: gap)
             if expanded[parent.id] == true, let children = parent.children {
                 ForEach(children) { child in
                     AssetRow(node: child,
                              mode: displayMode,
                              expanded: .constant(false),
-                             nameWidth: nameCol,
-                             targetWidth: targetCol,
-                             actualWidth: actualCol,
-                             trackWidth: trackCol,
-                             deltaWidth: deltaCol,
+                             nameWidth: nameW,
+                             targetWidth: targetW,
+                             actualWidth: actualW,
+                             deviationWidth: devW,
                              gap: gap)
                 }
             }
@@ -268,27 +261,34 @@ struct AllocationTreeCard: View {
         let nameWidth: CGFloat
         let targetWidth: CGFloat
         let actualWidth: CGFloat
-        let trackWidth: CGFloat
-        let deltaWidth: CGFloat
+        let deviationWidth: CGFloat
         let gap: CGFloat
 
         var body: some View {
             HStack(spacing: gap) {
                 Spacer().frame(width: nameWidth + 16)
                 Text("TARGET")
-                    .font(.caption2)
+                    .font(.caption2.weight(.semibold))
                     .foregroundStyle(.secondary)
                     .frame(width: targetWidth, alignment: .trailing)
+                    .lineLimit(1)
                 Text("ACTUAL")
-                    .font(.caption2)
+                    .font(.caption2.weight(.semibold))
                     .foregroundStyle(.secondary)
                     .frame(width: actualWidth, alignment: .trailing)
+                    .lineLimit(1)
                 Text("DEVIATION")
                     .font(.caption2.weight(.semibold))
-                    .frame(width: trackWidth + gap + deltaWidth, alignment: .center)
+                    .foregroundStyle(.secondary)
+                    .frame(width: deviationWidth, alignment: .center)
+                    .lineLimit(1)
             }
-            .padding(.horizontal, 24)
+            .padding(.horizontal, 16)
             .padding(.vertical, 4)
+            .overlay(alignment: .bottom) {
+                Divider()
+                    .background(Color.systemGray4)
+            }
         }
     }
 }
@@ -300,9 +300,11 @@ struct AssetRow: View {
     let nameWidth: CGFloat
     let targetWidth: CGFloat
     let actualWidth: CGFloat
-    let trackWidth: CGFloat
-    let deltaWidth: CGFloat
+    let deviationWidth: CGFloat
     let gap: CGFloat
+
+    private let labelWidth: CGFloat = 40
+    private var trackWidth: CGFloat { max(deviationWidth - labelWidth, 0) }
 
     private var target: Double {
         mode == .percent ? node.targetPct : node.targetChf
@@ -320,10 +322,16 @@ struct AssetRow: View {
     }
 
     var body: some View {
+        let diffPct = relativeDeviation * 100
+        let track = trackWidth - 24
+        let span = track * CGFloat(min(abs(diffPct), 100)) / 100 * 0.5
+        let labelInside = span >= track * 0.25
+
         HStack(spacing: gap) {
             if node.children != nil {
                 Button(action: { expanded.toggle() }) {
-                    Image(systemName: expanded ? "chevron.down" : "chevron.right")
+                    Image(systemName: "chevron.right")
+                        .rotationEffect(.degrees(expanded ? 90 : 0))
                         .font(.caption2)
                 }
                 .buttonStyle(.plain)
@@ -336,34 +344,56 @@ struct AssetRow: View {
             HStack(spacing: 4) {
                 Text(node.name)
                     .font(node.children != nil ? .body.bold() : .subheadline)
+                    .lineLimit(1)
 
                 Text("±\(Int(node.tolerancePercent))%")
                     .font(.caption2.weight(.semibold))
                     .foregroundStyle(.secondary)
                     .padding(.horizontal, 6)
                     .padding(.vertical, 2)
-                    .background(Capsule().fill(Color.fieldGray))
+                    .background(Capsule().fill(Color.systemGray5))
             }
             .frame(width: nameWidth - 16, alignment: .leading)
 
-            Text(formatValue(target))
+            Text(formatValue(target, width: targetWidth))
                 .frame(width: targetWidth, alignment: .trailing)
                 .font(node.children != nil ? .body.bold() : .subheadline)
-            Text(formatValue(actual))
+                .lineLimit(1)
+            Text(formatValue(actual, width: actualWidth))
                 .frame(width: actualWidth, alignment: .trailing)
                 .font(node.children != nil ? .body.bold() : .subheadline)
-            DeviationBar(target: target,
-                         actual: actual,
-                         trackWidth: trackWidth)
-                .frame(width: trackWidth)
+                .lineLimit(1)
 
-            Text(formatDeviation(deviation))
-                .frame(width: deltaWidth, alignment: .trailing)
-                .foregroundStyle(barColor(relativeDeviation * 100))
+            HStack(spacing: labelInside ? 0 : 4) {
+                ZStack(alignment: diffPct >= 0 ? .trailing : .leading) {
+                    DeviationBar(target: target,
+                                 actual: actual,
+                                 trackWidth: trackWidth)
+                        .frame(width: trackWidth)
+                    if labelInside {
+                        Text(formatDeviation(deviation, width: deviationWidth))
+                            .font(.caption2)
+                            .foregroundStyle(barColor(diffPct))
+                            .padding(.horizontal, 2)
+                            .lineLimit(1)
+                    }
+                }
+                if !labelInside {
+                    Text(formatDeviation(deviation, width: deviationWidth))
+                        .font(.caption2)
+                        .foregroundStyle(barColor(diffPct))
+                        .frame(width: labelWidth, alignment: .trailing)
+                        .lineLimit(1)
+                } else {
+                    Spacer().frame(width: labelWidth)
+                }
+            }
+            .frame(width: deviationWidth, alignment: .trailing)
 
         }
-        .padding(.vertical, node.children != nil ? 8 : 6)
-        .background(node.children != nil ? Color.gray.opacity(0.07) : .clear)
+        .padding(.vertical, node.children != nil ? 6 : 4)
+        .padding(.horizontal, 16)
+        .background(node.children != nil ? Color.systemGray6 : .clear)
         .accessibilityElement(children: .combine)
     }
 
@@ -392,6 +422,16 @@ struct AssetRow: View {
         Self.chfFormatter.string(from: NSNumber(value: value)) ?? ""
     }
 
+    private func shortChf(_ value: Double) -> String {
+        let absV = abs(value)
+        if absV >= 1_000_000 {
+            return String(format: "%.1f M", value / 1_000_000)
+        } else if absV >= 1_000 {
+            return String(format: "%.0f k", value / 1_000)
+        }
+        return formatChf(value)
+    }
+
     private func formatSignedPercent(_ value: Double) -> String {
         let sign = value >= 0 ? "+" : "-"
         return sign + (Self.percentFormatter.string(from: NSNumber(value: abs(value))) ?? "") + " %"
@@ -402,12 +442,19 @@ struct AssetRow: View {
         return sign + (Self.chfFormatter.string(from: NSNumber(value: abs(value))) ?? "")
     }
 
-    private func formatValue(_ value: Double) -> String {
-        mode == .percent ? formatPercent(value) : formatChf(value)
+    private func formatSignedShortChf(_ value: Double) -> String {
+        let sign = value >= 0 ? "+" : "-"
+        return sign + shortChf(abs(value))
     }
 
-    private func formatDeviation(_ value: Double) -> String {
-        mode == .percent ? formatSignedPercent(value) : formatSignedChf(value)
+    private func formatValue(_ value: Double, width: CGFloat) -> String {
+        if mode == .percent { return formatPercent(value) }
+        return width < 80 ? shortChf(value) : formatChf(value)
+    }
+
+    private func formatDeviation(_ value: Double, width: CGFloat) -> String {
+        if mode == .percent { return formatSignedPercent(value) }
+        return width < 80 ? formatSignedShortChf(value) : formatSignedChf(value)
     }
 
 }
@@ -429,9 +476,11 @@ struct DeviationBar: View {
         return (actual - target) / target * 100
     }
 
+    private var track: CGFloat { trackWidth - 24 }
+
     private var span: CGFloat {
         let mag = min(abs(diffPercent), 100)
-        return trackWidth * CGFloat(mag) / 100 * 0.5
+        return track * CGFloat(mag) / 100 * 0.5
     }
 
     private var offset: CGFloat {
@@ -442,14 +491,17 @@ struct DeviationBar: View {
 
     var body: some View {
         ZStack {
-            Capsule().fill(.quaternary)
-                .frame(width: trackWidth, height: 6)
-            Rectangle().fill(Color.black.opacity(0.6))
+            Capsule().fill(Color.systemGray5)
+                .frame(height: 6)
+                .padding(.horizontal, 12)
+            Rectangle().fill(Color.black)
                 .frame(width: 1, height: 8)
             Capsule().fill(barColor(diffPercent))
                 .frame(width: span, height: 6)
                 .offset(x: offset)
+                .padding(.horizontal, 12)
         }
+        .frame(width: trackWidth)
     }
 }
 

--- a/DragonShield/Views/DashboardView.swift
+++ b/DragonShield/Views/DashboardView.swift
@@ -36,7 +36,7 @@ struct DashboardView: View {
                 .animation(.easeInOut(duration: 0.2), value: columnCount)
             }
             .onAppear { updateColumns(width: geo.size.width) }
-            .onChange(of: geo.size.width) { updateColumns(width: $0) }
+            .onChange(of: geo.size.width) { _, newValue in updateColumns(width: newValue) }
         }
         .navigationTitle("Dashboard")
         .toolbar {
@@ -49,7 +49,7 @@ struct DashboardView: View {
                 .onDisappear { saveLayout() }
         }
         .onAppear(perform: loadLayout)
-        .onChange(of: tileIDs) {
+        .onChange(of: tileIDs) { _, _ in
             saveLayout()
         }
     }

--- a/DragonShield/helpers/Color+Palette.swift
+++ b/DragonShield/helpers/Color+Palette.swift
@@ -42,4 +42,29 @@ extension Color {
         Color(uiColor: .quaternaryLabel)
         #endif
     }
+
+    /// System gray colours cross-platform
+    static var systemGray4: Color {
+        #if os(macOS)
+        Color(red: 174/255, green: 174/255, blue: 178/255)
+        #else
+        Color(uiColor: .systemGray4)
+        #endif
+    }
+
+    static var systemGray5: Color {
+        #if os(macOS)
+        Color(red: 199/255, green: 199/255, blue: 204/255)
+        #else
+        Color(uiColor: .systemGray5)
+        #endif
+    }
+
+    static var systemGray6: Color {
+        #if os(macOS)
+        Color(red: 239/255, green: 239/255, blue: 244/255)
+        #else
+        Color(uiColor: .systemGray6)
+        #endif
+    }
 }


### PR DESCRIPTION
## Summary
- adjust asset table row layout and deviation label logic
- update changelog entry for UI tweak
- fix caption row overlay compile error
- provide macOS fallback for systemGray colors
- flex asset table columns and abbreviate CHF numbers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885507390348323bc62271a367c0a24