### PR TITLE
Remove Double Donut chart and update onChange API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this project will be documented in this file.
 - Make pencil buttons persistent with row highlight and keyboard activation
 - Fix compile errors in Asset Allocation dashboard views
 - Fix caption row overlay placement in Asset Allocation table
+- Remove Double Donut chart from legacy Asset Allocation view
+- Migrate width update onChange to new two-parameter closure
 - Redesign overview bar layout with dedicated tiles
 - Fix color scheme handling in overview bar and card components
 - Convert Allocation dashboard to two-column layout with full-width overview bar

--- a/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
+++ b/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
@@ -222,7 +222,7 @@ struct AllocationTreeCard: View {
                 let tableWidth = geo.size.width - sidePad * 2
                 Color.clear
                     .onAppear { updateWidths(for: tableWidth) }
-                    .onChange(of: geo.size.width) { newVal in
+                    .onChange(of: geo.size.width, initial: false) { _, newVal in
                         updateWidths(for: newVal - sidePad * 2)
                     }
                 let compact = tableWidth < 1024


### PR DESCRIPTION
## Summary
- remove obsolete Double Donut chart from legacy Asset Allocation view
- delete DualRingDonutChart implementation
- update onChange syntax for macOS 14
- document changes in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bc22b703c8323b217539fdab6a3a2