### PR TITLE
feat: target kind bullet UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -430,3 +430,4 @@ All notable changes to this project will be documented in this file.
 - Tweak Asset Allocation rows with caption header and uniform deviation bars
 - Enhance deviation column with centre line, delta numbers and action icons
 - Add target_kind and tolerance_percent columns to TargetAllocation table
+- Indicate stored target_kind with a bullet when display mode matches

--- a/DragonShield/DatabaseManager+PortfolioTargets.swift
+++ b/DragonShield/DatabaseManager+PortfolioTargets.swift
@@ -129,9 +129,23 @@ extension DatabaseManager {
     // MARK: - New persistence helpers
 
     /// Returns stored target percentages aggregated by asset class or sub-class.
-    func fetchPortfolioTargetRecords(portfolioId: Int) -> [(classId: Int?, subClassId: Int?, percent: Double, amountCHF: Double?, tolerance: Double)] {
-        var results: [(classId: Int?, subClassId: Int?, percent: Double, amountCHF: Double?, tolerance: Double)] = []
-        let query = "SELECT asset_class_id, sub_class_id, COALESCE(target_percent,0), target_amount_chf, tolerance_percent FROM TargetAllocation;"
+    func fetchPortfolioTargetRecords(portfolioId: Int) -> [(
+        classId: Int?,
+        subClassId: Int?,
+        percent: Double,
+        amountCHF: Double?,
+        targetKind: String,
+        tolerance: Double
+    )] {
+        var results: [(
+            classId: Int?,
+            subClassId: Int?,
+            percent: Double,
+            amountCHF: Double?,
+            targetKind: String,
+            tolerance: Double
+        )] = []
+        let query = "SELECT asset_class_id, sub_class_id, COALESCE(target_percent,0), target_amount_chf, target_kind, tolerance_percent FROM TargetAllocation;"
         var statement: OpaquePointer?
         if sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK {
             while sqlite3_step(statement) == SQLITE_ROW {
@@ -139,8 +153,14 @@ extension DatabaseManager {
                 let subId = sqlite3_column_type(statement, 1) == SQLITE_NULL ? nil : Int(sqlite3_column_int(statement, 1))
                 let pct = sqlite3_column_double(statement, 2)
                 let amount = sqlite3_column_type(statement, 3) == SQLITE_NULL ? nil : sqlite3_column_double(statement, 3)
-                let tolerance = sqlite3_column_double(statement, 4)
-                results.append((classId: classId, subClassId: subId, percent: pct, amountCHF: amount, tolerance: tolerance))
+                let kind = String(cString: sqlite3_column_text(statement, 4))
+                let tolerance = sqlite3_column_double(statement, 5)
+                results.append((classId: classId,
+                                subClassId: subId,
+                                percent: pct,
+                                amountCHF: amount,
+                                targetKind: kind,
+                                tolerance: tolerance))
             }
         } else {
             LoggingService.shared.log("Failed to prepare fetchPortfolioTargetRecords: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)

--- a/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
+++ b/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
@@ -426,6 +426,11 @@ struct AssetRow: View {
         mode == .percent ? node.targetPct : node.targetChf
     }
 
+    private var showBullet: Bool {
+        (mode == .percent && node.targetKind == .percent) ||
+        (mode == .chf && node.targetKind == .amount)
+    }
+
     private var actual: Double {
         mode == .percent ? node.actualPct : node.actualChf
     }
@@ -467,10 +472,18 @@ struct AssetRow: View {
             }
             .frame(width: max(0, nameWidth - 16), alignment: .leading)
 
-            Text(formatValue(target))
-                .frame(width: targetWidth, alignment: .trailing)
-                .font(node.children != nil ? .body.bold() : .subheadline)
-                .lineLimit(1)
+            HStack(spacing: 2) {
+                Text(formatValue(target))
+                if showBullet {
+                    Text("\u{25CF}")
+                        .font(.system(size: 7))
+                        .foregroundStyle(.primary)
+                }
+            }
+            .alignmentGuide(.trailing) { d in d[.trailing] }
+            .frame(width: targetWidth, alignment: .trailing)
+            .font(node.children != nil ? .body.bold() : .subheadline)
+            .lineLimit(1)
             Text(formatValue(actual))
                 .frame(width: actualWidth, alignment: .trailing)
                 .font(node.children != nil ? .body.bold() : .subheadline)


### PR DESCRIPTION
## Summary
- show target_kind bullet when current display mode matches row
- expose target_kind from database
- plumb targetKind into allocation dashboard model
- document bullet indicator in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887784b6ee08323bd7f3e93998d03d1