### PR TITLE
fix allocation header row alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Make pencil buttons persistent with row highlight and keyboard activation
 - Fix compile errors in Asset Allocation dashboard views
 - Fix caption row overlay placement in Asset Allocation table
+- Align header captions with Asset Class rows in legacy allocation view
 - Remove Double Donut chart from legacy Asset Allocation view
 - Remove Delta Bar section from legacy Asset Allocation view
 - Display overview bar in legacy Asset Allocation view

--- a/DragonShield/Views/AllocationTargetsTableView.swift
+++ b/DragonShield/Views/AllocationTargetsTableView.swift
@@ -593,6 +593,7 @@ struct AllocationTargetsTableView: View {
             }
         }
         .font(.system(size: 12, weight: .semibold))
+        .padding(.leading, 20)
     }
 
     private var totalsRow: some View {
@@ -627,6 +628,7 @@ struct AllocationTargetsTableView: View {
         }
         .font(.subheadline)
         .background(viewModel.totalsValid ? Color.white : Color.paleRed)
+        .padding(.leading, 20)
     }
 
     private var inactiveHeader: some View {
@@ -638,6 +640,7 @@ struct AllocationTargetsTableView: View {
         }
         .padding(.vertical, 2)
         .background(Color(NSColor.windowBackgroundColor))
+        .padding(.leading, 20)
     }
 
     private var totalCellPct: some View {


### PR DESCRIPTION
## Summary
- align header, totals and inactive captions with asset rows in the legacy allocation table
- document the fix in the changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c3b679e488323ab5264097822fd90