### PR TITLE
fix(ui): align header columns in legacy allocation table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Make pencil buttons persistent with row highlight and keyboard activation
 - Fix compile errors in Asset Allocation dashboard views
 - Fix caption row overlay placement in Asset Allocation table
+- Align header columns with asset category rows in legacy Asset Allocation table
 - Remove Double Donut chart from legacy Asset Allocation view
 - Remove Delta Bar section from legacy Asset Allocation view
 - Display overview bar in legacy Asset Allocation view

--- a/DragonShield/Views/AllocationTargetsTableView.swift
+++ b/DragonShield/Views/AllocationTargetsTableView.swift
@@ -575,6 +575,8 @@ struct AllocationTargetsTableView: View {
                 Text("Target CHF")
                     .frame(width: 100)
             }
+            Spacer()
+                .frame(width: 24)
             Divider()
             HStack {
                 sortHeader(title: "Actual %", column: .actualPct)


### PR DESCRIPTION
## Summary
- fix alignment issue in legacy asset allocation table by spacing header row
- document change in Unreleased changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c3b679e488323ab5264097822fd90