### PR TITLE
Add Target Allocation edit panel spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 - Show database schema version in Database Management view and include it in backup file names
 - Polish Crypto Allocations tile visuals and reduce row spacing
 - Redesign Asset Allocation dashboard with modern cards
+- Document Target Allocation edit panel workflow
+- Add side-panel editor to update class targets with auto-balance
 - Fix compile errors in Asset Allocation dashboard views
 - Fix caption row overlay placement in Asset Allocation table
 - Redesign overview bar layout with dedicated tiles

--- a/DragonShield/Views/AllocationDashboard/TargetClassEditPanel.swift
+++ b/DragonShield/Views/AllocationDashboard/TargetClassEditPanel.swift
@@ -1,0 +1,190 @@
+import SwiftUI
+
+/// Side-panel for editing an asset class target and its sub-classes.
+struct TargetClassEditPanel: View {
+    @EnvironmentObject var db: DatabaseManager
+    @Binding var isPresented: Bool
+
+    let assetClassId: Int
+
+    @StateObject private var viewModel: ViewModel
+
+    init(assetClassId: Int, isPresented: Binding<Bool>) {
+        self.assetClassId = assetClassId
+        _isPresented = isPresented
+        _viewModel = StateObject(wrappedValue: ViewModel(classId: assetClassId))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Button("Back") { isPresented = false }
+                Spacer()
+                Text("Edit targets — \(viewModel.className)")
+                    .font(.headline)
+            }
+
+            Picker("Target Kind", selection: $viewModel.targetKind) {
+                Text("%" ).tag(ViewModel.TargetKind.percent)
+                Text("CHF").tag(ViewModel.TargetKind.amount)
+            }
+            .pickerStyle(.segmented)
+            .disabled(viewModel.kindLocked)
+
+            HStack {
+                TextField("", value: $viewModel.targetValue, formatter: viewModel.valueFormatter)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 100)
+                Text(viewModel.unitLabel)
+            }
+
+            Divider()
+
+            List {
+                ForEach($viewModel.children) { $child in
+                    HStack {
+                        Text(child.name)
+                        Spacer()
+                        TextField("", value: $child.value, formatter: viewModel.valueFormatter)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 100)
+                    }
+                }
+            }
+            .listStyle(.plain)
+
+            Text(viewModel.remainingText)
+                .foregroundColor(viewModel.remainingIsZero ? .secondary : .red)
+
+            HStack {
+                Button("Auto-balance") { viewModel.autoBalance() }
+                Spacer()
+                Button("Cancel") { isPresented = false }
+                Button("Save") { viewModel.save(using: db); isPresented = false }
+                    .disabled(!viewModel.canSave)
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 360)
+        .onAppear { viewModel.load(using: db) }
+    }
+}
+
+extension TargetClassEditPanel {
+    final class ViewModel: ObservableObject {
+        enum TargetKind: String { case percent, amount }
+
+        struct Child: Identifiable {
+            let id: Int
+            let name: String
+            var value: Double
+        }
+
+        @Published var className: String = ""
+        @Published var targetKind: TargetKind = .percent
+        @Published var targetValue: Double = 0
+        @Published var children: [Child] = []
+        var kindLocked: Bool = false
+
+        private let classId: Int
+        private let tolerancePct: Double = 0.1
+        private let toleranceChf: Double = 1.0
+
+        init(classId: Int) {
+            self.classId = classId
+        }
+
+        var remaining: Double {
+            let sum = children.reduce(0) { $0 + $1.value }
+            if targetKind == .percent {
+                return 100 - sum
+            } else {
+                return targetValue - sum
+            }
+        }
+
+        var remainingText: String {
+            if targetKind == .percent {
+                return String(format: "Remaining to allocate: %.1f %%", remaining)
+            } else {
+                return String(format: "Remaining to allocate: %.0f CHF", remaining)
+            }
+        }
+
+        var remainingIsZero: Bool {
+            if targetKind == .percent {
+                abs(remaining) < tolerancePct
+            } else {
+                abs(remaining) < toleranceChf
+            }
+        }
+
+        var canSave: Bool { remainingIsZero && children.allSatisfy { $0.value >= 0 } }
+
+        var valueFormatter: NumberFormatter {
+            let f = NumberFormatter()
+            f.numberStyle = .decimal
+            f.maximumFractionDigits = targetKind == .percent ? 1 : 0
+            return f
+        }
+
+        var unitLabel: String { targetKind == .percent ? "%" : "CHF" }
+
+        func load(using db: DatabaseManager) {
+            if let cls = db.fetchAssetClassDetails(id: classId) {
+                className = cls.name
+            }
+            let rows = db.fetchPortfolioTargetRecords(portfolioId: 1)
+            if let row = rows.first(where: { $0.classId == classId && $0.subClassId == nil }) {
+                targetKind = TargetKind(rawValue: row.targetKind) ?? .percent
+                targetValue = targetKind == .percent ? row.percent : (row.amountCHF ?? 0)
+            }
+            children = db.subAssetClasses(for: classId).map { sub in
+                let childRow = rows.first(where: { $0.subClassId == sub.id })
+                let val = targetKind == .percent ? (childRow?.percent ?? 0) : (childRow?.amountCHF ?? 0)
+                return Child(id: sub.id, name: sub.name, value: val)
+            }
+        }
+
+        func autoBalance() {
+            var unlockedIndices = Array(children.indices)
+            guard !unlockedIndices.isEmpty else { return }
+            var remainder = remaining
+            let share = remainder / Double(unlockedIndices.count)
+            for idx in unlockedIndices.dropLast() {
+                children[idx].value += share
+                remainder -= share
+            }
+            if let last = unlockedIndices.last { children[last].value += remainder }
+            if targetKind == .percent {
+                for idx in children.indices {
+                    children[idx].value = (children[idx].value * 10).rounded() / 10
+                }
+            }
+        }
+
+        func save(using db: DatabaseManager) {
+            if targetKind == .percent {
+                db.upsertClassTarget(portfolioId: 1, classId: classId, percent: targetValue)
+                for c in children {
+                    db.upsertSubClassTarget(portfolioId: 1, subClassId: c.id, percent: c.value)
+                }
+            } else {
+                db.upsertClassTarget(portfolioId: 1, classId: classId, percent: 0, amountChf: targetValue)
+                for c in children {
+                    db.upsertSubClassTarget(portfolioId: 1, subClassId: c.id, percent: 0, amountChf: c.value)
+                }
+            }
+        }
+    }
+}
+
+#if DEBUG
+struct TargetClassEditPanel_Previews: PreviewProvider {
+    static var previews: some View {
+        TargetClassEditPanel(assetClassId: 1, isPresented: .constant(true))
+            .environmentObject(DatabaseManager())
+    }
+}
+#endif
+

