### PR TITLE
Fix edit pencil placement in Allocation Targets table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to this project will be documented in this file.
 - Show database schema version in Database Management view and include it in backup file names
 - Polish Crypto Allocations tile visuals and reduce row spacing
 - Redesign Asset Allocation dashboard with modern cards
+- Document Target Allocation edit panel workflow
+- Added persistent edit buttons & dbl-click shortcut for target rows (PR #XXX)
+- Implement side-panel editor for Asset Class targets
+- Activate pencil edit button in Allocation Targets table
+- Fix edit pencil visibility in Allocation Targets table and place it next to Target column
+- Style pencil button for visibility and ensure it opens the edit panel
+- Show pencil button next to the Target column and open the edit panel on
+  double-click
 - Fix compile errors in Asset Allocation dashboard views
 - Fix caption row overlay placement in Asset Allocation table
 - Redesign overview bar layout with dedicated tiles

--- a/DragonShield/Views/AllocationTargetsTableView.swift
+++ b/DragonShield/Views/AllocationTargetsTableView.swift
@@ -404,6 +404,7 @@ struct AllocationTargetsTableView: View {
     @State private var showDetails = true
     @State private var showDonut = true
     @State private var showDelta = true
+    @State private var editingClassId: Int?
 
     private let percentFormatter: NumberFormatter = {
         let f = NumberFormatter()
@@ -559,6 +560,16 @@ struct AllocationTargetsTableView: View {
                 .frame(maxWidth: .infinity)
             }
         }
+        .overlay(alignment: .trailing) {
+            if let cid = editingClassId {
+                TargetEditPanel(classId: cid) {
+                    viewModel.load(using: dbManager)
+                    refreshDrafts()
+                    withAnimation { editingClassId = nil }
+                }
+                .environmentObject(dbManager)
+            }
+        }
         .onAppear {
             viewModel.load(using: dbManager)
             refreshDrafts()
@@ -685,6 +696,9 @@ struct AllocationTargetsTableView: View {
     }
 
     private func rowBackground(for asset: AllocationAsset) -> Color {
+        if let id = editingClassId, asset.id == "class-\(id)" {
+            return .rowSelect
+        }
         if viewModel.rowHasWarning(asset) {
             return .paleRed
         }
@@ -712,10 +726,12 @@ struct AllocationTargetsTableView: View {
         let deltaTol = abs(asset.targetChf) * 0.01
         let aggregateDeltaColor: Color = abs(deltaChf) > deltaTol ? .red : .secondary
 
-        HStack(spacing: 0) {
+        HStack(spacing: 4) {
             Text(asset.name)
                 .fontWeight((abs(asset.targetPct) > 0.0001 || abs(asset.targetChf) > 0.01) ? .bold : .regular)
-                .frame(width: 200, alignment: .leading)
+        }
+        .frame(width: 200, alignment: .leading)
+        HStack(spacing: 0) {
             Divider()
             HStack(alignment: .top, spacing: 0) {
                 Picker("", selection: viewModel.modeBinding(for: asset)) {
@@ -800,6 +816,19 @@ struct AllocationTargetsTableView: View {
                     }
                 }
             }
+            if isClass {
+                let cid = Int(asset.id.dropFirst(6))
+                Button {
+                    if let id = cid { editingClassId = id }
+                } label: {
+                    Image(systemName: editingClassId == cid ? "pencil.circle.fill" : "pencil.circle")
+                        .foregroundColor(.accentColor)
+                        .frame(width: 16, height: 16)
+                }
+                .buttonStyle(.plain)
+                .frame(width: 24, height: 24)
+                .accessibilityLabel("Edit targets for \(asset.name)")
+            }
             Divider()
             HStack {
                 Text("\(formatPercent(asset.actualPct))%")
@@ -840,7 +869,23 @@ struct AllocationTargetsTableView: View {
             }
         }
         .frame(height: isClass ? 60 : 48)
+        .contentShape(Rectangle())
         .background(rowBackground(for: asset))
+        .onTapGesture(count: 2) {
+            if isClass, let id = Int(asset.id.dropFirst(6)) {
+                editingClassId = id
+            }
+        }
+        .onKeyDown(.enter) {
+            if isClass, let id = Int(asset.id.dropFirst(6)) {
+                editingClassId = id
+            }
+        }
+        .onKeyDown(.space) {
+            if isClass, let id = Int(asset.id.dropFirst(6)) {
+                editingClassId = id
+            }
+        }
     }
 }
 

--- a/DragonShield/Views/TargetEditPanel.swift
+++ b/DragonShield/Views/TargetEditPanel.swift
@@ -1,0 +1,149 @@
+import SwiftUI
+
+struct TargetEditPanel: View {
+    @EnvironmentObject var db: DatabaseManager
+    let classId: Int
+    let onClose: () -> Void
+
+    @State private var kind: TargetKind = .percent
+    @State private var parentValue: Double = 0
+    @State private var rows: [Row] = []
+
+    struct Row: Identifiable {
+        let id: Int
+        let name: String
+        var value: Double
+        var locked: Bool = false
+    }
+
+    enum TargetKind: String, CaseIterable { case percent, amount }
+
+    private var total: Double { rows.map(\.value).reduce(0, +) }
+
+    private var remaining: Double {
+        kind == .percent ? (100 - total) : (parentValue - total)
+    }
+
+    private var parentOK: Bool {
+        if kind == .percent {
+            abs(total - 100) < 0.1
+        } else {
+            abs(total - parentValue) < 1.0
+        }
+    }
+
+    private var canSave: Bool { parentOK && parentValue >= 0 && rows.allSatisfy { $0.value >= 0 } }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Button("Back") { onClose() }
+                Spacer()
+                Text("Edit targets")
+                    .font(.headline)
+            }
+            .padding(.bottom)
+
+            HStack {
+                Text("Target Kind")
+                Spacer()
+                Picker("Target Kind", selection: $kind) {
+                    Text("%").tag(TargetKind.percent)
+                    Text("CHF").tag(TargetKind.amount)
+                }
+                .pickerStyle(.radioGroup)
+                .frame(width: 120)
+            }
+
+            HStack {
+                Text("Target Value")
+                Spacer()
+                TextField("", value: $parentValue, formatter: Self.numberFormatter)
+                    .frame(width: 80)
+                    .multilineTextAlignment(.trailing)
+                    .textFieldStyle(.roundedBorder)
+                Text(kind == .percent ? "%" : "CHF")
+            }
+
+            Text("Sub-Class Targets")
+                .font(.headline)
+
+            Grid(alignment: .trailing, horizontalSpacing: 8, verticalSpacing: 4) {
+                ForEach($rows) { $row in
+                    GridRow {
+                        Text(row.name)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        TextField("", value: $row.value, formatter: Self.numberFormatter)
+                            .frame(width: 60)
+                            .multilineTextAlignment(.trailing)
+                            .textFieldStyle(.roundedBorder)
+                        Text(kind == .percent ? "%" : "CHF")
+                    }
+                }
+            }
+
+            Text("Remaining to allocate: \(remaining, format: .number.precision(.fractionLength(1))) \(kind == .percent ? "%" : "CHF")")
+                .foregroundColor(remaining == 0 ? .primary : .red)
+
+            HStack {
+                Button("Auto-balance") { autoBalance() }
+                Spacer()
+                Button("Cancel") { onClose() }
+                Button("Save") { save() }
+                    .disabled(!canSave)
+            }
+        }
+        .padding()
+        .frame(maxWidth: 320)
+        .onAppear { load() }
+        .transition(.move(edge: .trailing))
+    }
+
+    private func load() {
+        let records = db.fetchPortfolioTargetRecords(portfolioId: 1)
+        if let parent = records.first(where: { $0.classId == classId && $0.subClassId == nil }) {
+            if parent.targetKind == "amount" { kind = .amount } else { kind = .percent }
+            parentValue = kind == .percent ? parent.percent : (parent.amountCHF ?? 0)
+        }
+        let subs = db.subAssetClasses(for: classId)
+        rows = subs.map { sub in
+            let rec = records.first(where: { $0.subClassId == sub.id })
+            let val = kind == .percent ? (rec?.percent ?? 0) : (rec?.amountCHF ?? 0)
+            return Row(id: sub.id, name: sub.name, value: val)
+        }
+    }
+
+    private func autoBalance() {
+        let unlocked = rows.indices.filter { !rows[$0].locked }
+        guard !unlocked.isEmpty else { return }
+        let share = remaining / Double(unlocked.count)
+        for idx in unlocked { rows[idx].value += share }
+        // minor adjustment to remove rounding drift
+        if let last = unlocked.last { rows[last].value += remaining - share * Double(unlocked.count) }
+    }
+
+    private func save() {
+        if kind == .percent {
+            db.upsertClassTarget(portfolioId: 1, classId: classId, percent: parentValue)
+            for r in rows { db.upsertSubClassTarget(portfolioId: 1, subClassId: r.id, percent: r.value) }
+        } else {
+            db.upsertClassTarget(portfolioId: 1, classId: classId, percent: 0, amountChf: parentValue)
+            for r in rows { db.upsertSubClassTarget(portfolioId: 1, subClassId: r.id, percent: 0, amountChf: r.value) }
+        }
+        onClose()
+    }
+
+    private static let numberFormatter: NumberFormatter = {
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        f.maximumFractionDigits = 1
+        return f
+    }()
+}
+
+struct TargetEditPanel_Previews: PreviewProvider {
+    static var previews: some View {
+        TargetEditPanel(classId: 1, onClose: {})
+            .environmentObject(DatabaseManager())
+    }
+}

--- a/DragonShield/docs/UX_UI_concept/target_allocation_edit_panel.md
+++ b/DragonShield/docs/UX_UI_concept/target_allocation_edit_panel.md
@@ -1,0 +1,69 @@
+# Target Allocation Edit Panel
+
+This document outlines the side‑panel workflow for editing Asset Class targets along with their Sub‑Classes. The goal is a minimal, fool‑proof UI that stores either percentage or CHF values per class, never a mix.
+
+## Core Rules
+1. The parent Asset Class selects **Target Kind** – either percentage (%) or amount in CHF. When Sub‑Classes already exist, the radio buttons are disabled so the kind matches existing children.
+2. Validation differs by kind:
+   - **Percent** – the sum of child percentages must equal `100 %`.
+   - **CHF** – the sum of child CHF amounts must equal the parent amount.
+3. The **Save** button only enables when all panels pass validation.
+4. An optional **Auto‑balance** button distributes any remainder across unlocked rows.
+
+## Layout
+```
+  ◁ Back          Edit targets — [Asset Class]
+  ──────────────────────────────────────────────
+  TARGET KIND     (•) %   ( ) CHF
+  TARGET VALUE    [ 25.0 ] %
+  ──────────────────────────────────────────────
+  SUB‑CLASS TARGETS
+  +----------------------------+-----------+
+  | Sub‑class                  | Target    |
+  +----------------------------+-----------+
+  | Large Cap                  | [ 15.0 ] %|
+  | Small Cap                  | [  5.0 ] %|
+  | Emerging Markets           | [  5.0 ] %|
+  +----------------------------+-----------+
+  Remaining to allocate: 0.0 %
+  ( Auto‑balance )  ( Cancel )  ( Save )
+```
+- The remaining line turns red when non‑zero.
+- Auto‑balance fills the remainder proportionally across editable rows.
+- Save stays disabled until remaining equals zero.
+- A pencil button appears next to each Asset Class target column. Clicking it or
+  double‑clicking the row opens the side‑panel editor.
+- The pencil is always visible beside the target value and switches to a filled
+  icon while editing. Hitting **Enter** or **Space** when the row is focused
+  also opens the editor, and the row background turns light blue until closed.
+
+## Validation Logic (pseudo)
+```swift
+if parent.kind == .percent {
+    parentOK = abs(sum(child.percent) - 100.0) < 0.1
+} else {
+    parentOK = abs(sum(child.amount) - parent.amount) < 1.0
+}
+canSave = parentOK && rootOK && allTargetsPositive()
+```
+
+## Auto‑balance Algorithm
+```
+remainder = 100 - Σ currentChildren%
+unlocked = children.filter { !isLocked($0) }
+share = remainder / unlocked.count
+for row in unlocked { row.value += share }
+round rows to 0.1 precision
+adjust last row to remove rounding drift
+```
+
+The CHF path works identically using money units.
+
+## Edge Cases
+1. Parent in CHF 1 000 000, children total 950 000 → Remaining −50 000 CHF.
+   - Save disabled, Remaining turns red, Auto‑balance distributes 50 000 CHF.
+2. Parent in %; user edits Large Cap from 15.0 → 20.0.
+   - Remaining shows −5.0 % until another row decreases by 5.0 %.
+3. User switches kind from % → CHF while children exist.
+   - Radio buttons are locked with a tooltip stating the kind is fixed by existing children.
+```

--- a/DragonShield/helpers/Color+Palette.swift
+++ b/DragonShield/helpers/Color+Palette.swift
@@ -13,6 +13,9 @@ extension Color {
     /// Soft blue highlight used for segmented controls and headers.
     static let softBlue = Color(red: 229/255, green: 241/255, blue: 255/255)
 
+    /// Row highlight used when editing a table row.
+    static let rowSelect = Color(red: 245/255, green: 249/255, blue: 255/255)
+
     /// Neutral gray used for text field backgrounds across platforms.
     static var fieldGray: Color {
 #if os(macOS)

--- a/DragonShield/helpers/View+KeyDown.swift
+++ b/DragonShield/helpers/View+KeyDown.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+#if os(macOS)
+private struct KeyDownRepresentable: NSViewRepresentable {
+    let key: KeyEquivalent
+    let action: () -> Void
+
+    func makeNSView(context: Context) -> KeyView {
+        let view = KeyView()
+        view.key = key
+        view.action = action
+        return view
+    }
+
+    func updateNSView(_ nsView: KeyView, context: Context) {
+        nsView.key = key
+        nsView.action = action
+    }
+
+    class KeyView: NSView {
+        var key: KeyEquivalent = .return
+        var action: () -> Void = {}
+
+        override var acceptsFirstResponder: Bool { true }
+
+        override func keyDown(with event: NSEvent) {
+            if event.charactersIgnoringModifiers == String(key.character ?? "") {
+                action()
+            } else {
+                super.keyDown(with: event)
+            }
+        }
+    }
+}
+#endif
+
+private struct KeyDownModifier: ViewModifier {
+    let key: KeyEquivalent
+    let action: () -> Void
+
+    func body(content: Content) -> some View {
+#if os(macOS)
+        content.background(KeyDownRepresentable(key: key, action: action))
+#else
+        content
+#endif
+    }
+}
+
+extension View {
+    func onKeyDown(_ key: KeyEquivalent, perform action: @escaping () -> Void) -> some View {
+        modifier(KeyDownModifier(key: key, action: action))
+    }
+}

--- a/tests/test_edit_pencil.py
+++ b/tests/test_edit_pencil.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+VIEW = Path(__file__).resolve().parents[1] / 'DragonShield' / 'Views' / 'AllocationTargetsTableView.swift'
+
+def _view_text():
+    return VIEW.read_text(encoding='utf-8')
+
+def test_pencil_is_visible():
+    text = _view_text()
+    assert 'pencil.circle' in text
+    assert '.accessibilityLabel("Edit targets for' in text
+
+def test_double_click_opens_panel():
+    text = _view_text()
+    assert '.onTapGesture(count: 2)' in text
+
+
+def test_keyboard_enter_opens_panel():
+    text = _view_text()
+    assert '.onKeyDown(.enter' in text


### PR DESCRIPTION
## Summary
- fix edit pencil visibility in Allocation Targets table
- move the pencil button beside the Target column for asset classes
- allow double-click on a row to open the target editor
- document new interaction in UI concept and changelog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887800a9d2c832393fe84efab6b3d0a