### PR TITLE
feat(python): parse dates with python-dateutil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 - Add segmented display mode toggle for Asset Classes tile
 - Show database schema version in Database Management view and include it in backup file names
+- Parse statement and cell dates with `python-dateutil`
 - Polish Crypto Allocations tile visuals and reduce row spacing
 - Redesign Asset Allocation dashboard with modern cards
 - Fix compile errors in Asset Allocation dashboard views

--- a/DragonShield/python_scripts/credit_suisse_parser.py
+++ b/DragonShield/python_scripts/credit_suisse_parser.py
@@ -13,6 +13,7 @@ import os
 import csv
 import sqlite3
 from datetime import datetime
+from dateutil.parser import parse as parse_date
 from typing import Dict, Tuple, Any, List, Set, Optional
 from openpyxl.cell import Cell, MergedCell # Import Cell types for isinstance checks
 
@@ -82,6 +83,10 @@ def parse_statement_date_from_filename(filename: str) -> Optional[str]:
         if month:
             try: return datetime(int(year), month, int(day)).strftime('%Y-%m-%d')
             except Exception: pass
+    try:
+        return parse_date(filename, dayfirst=True).date().isoformat()
+    except Exception:
+        pass
     return None
 
 def parse_date_from_excel_cell(cell_content: Any, input_format: Optional[str] = None) -> Optional[str]:
@@ -103,6 +108,10 @@ def parse_date_from_excel_cell(cell_content: Any, input_format: Optional[str] = 
         if len(cell_str) >= 10 and cell_str[4] == '-' and cell_str[7] == '-': # YYYY-MM-DD or longer
             try: return datetime.strptime(cell_str[:10], '%Y-%m-%d').strftime('%Y-%m-%d')
             except ValueError: pass
+        try:
+            return parse_date(cell_str, dayfirst=True).date().isoformat()
+        except Exception:
+            pass
         # print(f"Warning: Could not parse date string '{cell_str}' to YYYY-MM-DD") # Reduce noise
     return None
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ DragonShield/
    pip install -r requirements.txt
    ```
    All required packages are listed in `requirements.txt`.
+   The list now includes `python-dateutil` for more flexible date parsing.
 
 5. **Generate the local database**
    ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ openpyxl
 pdfplumber
 openai
 jsonschema
+python-dateutil

--- a/tests/test_dateutil_parsing.py
+++ b/tests/test_dateutil_parsing.py
@@ -1,0 +1,10 @@
+from DragonShield.python_scripts.credit_suisse_parser import parse_date_from_excel_cell, parse_statement_date_from_filename
+
+
+def test_parse_flexible_date_from_cell():
+    assert parse_date_from_excel_cell("20 Aug 2025") == "2025-08-20"
+    assert parse_date_from_excel_cell("August 5, 2024") == "2024-08-05"
+
+
+def test_parse_flexible_date_from_filename():
+    assert parse_statement_date_from_filename("statement_Aug-15-2023.pdf") == "2023-08-15"


### PR DESCRIPTION
## Summary
- add python-dateutil to dependencies
- document new dependency in README
- parse dates with dateutil in `credit_suisse_parser`
- test flexible date parsing using python-dateutil
- note new changelog entry

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openpyxl'; ModuleNotFoundError: No module named 'dateutil')*

------
https://chatgpt.com/codex/tasks/task_e_688755a1b54c83238f7c43e7964032b8