### PR TITLE
Fix header alignment in legacy allocation view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Align header row with Asset Class rows in legacy Allocation table
 - Add segmented display mode toggle for Asset Classes tile
 - Move Asset Allocation Errors panel beside legacy targets table
 - Show database schema version in Database Management view and include it in backup file names

--- a/DragonShield/Views/AllocationTargetsTableView.swift
+++ b/DragonShield/Views/AllocationTargetsTableView.swift
@@ -575,6 +575,8 @@ struct AllocationTargetsTableView: View {
                 Text("Target CHF")
                     .frame(width: 100)
             }
+            Spacer()
+                .frame(width: 24)
             Divider()
             HStack {
                 sortHeader(title: "Actual %", column: .actualPct)
@@ -608,6 +610,8 @@ struct AllocationTargetsTableView: View {
                 Text(formatChf(viewModel.targetChfTotal))
                     .frame(width: 100, alignment: .trailing)
             }
+            Spacer()
+                .frame(width: 24)
             Divider()
             HStack {
                 Text("\(formatPercent(viewModel.actualPctTotal))%")


### PR DESCRIPTION
## Summary
- align caption row with asset class rows in legacy allocation table
- document change in Unreleased section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c3b679e488323ab5264097822fd90