### PR TITLE
feat(ui): improve asset classes table layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Maintain equal margin around Asset-Class table to prevent bleed
 - Optimise Asset Class tile layout and cap deviation bars in Allocation dashboard
 - Add sidebar link to the Kanban board
+- Enhance Asset Classes table with flexible columns, dedicated delta column and sortable headers
 - Reorganize sidebar navigation with expandable sections and remove old transaction links
 - Combine Currencies and FX Rates maintenance into one tabbed view
 - Rework Asset Classes card header with inline picker


### PR DESCRIPTION
## Summary
- improve Asset Classes table layout
- keep delta value in its own column
- abbreviate large numbers with k/M
- make columns sortable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688652600068832389715376bdf25b97