### PR TITLE
feat: resizable asset allocation columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Add segmented display mode toggle for Asset Classes tile
+- Make Asset Class Allocation table columns resizable and rename card title
 - Show database schema version in Database Management view and include it in backup file names
 - Polish Crypto Allocations tile visuals and reduce row spacing
 - Redesign Asset Allocation dashboard with modern cards


### PR DESCRIPTION
## Summary
- rename Asset Class card title
- allow Asset Allocation columns to be resized
- persist column widths in user defaults
- adjust deviation bar padding

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688758e320248323a4fa00be612c8cc5