### PR TITLE
Add Target Allocation edit panel spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 - Show database schema version in Database Management view and include it in backup file names
 - Polish Crypto Allocations tile visuals and reduce row spacing
 - Redesign Asset Allocation dashboard with modern cards
+- Document Target Allocation edit panel workflow
+- Implement side-panel editor for Asset Class targets
+- Activate pencil edit button in Allocation Targets table
+- Place pencil button next to Target column for visibility
 - Fix compile errors in Asset Allocation dashboard views
 - Fix caption row overlay placement in Asset Allocation table
 - Redesign overview bar layout with dedicated tiles

--- a/DragonShield/Views/AllocationTargetsTableView.swift
+++ b/DragonShield/Views/AllocationTargetsTableView.swift
@@ -404,6 +404,7 @@ struct AllocationTargetsTableView: View {
     @State private var showDetails = true
     @State private var showDonut = true
     @State private var showDelta = true
+    @State private var editingClassId: Int?
 
     private let percentFormatter: NumberFormatter = {
         let f = NumberFormatter()
@@ -559,6 +560,16 @@ struct AllocationTargetsTableView: View {
                 .frame(maxWidth: .infinity)
             }
         }
+        .overlay(alignment: .trailing) {
+            if let cid = editingClassId {
+                TargetEditPanel(classId: cid) {
+                    viewModel.load(using: dbManager)
+                    refreshDrafts()
+                    withAnimation { editingClassId = nil }
+                }
+                .environmentObject(dbManager)
+            }
+        }
         .onAppear {
             viewModel.load(using: dbManager)
             refreshDrafts()
@@ -712,10 +723,12 @@ struct AllocationTargetsTableView: View {
         let deltaTol = abs(asset.targetChf) * 0.01
         let aggregateDeltaColor: Color = abs(deltaChf) > deltaTol ? .red : .secondary
 
-        HStack(spacing: 0) {
+        HStack(spacing: 4) {
             Text(asset.name)
                 .fontWeight((abs(asset.targetPct) > 0.0001 || abs(asset.targetChf) > 0.01) ? .bold : .regular)
-                .frame(width: 200, alignment: .leading)
+        }
+        .frame(width: 200, alignment: .leading)
+        HStack(spacing: 0) {
             Divider()
             HStack(alignment: .top, spacing: 0) {
                 Picker("", selection: viewModel.modeBinding(for: asset)) {
@@ -798,6 +811,17 @@ struct AllocationTargetsTableView: View {
                             .frame(width: 100, alignment: .trailing)
                         }
                     }
+                }
+            }
+            .overlay(alignment: .topTrailing) {
+                if isClass {
+                    Button {
+                        if let id = Int(asset.id.dropFirst(6)) { editingClassId = id }
+                    } label: {
+                        Image(systemName: "pencil")
+                    }
+                    .buttonStyle(.borderless)
+                    .padding(.trailing, 4)
                 }
             }
             Divider()

--- a/DragonShield/Views/TargetEditPanel.swift
+++ b/DragonShield/Views/TargetEditPanel.swift
@@ -1,0 +1,149 @@
+import SwiftUI
+
+struct TargetEditPanel: View {
+    @EnvironmentObject var db: DatabaseManager
+    let classId: Int
+    let onClose: () -> Void
+
+    @State private var kind: TargetKind = .percent
+    @State private var parentValue: Double = 0
+    @State private var rows: [Row] = []
+
+    struct Row: Identifiable {
+        let id: Int
+        let name: String
+        var value: Double
+        var locked: Bool = false
+    }
+
+    enum TargetKind: String, CaseIterable { case percent, amount }
+
+    private var total: Double { rows.map(\.value).reduce(0, +) }
+
+    private var remaining: Double {
+        kind == .percent ? (100 - total) : (parentValue - total)
+    }
+
+    private var parentOK: Bool {
+        if kind == .percent {
+            abs(total - 100) < 0.1
+        } else {
+            abs(total - parentValue) < 1.0
+        }
+    }
+
+    private var canSave: Bool { parentOK && parentValue >= 0 && rows.allSatisfy { $0.value >= 0 } }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Button("Back") { onClose() }
+                Spacer()
+                Text("Edit targets")
+                    .font(.headline)
+            }
+            .padding(.bottom)
+
+            HStack {
+                Text("Target Kind")
+                Spacer()
+                Picker("Target Kind", selection: $kind) {
+                    Text("%").tag(TargetKind.percent)
+                    Text("CHF").tag(TargetKind.amount)
+                }
+                .pickerStyle(.radioGroup)
+                .frame(width: 120)
+            }
+
+            HStack {
+                Text("Target Value")
+                Spacer()
+                TextField("", value: $parentValue, formatter: Self.numberFormatter)
+                    .frame(width: 80)
+                    .multilineTextAlignment(.trailing)
+                    .textFieldStyle(.roundedBorder)
+                Text(kind == .percent ? "%" : "CHF")
+            }
+
+            Text("Sub-Class Targets")
+                .font(.headline)
+
+            Grid(alignment: .trailing, horizontalSpacing: 8, verticalSpacing: 4) {
+                ForEach($rows) { $row in
+                    GridRow {
+                        Text(row.name)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        TextField("", value: $row.value, formatter: Self.numberFormatter)
+                            .frame(width: 60)
+                            .multilineTextAlignment(.trailing)
+                            .textFieldStyle(.roundedBorder)
+                        Text(kind == .percent ? "%" : "CHF")
+                    }
+                }
+            }
+
+            Text("Remaining to allocate: \(remaining, format: .number.precision(.fractionLength(1))) \(kind == .percent ? "%" : "CHF")")
+                .foregroundColor(remaining == 0 ? .primary : .red)
+
+            HStack {
+                Button("Auto-balance") { autoBalance() }
+                Spacer()
+                Button("Cancel") { onClose() }
+                Button("Save") { save() }
+                    .disabled(!canSave)
+            }
+        }
+        .padding()
+        .frame(maxWidth: 320)
+        .onAppear { load() }
+        .transition(.move(edge: .trailing))
+    }
+
+    private func load() {
+        let records = db.fetchPortfolioTargetRecords(portfolioId: 1)
+        if let parent = records.first(where: { $0.classId == classId && $0.subClassId == nil }) {
+            if parent.targetKind == "amount" { kind = .amount } else { kind = .percent }
+            parentValue = kind == .percent ? parent.percent : (parent.amountCHF ?? 0)
+        }
+        let subs = db.subAssetClasses(for: classId)
+        rows = subs.map { sub in
+            let rec = records.first(where: { $0.subClassId == sub.id })
+            let val = kind == .percent ? (rec?.percent ?? 0) : (rec?.amountCHF ?? 0)
+            return Row(id: sub.id, name: sub.name, value: val)
+        }
+    }
+
+    private func autoBalance() {
+        let unlocked = rows.indices.filter { !rows[$0].locked }
+        guard !unlocked.isEmpty else { return }
+        let share = remaining / Double(unlocked.count)
+        for idx in unlocked { rows[idx].value += share }
+        // minor adjustment to remove rounding drift
+        if let last = unlocked.last { rows[last].value += remaining - share * Double(unlocked.count) }
+    }
+
+    private func save() {
+        if kind == .percent {
+            db.upsertClassTarget(portfolioId: 1, classId: classId, percent: parentValue)
+            for r in rows { db.upsertSubClassTarget(portfolioId: 1, subClassId: r.id, percent: r.value) }
+        } else {
+            db.upsertClassTarget(portfolioId: 1, classId: classId, percent: 0, amountChf: parentValue)
+            for r in rows { db.upsertSubClassTarget(portfolioId: 1, subClassId: r.id, percent: 0, amountChf: r.value) }
+        }
+        onClose()
+    }
+
+    private static let numberFormatter: NumberFormatter = {
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        f.maximumFractionDigits = 1
+        return f
+    }()
+}
+
+struct TargetEditPanel_Previews: PreviewProvider {
+    static var previews: some View {
+        TargetEditPanel(classId: 1, onClose: {})
+            .environmentObject(DatabaseManager())
+    }
+}

--- a/DragonShield/docs/UX_UI_concept/target_allocation_edit_panel.md
+++ b/DragonShield/docs/UX_UI_concept/target_allocation_edit_panel.md
@@ -1,0 +1,64 @@
+# Target Allocation Edit Panel
+
+This document outlines the side‑panel workflow for editing Asset Class targets along with their Sub‑Classes. The goal is a minimal, fool‑proof UI that stores either percentage or CHF values per class, never a mix.
+
+## Core Rules
+1. The parent Asset Class selects **Target Kind** – either percentage (%) or amount in CHF. When Sub‑Classes already exist, the radio buttons are disabled so the kind matches existing children.
+2. Validation differs by kind:
+   - **Percent** – the sum of child percentages must equal `100 %`.
+   - **CHF** – the sum of child CHF amounts must equal the parent amount.
+3. The **Save** button only enables when all panels pass validation.
+4. An optional **Auto‑balance** button distributes any remainder across unlocked rows.
+
+## Layout
+```
+  ◁ Back          Edit targets — [Asset Class]
+  ──────────────────────────────────────────────
+  TARGET KIND     (•) %   ( ) CHF
+  TARGET VALUE    [ 25.0 ] %
+  ──────────────────────────────────────────────
+  SUB‑CLASS TARGETS
+  +----------------------------+-----------+
+  | Sub‑class                  | Target    |
+  +----------------------------+-----------+
+  | Large Cap                  | [ 15.0 ] %|
+  | Small Cap                  | [  5.0 ] %|
+  | Emerging Markets           | [  5.0 ] %|
+  +----------------------------+-----------+
+  Remaining to allocate: 0.0 %
+  ( Auto‑balance )  ( Cancel )  ( Save )
+```
+- The remaining line turns red when non‑zero.
+- Auto‑balance fills the remainder proportionally across editable rows.
+- Save stays disabled until remaining equals zero.
+
+## Validation Logic (pseudo)
+```swift
+if parent.kind == .percent {
+    parentOK = abs(sum(child.percent) - 100.0) < 0.1
+} else {
+    parentOK = abs(sum(child.amount) - parent.amount) < 1.0
+}
+canSave = parentOK && rootOK && allTargetsPositive()
+```
+
+## Auto‑balance Algorithm
+```
+remainder = 100 - Σ currentChildren%
+unlocked = children.filter { !isLocked($0) }
+share = remainder / unlocked.count
+for row in unlocked { row.value += share }
+round rows to 0.1 precision
+adjust last row to remove rounding drift
+```
+
+The CHF path works identically using money units.
+
+## Edge Cases
+1. Parent in CHF 1 000 000, children total 950 000 → Remaining −50 000 CHF.
+   - Save disabled, Remaining turns red, Auto‑balance distributes 50 000 CHF.
+2. Parent in %; user edits Large Cap from 15.0 → 20.0.
+   - Remaining shows −5.0 % until another row decreases by 5.0 %.
+3. User switches kind from % → CHF while children exist.
+   - Radio buttons are locked with a tooltip stating the kind is fixed by existing children.
+```


### PR DESCRIPTION
## Summary
- document the new Target Allocation side-panel workflow
- implement a side-panel editor for Asset Class targets
- activate the pencil button so classes can be edited
- place the pencil button next to the Target column for visibility

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887800a9d2c832393fe84efab6b3d0a