### PR TITLE
Fix allocation table caption alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Add segmented display mode toggle for Asset Classes tile
+- Align caption row with asset category rows in legacy Allocation table
 - Move Asset Allocation Errors panel beside legacy targets table
 - Show database schema version in Database Management view and include it in backup file names
 - Polish Crypto Allocations tile visuals and reduce row spacing

--- a/DragonShield/Views/AllocationTargetsTableView.swift
+++ b/DragonShield/Views/AllocationTargetsTableView.swift
@@ -593,6 +593,7 @@ struct AllocationTargetsTableView: View {
             }
         }
         .font(.system(size: 12, weight: .semibold))
+        .padding(.leading, 20)
     }
 
     private var totalsRow: some View {
@@ -627,6 +628,7 @@ struct AllocationTargetsTableView: View {
         }
         .font(.subheadline)
         .background(viewModel.totalsValid ? Color.white : Color.paleRed)
+        .padding(.leading, 20)
     }
 
     private var inactiveHeader: some View {


### PR DESCRIPTION
## Summary
- align caption and totals rows with asset category content in the legacy allocation table
- note the UI fix in the changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c3b679e488323ab5264097822fd90