### PR TITLE
Enable resizable columns for Asset Class Allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ All notable changes to this project will be documented in this file.
 - Fix Δ column layout to stay visible within Asset Classes card
 - Shrink table padding and correct column widths to keep Δ column visible
 - Add sidebar link to the Kanban board
+- Asset Class Allocation columns now resizable with persistent widths
+- Fix build errors in column resizing logic
+- Fix cross-platform compile issue with column grip cursor style by importing AppKit
 - Reorganize sidebar navigation with expandable sections and remove old transaction links
 - Combine Currencies and FX Rates maintenance into one tabbed view
 - Rework Asset Classes card header with inline picker


### PR DESCRIPTION
## Summary
- rename Asset Allocation card title to **Asset Class Allocation**
- allow resizing all table columns with drag grips
- persist column widths in user defaults and add reset button
- adjust deviation bar width calculation
- wrap column grip pointer style in macOS only
- fix cross-platform compile issue with column grip cursor style by importing AppKit

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688758e320248323a4fa00be612c8cc5