### PR TITLE
Implement resizable columns for allocation table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Polish Crypto Allocations tile visuals and reduce row spacing
 - Redesign Asset Allocation dashboard with modern cards
 - Fix compile errors in Asset Allocation dashboard views
+- Allow resizing Asset Class Allocation table columns with persistence
 - Fix caption row overlay placement in Asset Allocation table
 - Redesign overview bar layout with dedicated tiles
 - Fix color scheme handling in overview bar and card components

--- a/DragonShield/helpers/UserDefaultsKeys.swift
+++ b/DragonShield/helpers/UserDefaultsKeys.swift
@@ -21,4 +21,6 @@ struct UserDefaultsKeys {
     static let positionsFontSize = "positionsFontSize"
     /// Persist selected segment in Currencies & FX maintenance view.
     static let currenciesFxSegment = "currenciesFxSegment"
+    /// Persist custom column widths in Asset Allocation table.
+    static let allocationColumnWidths = "ui.assetAllocation.columnWidths"
 }


### PR DESCRIPTION
## Summary
- rename Asset Classes card to **Asset Class Allocation**
- allow resizing all five columns with per-user persistence
- add reset button next to display mode toggle
- store widths in `UserDefaults`
- update changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688758e320248323a4fa00be612c8cc5