### PR TITLE
Add Asset Class allocation column UI spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -429,3 +429,4 @@ All notable changes to this project will be documented in this file.
 - Tweak Asset Allocation rows with caption header and uniform deviation bars
 - Enhance deviation column with centre line, delta numbers and action icons
 - Add target_kind and tolerance_percent columns to TargetAllocation table
+- Document Asset Class Allocation column UI specification

--- a/DragonShield/docs/UX_UI_concept/asset_class_allocation_column_ui_spec.md
+++ b/DragonShield/docs/UX_UI_concept/asset_class_allocation_column_ui_spec.md
@@ -1,0 +1,48 @@
+# Asset Class Allocation – Column UI Specification
+
+This document defines the user interface behaviour for the Asset Class allocation table. The specification focuses on column order, resizing and proportional scaling when the canvas changes size.
+
+## 1. Column headers & order
+- First header: **"Asset Class"**
+- Fixed order (left → right) that cannot be dragged:
+  1. Asset Class
+  2. Target
+  3. Actual
+  4. Deviation Bar
+  5. Δ Deviation
+- Persist the order and individual column widths in `ui.assetAllocation.columnMeta` as JSON:
+  ```json
+  {
+    "order": ["name", "target", "actual", "bar", "deltaVal"],
+    "widths": { "name": 160, "target": 90, "actual": 90, "bar": 200, "deltaVal": 80 }
+  }
+  ```
+- If the stored order differs from the list above, discard and regenerate with defaults.
+
+## 2. Manual column‑width resizing
+- Each header shows a 6 px vertical grip on its right edge.
+- Dragging a grip adjusts only that column; the new width is stored immediately in `columnMeta.widths`.
+
+## 3. Auto‑proportional scaling on canvas resize
+- Listen to the Asset Class canvas `frameDidResize` event.
+- Compute the change in inner content width (new − old).
+- Distribute the delta across **all resizable columns proportionally** to their current widths:
+  ```pseudo
+  for each col:
+      newWidth[col] = oldWidth[col] + Δ * (oldWidth[col] / totalOldWidth)
+  ```
+- Update the header and cell layout in one pass to avoid flicker.
+- Persist the updated `columnMeta.widths` set.
+
+## 4. Visual / interaction checklist
+- Header displays: *Asset Class | Target | Actual | Deviation | Δ*
+- Sorting chevrons remain only on *Target* and *Actual*.
+- Column order never changes; widths adjust smoothly when users drag a grip or the canvas size changes.
+- Minimum width safeguards:
+  - Name ≥ 120 px
+  - Numeric columns ≥ 60 px
+  - Bar ≥ 120 px
+  - Clamp proportionally if limits are reached.
+
+## 5. Scope
+- Pure front‑end/view change. No backend logic or data schema modifications are required.


### PR DESCRIPTION
## Summary
- document column order and resizing behavior for Asset Class Allocation table
- record change in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688772f615bc8323aa6e4f7a07bbe706