### PR TITLE
fix(ui): keep delta column visible in asset table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to this project will be documented in this file.
 - Make Asset-Class table responsive with compact CHF numbers
 - Maintain equal margin around Asset-Class table to prevent bleed
 - Optimise Asset Class tile layout and cap deviation bars in Allocation dashboard
+- Add fixed Δ column and abbreviated numbers in Asset Classes table
+- Fix Δ column layout to stay visible within Asset Classes card
 - Add sidebar link to the Kanban board
 - Reorganize sidebar navigation with expandable sections and remove old transaction links
 - Combine Currencies and FX Rates maintenance into one tabbed view


### PR DESCRIPTION
## Summary
- ensure name column never yields a negative width
- update changelog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688652600068832389715376bdf25b97