--- a/DragonShield/docs/UX_UI_concept/target_allocation_edit_panel.md
+++ b/DragonShield/docs/UX_UI_concept/target_allocation_edit_panel.md
@@ -1,0 +1,64 @@
+# Target Allocation Edit Panel
+
+This document outlines the side‑panel workflow for editing Asset Class targets along with their Sub‑Classes. The goal is a minimal, fool‑proof UI that stores either percentage or CHF values per class, never a mix.
+
+## Core Rules
+1. The parent Asset Class selects **Target Kind** – either percentage (%) or amount in CHF. When Sub‑Classes already exist, the radio buttons are disabled so the kind matches existing children.
+2. Validation differs by kind:
+   - **Percent** – the sum of child percentages must equal `100 %`.
+   - **CHF** – the sum of child CHF amounts must equal the parent amount.
+3. The **Save** button only enables when all panels pass validation.
+4. An optional **Auto‑balance** button distributes any remainder across unlocked rows.
+
+## Layout
+```
+  ◁ Back          Edit targets — [Asset Class]
+  ──────────────────────────────────────────────
+  TARGET KIND     (•) %   ( ) CHF
+  TARGET VALUE    [ 25.0 ] %
+  ──────────────────────────────────────────────
+  SUB‑CLASS TARGETS
+  +----------------------------+-----------+
+  | Sub‑class                  | Target    |
+  +----------------------------+-----------+
+  | Large Cap                  | [ 15.0 ] %|
+  | Small Cap                  | [  5.0 ] %|
+  | Emerging Markets           | [  5.0 ] %|
+  +----------------------------+-----------+
+  Remaining to allocate: 0.0 %
+  ( Auto‑balance )  ( Cancel )  ( Save )
+```
+- The remaining line turns red when non‑zero.
+- Auto‑balance fills the remainder proportionally across editable rows.
+- Save stays disabled until remaining equals zero.
+
+## Validation Logic (pseudo)
+```swift
+if parent.kind == .percent {
+    parentOK = abs(sum(child.percent) - 100.0) < 0.1
+} else {
+    parentOK = abs(sum(child.amount) - parent.amount) < 1.0
+}
+canSave = parentOK && rootOK && allTargetsPositive()
+```
+
+## Auto‑balance Algorithm
+```
+remainder = 100 - Σ currentChildren%
+unlocked = children.filter { !isLocked($0) }
+share = remainder / unlocked.count
+for row in unlocked { row.value += share }
+round rows to 0.1 precision
+adjust last row to remove rounding drift
+```
+
+The CHF path works identically using money units.
+
+## Edge Cases
+1. Parent in CHF 1 000 000, children total 950 000 → Remaining −50 000 CHF.
+   - Save disabled, Remaining turns red, Auto‑balance distributes 50 000 CHF.
+2. Parent in %; user edits Large Cap from 15.0 → 20.0.
+   - Remaining shows −5.0 % until another row decreases by 5.0 %.
+3. User switches kind from % → CHF while children exist.
+   - Radio buttons are locked with a tooltip stating the kind is fixed by existing children.
+```


### PR DESCRIPTION
## Summary
- document the new Target Allocation side-panel workflow
- note the specification in the changelog
- implement a TargetClassEditPanel view for editing asset class targets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887800a9d2c832393fe84efab6b3d0a