### PR TITLE
Add Target Allocation edit panel spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 - Show database schema version in Database Management view and include it in backup file names
 - Polish Crypto Allocations tile visuals and reduce row spacing
 - Redesign Asset Allocation dashboard with modern cards
+- Document Target Allocation edit panel workflow
+- Implement side-panel editor for Asset Class targets with auto-balance
 - Fix compile errors in Asset Allocation dashboard views
 - Fix caption row overlay placement in Asset Allocation table
 - Redesign overview bar layout with dedicated tiles

--- a/DragonShield/Views/EditPanels/TargetAllocationEditPanel.swift
+++ b/DragonShield/Views/EditPanels/TargetAllocationEditPanel.swift
@@ -1,0 +1,190 @@
+import SwiftUI
+
+struct SubTargetInput: Identifiable {
+    let id: Int
+    let name: String
+    var value: Double
+}
+
+final class TargetAllocationEditorModel: ObservableObject {
+    @Published var kind: AllocationInputMode = .percent
+    @Published var targetValue: Double = 0
+    @Published var subTargets: [SubTargetInput] = []
+    @Published var className: String = ""
+    @Published var kindLocked = false
+
+    private let classId: Int
+    private unowned let db: DatabaseManager
+    private let portfolioId: Int = 1
+
+    init(classId: Int, db: DatabaseManager) {
+        self.classId = classId
+        self.db = db
+        load()
+    }
+
+    func load() {
+        className = db.fetchAssetClassDetails(id: classId)?.name ?? ""
+        subTargets = db.subAssetClasses(for: classId).map {
+            SubTargetInput(id: $0.id, name: $0.name, value: 0)
+        }
+        for row in db.fetchPortfolioTargetRecords(portfolioId: portfolioId) {
+            if row.classId == classId && row.subClassId == nil {
+                targetValue = row.amountCHF ?? row.percent
+                kind = AllocationInputMode(rawValue: row.targetKind) ?? .percent
+            }
+            if let subId = row.subClassId, row.classId == classId {
+                if let idx = subTargets.firstIndex(where: { $0.id == subId }) {
+                    subTargets[idx].value = row.amountCHF ?? row.percent
+                }
+            }
+        }
+        kindLocked = !subTargets.isEmpty
+    }
+
+    private var tolerance: Double { kind == .percent ? 0.1 : 1.0 }
+
+    var remainder: Double {
+        let sum = subTargets.map { $0.value }.reduce(0, +)
+        return kind == .percent ? 100 - sum : targetValue - sum
+    }
+
+    var canSave: Bool { abs(remainder) <= tolerance }
+
+    func autoBalance() {
+        guard !subTargets.isEmpty else { return }
+        let share = remainder / Double(subTargets.count)
+        for idx in subTargets.indices { subTargets[idx].value += share }
+        if let last = subTargets.indices.last {
+            let sum = subTargets.map { $0.value }.reduce(0, +)
+            let diff = (kind == .percent ? (100 - sum) : (targetValue - sum))
+            subTargets[last].value += diff
+        }
+    }
+
+    func save() {
+        if kind == .percent {
+            db.upsertClassTarget(portfolioId: portfolioId,
+                                  classId: classId,
+                                  percent: targetValue,
+                                  amountChf: nil)
+            for sub in subTargets {
+                db.upsertSubClassTarget(portfolioId: portfolioId,
+                                         subClassId: sub.id,
+                                         percent: sub.value,
+                                         amountChf: nil)
+            }
+        } else {
+            db.upsertClassTarget(portfolioId: portfolioId,
+                                  classId: classId,
+                                  percent: 0,
+                                  amountChf: targetValue)
+            for sub in subTargets {
+                db.upsertSubClassTarget(portfolioId: portfolioId,
+                                         subClassId: sub.id,
+                                         percent: 0,
+                                         amountChf: sub.value)
+            }
+        }
+    }
+
+    func binding(for sub: SubTargetInput) -> Binding<Double> {
+        Binding(
+            get: {
+                subTargets.first(where: { $0.id == sub.id })?.value ?? 0
+            },
+            set: { newVal in
+                if let idx = subTargets.firstIndex(where: { $0.id == sub.id }) {
+                    subTargets[idx].value = newVal
+                }
+            }
+        )
+    }
+}
+
+struct TargetAllocationEditPanel: View {
+    @Environment(\.dismiss) private var dismiss
+    @ObservedObject var model: TargetAllocationEditorModel
+
+    private var percentFormatter: NumberFormatter {
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        f.maximumFractionDigits = 1
+        return f
+    }
+
+    private var chfFormatter: NumberFormatter {
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        f.maximumFractionDigits = 0
+        f.groupingSeparator = "'"
+        f.usesGroupingSeparator = true
+        return f
+    }
+
+    private func format(_ value: Double) -> String {
+        let formatter = model.kind == .percent ? percentFormatter : chfFormatter
+        return formatter.string(from: NSNumber(value: value)) ?? "0"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Button("Back") { dismiss() }
+                Spacer()
+                Text("Edit targets — \(model.className)")
+                Spacer()
+            }
+            Divider()
+            Text("TARGET KIND").font(.caption)
+            Picker("Kind", selection: $model.kind) {
+                Text("%" ).tag(AllocationInputMode.percent)
+                Text("CHF").tag(AllocationInputMode.chf)
+            }
+            .pickerStyle(.radioGroup)
+            .disabled(model.kindLocked)
+            Text("TARGET VALUE").font(.caption)
+            HStack {
+                TextField("", value: $model.targetValue, formatter: model.kind == .percent ? percentFormatter : chfFormatter)
+                    .frame(width: 80)
+                Text(model.kind == .percent ? "%" : "CHF")
+            }
+            Divider()
+            Text("SUB-CLASS TARGETS").font(.caption)
+            ForEach(model.subTargets) { sub in
+                HStack {
+                    Text(sub.name)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    TextField("", value: model.binding(for: sub), formatter: model.kind == .percent ? percentFormatter : chfFormatter)
+                        .frame(width: 80)
+                    Text(model.kind == .percent ? "%" : "CHF")
+                }
+            }
+            Text("Remaining to allocate: \(format(model.remainder)) \(model.kind == .percent ? "%" : "CHF")")
+                .foregroundColor(model.canSave ? .primary : .red)
+                .font(.caption)
+            Divider()
+            HStack {
+                Button("Auto-balance") { model.autoBalance() }
+                Spacer()
+                Button("Cancel") { dismiss() }
+                Button("Save") {
+                    model.save()
+                    dismiss()
+                }
+                .disabled(!model.canSave)
+            }
+        }
+        .padding()
+        .frame(minWidth: 320)
+    }
+}
+
+#if DEBUG
+struct TargetAllocationEditPanel_Previews: PreviewProvider {
+    static var previews: some View {
+        TargetAllocationEditPanel(model: TargetAllocationEditorModel(classId: 1, db: DatabaseManager()))
+            .frame(width: 360)
+    }
+}
+#endif

