### PR TITLE
Add Target Allocation edit panel spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 - Show database schema version in Database Management view and include it in backup file names
 - Polish Crypto Allocations tile visuals and reduce row spacing
 - Redesign Asset Allocation dashboard with modern cards
+- Document Target Allocation edit panel workflow
+- Implement side-panel editor for Asset Class targets with auto-balance
 - Fix compile errors in Asset Allocation dashboard views
 - Fix caption row overlay placement in Asset Allocation table
 - Redesign overview bar layout with dedicated tiles

--- a/DragonShield/DatabaseManager+PortfolioTargets.swift
+++ b/DragonShield/DatabaseManager+PortfolioTargets.swift
@@ -170,13 +170,18 @@ extension DatabaseManager {
     }
 
     /// Upsert a class-level target percentage.
-    func upsertClassTarget(portfolioId: Int, classId: Int, percent: Double, amountChf: Double? = nil) {
+    func upsertClassTarget(portfolioId: Int,
+                           classId: Int,
+                           percent: Double,
+                           amountChf: Double? = nil,
+                           kind: AllocationInputMode = .percent) {
         let query = """
-            INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, updated_at)
-            VALUES (?, NULL, ?, ?, CURRENT_TIMESTAMP)
+            INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, updated_at)
+            VALUES (?, NULL, ?, ?, ?, CURRENT_TIMESTAMP)
             ON CONFLICT(asset_class_id, sub_class_id)
             DO UPDATE SET target_percent = excluded.target_percent,
                          target_amount_chf = excluded.target_amount_chf,
+                         target_kind = excluded.target_kind,
                          updated_at = CURRENT_TIMESTAMP;
         """
         var statement: OpaquePointer?
@@ -188,6 +193,7 @@ extension DatabaseManager {
             } else {
                 sqlite3_bind_null(statement, 3)
             }
+            sqlite3_bind_text(statement, 4, kind.rawValue, -1, SQLITE_TRANSIENT)
             if sqlite3_step(statement) != SQLITE_DONE {
                 LoggingService.shared.log("Failed to upsert class target: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
             }
@@ -198,13 +204,18 @@ extension DatabaseManager {
     }
 
     /// Upsert a sub-class-level target percentage.
-    func upsertSubClassTarget(portfolioId: Int, subClassId: Int, percent: Double, amountChf: Double? = nil) {
+    func upsertSubClassTarget(portfolioId: Int,
+                              subClassId: Int,
+                              percent: Double,
+                              amountChf: Double? = nil,
+                              kind: AllocationInputMode = .percent) {
         let query = """
-            INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, updated_at)
-            VALUES ((SELECT class_id FROM AssetSubClasses WHERE sub_class_id = ?), ?, ?, ?, CURRENT_TIMESTAMP)
+            INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, updated_at)
+            VALUES ((SELECT class_id FROM AssetSubClasses WHERE sub_class_id = ?), ?, ?, ?, ?, CURRENT_TIMESTAMP)
             ON CONFLICT(asset_class_id, sub_class_id)
             DO UPDATE SET target_percent = excluded.target_percent,
                          target_amount_chf = excluded.target_amount_chf,
+                         target_kind = excluded.target_kind,
                          updated_at = CURRENT_TIMESTAMP;
         """
         var statement: OpaquePointer?
@@ -217,6 +228,7 @@ extension DatabaseManager {
             } else {
                 sqlite3_bind_null(statement, 4)
             }
+            sqlite3_bind_text(statement, 5, kind.rawValue, -1, SQLITE_TRANSIENT)
             if sqlite3_step(statement) != SQLITE_DONE {
                 LoggingService.shared.log("Failed to upsert sub-class target: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
             }

--- a/DragonShield/Views/TargetAllocationEditPanel.swift
+++ b/DragonShield/Views/TargetAllocationEditPanel.swift
@@ -1,0 +1,159 @@
+import SwiftUI
+
+struct TargetAllocationEditPanel: View {
+    @EnvironmentObject var dbManager: DatabaseManager
+    @Environment(\.dismiss) private var dismiss
+
+    let classId: Int
+    let className: String
+
+    @State private var mode: AllocationInputMode = .percent
+    @State private var targetValue: Double = 0
+    @State private var subTargets: [SubRow] = []
+
+    struct SubRow: Identifiable {
+        let id: Int
+        let name: String
+        var value: Double
+        var locked: Bool = false
+    }
+
+    private var remaining: Double {
+        let sum = subTargets.map(\.value).reduce(0, +)
+        if mode == .percent {
+            return 100 - sum
+        }
+        return targetValue - sum
+    }
+
+    private var canSave: Bool { abs(remaining) < 0.1 }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Button("Back") { dismiss() }
+                Spacer()
+                Text("Edit targets — \(className)")
+                    .font(.headline)
+                Spacer()
+            }
+            Divider()
+            Picker("Target Kind", selection: $mode) {
+                Text("%").tag(AllocationInputMode.percent)
+                Text("CHF").tag(AllocationInputMode.chf)
+            }
+            .pickerStyle(.segmented)
+            HStack {
+                Text("Target Value")
+                TextField("", value: $targetValue, formatter: numberFormatter)
+                    .frame(width: 80)
+                Text(mode == .percent ? "%" : "CHF")
+            }
+            Divider()
+            Text("Sub-Class Targets")
+                .font(.subheadline)
+            ForEach($subTargets) { $row in
+                HStack {
+                    Text(row.name)
+                        .frame(width: 160, alignment: .leading)
+                    TextField("", value: $row.value, formatter: numberFormatter)
+                        .frame(width: 80, alignment: .trailing)
+                }
+            }
+            Text(String(format: "Remaining to allocate: %.1f %@",
+                         remaining,
+                         mode == .percent ? "%" : "CHF"))
+                .foregroundColor(canSave ? .secondary : .red)
+            HStack {
+                Button("Auto-balance") { autoBalance() }
+                Spacer()
+                Button("Cancel") { dismiss() }
+                Button("Save") { save() }
+                    .disabled(!canSave)
+            }
+        }
+        .padding()
+        .frame(width: 360)
+        .onAppear { load() }
+    }
+
+    private var numberFormatter: NumberFormatter {
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        f.maximumFractionDigits = 1
+        return f
+    }
+
+    private func load() {
+        let rows = dbManager.fetchPortfolioTargetRecords(portfolioId: 1)
+        if let classRow = rows.first(where: { $0.classId == classId && $0.subClassId == nil }) {
+            targetValue = classRow.amountCHF ?? classRow.percent
+            mode = AllocationInputMode(rawValue: classRow.targetKind) ?? .percent
+        }
+        subTargets = dbManager.subAssetClasses(for: classId).map { sub in
+            let row = rows.first(where: { $0.subClassId == sub.id })
+            let val = row?.amountCHF ?? row?.percent ?? 0
+            return SubRow(id: sub.id, name: sub.name, value: val)
+        }
+    }
+
+    private func autoBalance() {
+        var unlockedIndices: [Int] = []
+        for (idx, row) in subTargets.enumerated() where !row.locked {
+            unlockedIndices.append(idx)
+        }
+        guard !unlockedIndices.isEmpty else { return }
+        let share = remaining / Double(unlockedIndices.count)
+        for idx in unlockedIndices {
+            subTargets[idx].value += share
+            subTargets[idx].value = (subTargets[idx].value * 10).rounded() / 10
+        }
+        let drift: Double
+        if mode == .percent {
+            drift = 100 - subTargets.map(\.value).reduce(0, +)
+        } else {
+            drift = targetValue - subTargets.map(\.value).reduce(0, +)
+        }
+        if let last = unlockedIndices.last {
+            subTargets[last].value += drift
+        }
+    }
+
+    private func save() {
+        if mode == .percent {
+            dbManager.upsertClassTarget(portfolioId: 1,
+                                        classId: classId,
+                                        percent: targetValue,
+                                        amountChf: nil,
+                                        kind: mode)
+            for row in subTargets {
+                dbManager.upsertSubClassTarget(portfolioId: 1,
+                                               subClassId: row.id,
+                                               percent: row.value,
+                                               amountChf: nil,
+                                               kind: mode)
+            }
+        } else {
+            dbManager.upsertClassTarget(portfolioId: 1,
+                                        classId: classId,
+                                        percent: 0,
+                                        amountChf: targetValue,
+                                        kind: mode)
+            for row in subTargets {
+                dbManager.upsertSubClassTarget(portfolioId: 1,
+                                               subClassId: row.id,
+                                               percent: 0,
+                                               amountChf: row.value,
+                                               kind: mode)
+            }
+        }
+        dismiss()
+    }
+}
+
+struct TargetAllocationEditPanel_Previews: PreviewProvider {
+    static var previews: some View {
+        TargetAllocationEditPanel(classId: 1, className: "Equity")
+            .environmentObject(DatabaseManager())
+    }
+}

--- a/DragonShield/docs/UX_UI_concept/target_allocation_edit_panel.md
+++ b/DragonShield/docs/UX_UI_concept/target_allocation_edit_panel.md
@@ -1,0 +1,64 @@
+# Target Allocation Edit Panel
+
+This document outlines the side‑panel workflow for editing Asset Class targets along with their Sub‑Classes. The goal is a minimal, fool‑proof UI that stores either percentage or CHF values per class, never a mix.
+
+## Core Rules
+1. The parent Asset Class selects **Target Kind** – either percentage (%) or amount in CHF. When Sub‑Classes already exist, the radio buttons are disabled so the kind matches existing children.
+2. Validation differs by kind:
+   - **Percent** – the sum of child percentages must equal `100 %`.
+   - **CHF** – the sum of child CHF amounts must equal the parent amount.
+3. The **Save** button only enables when all panels pass validation.
+4. An optional **Auto‑balance** button distributes any remainder across unlocked rows.
+
+## Layout
+```
+  ◁ Back          Edit targets — [Asset Class]
+  ──────────────────────────────────────────────
+  TARGET KIND     (•) %   ( ) CHF
+  TARGET VALUE    [ 25.0 ] %
+  ──────────────────────────────────────────────
+  SUB‑CLASS TARGETS
+  +----------------------------+-----------+
+  | Sub‑class                  | Target    |
+  +----------------------------+-----------+
+  | Large Cap                  | [ 15.0 ] %|
+  | Small Cap                  | [  5.0 ] %|
+  | Emerging Markets           | [  5.0 ] %|
+  +----------------------------+-----------+
+  Remaining to allocate: 0.0 %
+  ( Auto‑balance )  ( Cancel )  ( Save )
+```
+- The remaining line turns red when non‑zero.
+- Auto‑balance fills the remainder proportionally across editable rows.
+- Save stays disabled until remaining equals zero.
+
+## Validation Logic (pseudo)
+```swift
+if parent.kind == .percent {
+    parentOK = abs(sum(child.percent) - 100.0) < 0.1
+} else {
+    parentOK = abs(sum(child.amount) - parent.amount) < 1.0
+}
+canSave = parentOK && rootOK && allTargetsPositive()
+```
+
+## Auto‑balance Algorithm
+```
+remainder = 100 - Σ currentChildren%
+unlocked = children.filter { !isLocked($0) }
+share = remainder / unlocked.count
+for row in unlocked { row.value += share }
+round rows to 0.1 precision
+adjust last row to remove rounding drift
+```
+
+The CHF path works identically using money units.
+
+## Edge Cases
+1. Parent in CHF 1 000 000, children total 950 000 → Remaining −50 000 CHF.
+   - Save disabled, Remaining turns red, Auto‑balance distributes 50 000 CHF.
+2. Parent in %; user edits Large Cap from 15.0 → 20.0.
+   - Remaining shows −5.0 % until another row decreases by 5.0 %.
+3. User switches kind from % → CHF while children exist.
+   - Radio buttons are locked with a tooltip stating the kind is fixed by existing children.
+```

--- a/DragonShield/python_scripts/auto_balance.py
+++ b/DragonShield/python_scripts/auto_balance.py
@@ -1,0 +1,45 @@
+"""Helpers for target auto-balance logic."""
+
+from typing import List, Optional
+
+
+def auto_balance(values: List[float], locked: Optional[List[bool]] = None,
+                 target: float = 100.0, precision: float = 0.1) -> List[float]:
+    """Distribute the remainder across unlocked values.
+
+    Parameters
+    ----------
+    values : list of floats
+        Current target values.
+    locked : list of bools, optional
+        True for rows that should not be modified.
+    target : float
+        Desired total of the values.
+    precision : float
+        Rounding increment for each value.
+
+    Returns
+    -------
+    list of floats
+        New values after auto-balancing.
+    """
+    if locked is None:
+        locked = [False] * len(values)
+    if len(locked) != len(values):
+        raise ValueError("locked length must match values length")
+
+    unlocked_indices = [i for i, l in enumerate(locked) if not l]
+    if not unlocked_indices:
+        return values
+
+    remainder = target - sum(values)
+    share = remainder / len(unlocked_indices)
+
+    updated = values[:]
+    for idx in unlocked_indices:
+        updated[idx] += share
+    updated = [round(v / precision) * precision for v in updated]
+
+    diff = target - sum(updated)
+    updated[unlocked_indices[-1]] += diff
+    return updated

--- a/tests/test_auto_balance.py
+++ b/tests/test_auto_balance.py
@@ -1,0 +1,13 @@
+from DragonShield.python_scripts.auto_balance import auto_balance
+
+
+def test_auto_balance_basic():
+    result = auto_balance([15.0, 5.0, 5.0])
+    assert abs(sum(result) - 100.0) < 1e-6
+    assert all(v >= 0 for v in result)
+
+
+def test_auto_balance_locked():
+    result = auto_balance([50.0, 20.0, 20.0], locked=[True, False, False])
+    assert result[0] == 50.0
+    assert abs(sum(result) - 100.0) < 1e-6


### PR DESCRIPTION
## Summary
- document the new Target Allocation side-panel workflow
- note the specification in the changelog
- implement Target Allocation side-panel with auto-balance algorithm

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887800a9d2c832393fe84efab6b3d0a