### PR TITLE
Add auto-balance helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Add auto-balance utility for allocation editing
 - Add segmented display mode toggle for Asset Classes tile
 - Show database schema version in Database Management view and include it in backup file names
 - Polish Crypto Allocations tile visuals and reduce row spacing

--- a/DragonShield/python_scripts/auto_balance.py
+++ b/DragonShield/python_scripts/auto_balance.py
@@ -1,0 +1,36 @@
+from typing import List
+
+
+def auto_balance(values: List[float], locked: List[bool], total: float = 100.0, precision: float = 0.1) -> List[float]:
+    """Return new values auto-balanced to match total.
+
+    Parameters
+    ----------
+    values : List[float]
+        Current values of the child items.
+    locked : List[bool]
+        True for locked items that should not change.
+    total : float, optional
+        Desired total sum for all values, by default 100.0.
+    precision : float, optional
+        Rounding precision, by default 0.1.
+    """
+    if len(values) != len(locked):
+        raise ValueError("values and locked must have same length")
+
+    remainder = total - sum(values)
+    unlocked_indices = [i for i, l in enumerate(locked) if not l]
+    if not unlocked_indices:
+        return values
+
+    share = remainder / len(unlocked_indices)
+    new_values = values.copy()
+    for idx in unlocked_indices:
+        new_values[idx] += share
+        new_values[idx] = round(new_values[idx] / precision) * precision
+
+    diff = total - sum(new_values)
+    if unlocked_indices:
+        last = unlocked_indices[-1]
+        new_values[last] = round((new_values[last] + diff) / precision) * precision
+    return new_values

--- a/tests/test_auto_balance.py
+++ b/tests/test_auto_balance.py
@@ -1,0 +1,29 @@
+from DragonShield.python_scripts.auto_balance import auto_balance
+
+
+def test_auto_balance_percent():
+    values = [40.0, 30.0, 20.0]
+    locked = [False, False, False]
+    result = auto_balance(values, locked, total=100.0, precision=0.1)
+    assert round(sum(result), 1) == 100.0
+
+
+def test_auto_balance_under_allocated():
+    values = [30.0, 30.0, 30.0]
+    locked = [False, False, False]
+    result = auto_balance(values, locked, total=100.0, precision=0.1)
+    assert round(sum(result), 1) == 100.0
+
+
+def test_auto_balance_over_allocated():
+    values = [50.0, 30.0, 30.0]
+    locked = [False, False, False]
+    result = auto_balance(values, locked, total=100.0, precision=0.1)
+    assert round(sum(result), 1) == 100.0
+
+
+def test_auto_balance_chf():
+    values = [50000.0, 30000.0, 10000.0]
+    locked = [False, True, False]
+    result = auto_balance(values, locked, total=100000.0, precision=1.0)
+    assert int(sum(result)) == 100000


### PR DESCRIPTION
## Summary
- implement `auto_balance` algorithm for rebalancing child target amounts
- cover percent and CHF paths in tests
- document new helper in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887800a9d2c832393fe84efab6b3d0a