### PR TITLE
Enable resizable allocation columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Add segmented display mode toggle for Asset Classes tile
+- Allow resizing Asset Class Allocation columns with persisted widths
 - Show database schema version in Database Management view and include it in backup file names
 - Polish Crypto Allocations tile visuals and reduce row spacing
 - Redesign Asset Allocation dashboard with modern cards

--- a/DragonShield/helpers/UserDefaultsKeys.swift
+++ b/DragonShield/helpers/UserDefaultsKeys.swift
@@ -19,6 +19,7 @@ struct UserDefaultsKeys {
     static let backupDirectoryBookmark = "backupDirectoryBookmark"
     static let positionsVisibleColumns = "positionsVisibleColumns"
     static let positionsFontSize = "positionsFontSize"
+    static let allocationColumnWidths = "ui.assetAllocation.columnWidths"
     /// Persist selected segment in Currencies & FX maintenance view.
     static let currenciesFxSegment = "currenciesFxSegment"
 }


### PR DESCRIPTION
## Summary
- allow resizing columns in the Asset Class Allocation table and persist widths
- rename the card title to "Asset Class Allocation" and add reset control

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688758e320248323a4fa00be612c8cc5