### PR TITLE
Polish Asset Allocation table layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Add segmented display mode toggle for Asset Classes tile
+- Polish Asset Allocation table layout with dedicated Δ column and sortable headers
 - Show database schema version in Database Management view and include it in backup file names
 - Polish Crypto Allocations tile visuals and reduce row spacing
 - Redesign Asset Allocation dashboard with modern cards


### PR DESCRIPTION
## Summary
- widen Asset Allocation table columns and add sorting controls
- separate Δ values into their own column
- display short currency numbers in k/M format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688652600068832389715376bdf25b97