### PR TITLE
Implement asset class header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Add "Asset Class" header and remove sort chevron from Δ column
 - Add segmented display mode toggle for Asset Classes tile
 - Show database schema version in Database Management view and include it in backup file names
 - Polish Crypto Allocations tile visuals and reduce row spacing

--- a/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
+++ b/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
@@ -313,7 +313,9 @@ struct AllocationTreeCard: View {
 
         var body: some View {
             HStack(spacing: gap) {
-                Spacer().frame(width: nameWidth + 16)
+                Text("Asset Class")
+                    .font(.caption2.weight(.semibold))
+                    .frame(width: nameWidth + 16, alignment: .leading)
                 sortHeader("TARGET", column: .target)
                     .frame(width: targetWidth, alignment: .trailing)
                 sortHeader("ACTUAL", column: .actual)
@@ -323,7 +325,8 @@ struct AllocationTreeCard: View {
                     .foregroundStyle(.secondary)
                     .frame(width: trackWidth, alignment: .center)
                     .lineLimit(1)
-                sortHeader("\u{0394}", column: .delta)
+                Text("\u{0394}")
+                    .font(.caption2.weight(.semibold))
                     .frame(width: deltaWidth, alignment: .trailing)
             }
             .padding(.vertical, 4)

--- a/DragonShield/helpers/UserDefaultsKeys.swift
+++ b/DragonShield/helpers/UserDefaultsKeys.swift
@@ -21,4 +21,6 @@ struct UserDefaultsKeys {
     static let positionsFontSize = "positionsFontSize"
     /// Persist selected segment in Currencies & FX maintenance view.
     static let currenciesFxSegment = "currenciesFxSegment"
+    /// Persist Asset Allocation column order and widths.
+    static let assetAllocationColumnMeta = "ui.assetAllocation.columnMeta"
 }


### PR DESCRIPTION
## Summary
- add Asset Class column header in allocation table
- document UI change in changelog
- define key for future allocation column preferences

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688772f615bc8323aa6e4f7a07bbe706