--- a/DragonShield/docs/UX_UI_concept/target_allocation_edit_panel.md
+++ b/DragonShield/docs/UX_UI_concept/target_allocation_edit_panel.md
@@ -1,0 +1,64 @@
+# Target Allocation Edit Panel
+
+This document outlines the side‑panel workflow for editing Asset Class targets along with their Sub‑Classes. The goal is a minimal, fool‑proof UI that stores either percentage or CHF values per class, never a mix.
+
+## Core Rules
+1. The parent Asset Class selects **Target Kind** – either percentage (%) or amount in CHF. When Sub‑Classes already exist, the radio buttons are disabled so the kind matches existing children.
+2. Validation differs by kind:
+   - **Percent** – the sum of child percentages must equal `100 %`.
+   - **CHF** – the sum of child CHF amounts must equal the parent amount.
+3. The **Save** button only enables when all panels pass validation.
+4. An optional **Auto‑balance** button distributes any remainder across unlocked rows.
+
+## Layout
+```
+  ◁ Back          Edit targets — [Asset Class]
+  ──────────────────────────────────────────────
+  TARGET KIND     (•) %   ( ) CHF
+  TARGET VALUE    [ 25.0 ] %
+  ──────────────────────────────────────────────
+  SUB‑CLASS TARGETS
+  +----------------------------+-----------+
+  | Sub‑class                  | Target    |
+  +----------------------------+-----------+
+  | Large Cap                  | [ 15.0 ] %|
+  | Small Cap                  | [  5.0 ] %|
+  | Emerging Markets           | [  5.0 ] %|
+  +----------------------------+-----------+
+  Remaining to allocate: 0.0 %
+  ( Auto‑balance )  ( Cancel )  ( Save )
+```
+- The remaining line turns red when non‑zero.
+- Auto‑balance fills the remainder proportionally across editable rows.
+- Save stays disabled until remaining equals zero.
+
+## Validation Logic (pseudo)
+```swift
+if parent.kind == .percent {
+    parentOK = abs(sum(child.percent) - 100.0) < 0.1
+} else {
+    parentOK = abs(sum(child.amount) - parent.amount) < 1.0
+}
+canSave = parentOK && rootOK && allTargetsPositive()
+```
+
+## Auto‑balance Algorithm
+```
+remainder = 100 - Σ currentChildren%
+unlocked = children.filter { !isLocked($0) }
+share = remainder / unlocked.count
+for row in unlocked { row.value += share }
+round rows to 0.1 precision
+adjust last row to remove rounding drift
+```
+
+The CHF path works identically using money units.
+
+## Edge Cases
+1. Parent in CHF 1 000 000, children total 950 000 → Remaining −50 000 CHF.
+   - Save disabled, Remaining turns red, Auto‑balance distributes 50 000 CHF.
+2. Parent in %; user edits Large Cap from 15.0 → 20.0.
+   - Remaining shows −5.0 % until another row decreases by 5.0 %.
+3. User switches kind from % → CHF while children exist.
+   - Radio buttons are locked with a tooltip stating the kind is fixed by existing children.
+```


### PR DESCRIPTION
## Summary
- document the new Target Allocation side-panel workflow
- implement side panel editor for Asset Class targets with auto-balance

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887800a9d2c832393fe84efab6b3d0a