### PR TITLE
docs: add test usage instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -431,3 +431,4 @@ All notable changes to this project will be documented in this file.
 - Enhance deviation column with centre line, delta numbers and action icons
 - Add target_kind and tolerance_percent columns to TargetAllocation table
 - Indicate stored target_kind with a bullet when display mode matches
+- Document unit test usage in README

--- a/README.md
+++ b/README.md
@@ -146,6 +146,26 @@ python3 python_scripts/gpt_shell.py call echo '{"text": "hello"}'
 
 At present the application must be run from Xcode. Future releases will ship a signed & notarized .app bundle.
 
+### Running Unit Tests
+
+1. Activate the virtual environment if you haven't already:
+
+   ```bash
+   source .venv/bin/activate
+   ```
+
+2. Install the test runner:
+
+   ```bash
+   pip install pytest
+   ```
+
+3. Execute all tests from the project root:
+
+   ```bash
+   pytest
+   ```
+
 ## 🛠 Troubleshooting
 
 See [docs/troubleshooting.md](docs/troubleshooting.md) for solutions to common issues. This includes the harmless


### PR DESCRIPTION
## Summary
- document how to run the unit test suite in the README
- note the change in the changelog

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6887800a9d2c832393fe84efab6b3d0a