### PR TITLE
Fix header alignment in legacy allocation table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Fix header alignment in legacy asset allocation table
 - Add segmented display mode toggle for Asset Classes tile
 - Move Asset Allocation Errors panel beside legacy targets table
 - Show database schema version in Database Management view and include it in backup file names

--- a/DragonShield/Views/AllocationTargetsTableView.swift
+++ b/DragonShield/Views/AllocationTargetsTableView.swift
@@ -497,18 +497,24 @@ struct AllocationTargetsTableView: View {
         HStack(alignment: .top, spacing: 16) {
             List {
                 headerRow
+                    .listRowInsets(.init())
                 totalsRow
+                    .listRowInsets(.init())
                 OutlineGroup(activeAssets, children: \.children) { asset in
                     tableRow(for: asset)
+                        .listRowInsets(.init())
                 }
                     if !inactiveAssets.isEmpty {
                         Divider()
                         inactiveHeader
+                            .listRowInsets(.init())
                         OutlineGroup(inactiveAssets, children: \.children) { asset in
                             tableRow(for: asset)
+                                .listRowInsets(.init())
                         }
                     }
             }
+            .listStyle(.plain)
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {

--- a/tests/test_header_alignment.py
+++ b/tests/test_header_alignment.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+VIEW_FILE = Path(__file__).resolve().parents[1] / 'DragonShield' / 'Views' / 'AllocationTargetsTableView.swift'
+
+
+def test_header_row_insets_removed():
+    text = VIEW_FILE.read_text(encoding='utf-8')
+    assert '.listRowInsets(.init())' in text


### PR DESCRIPTION
## Summary
- remove list row insets for legacy allocation header rows
- apply same zero insets to table rows
- verify header inset removal in a small test
- document change in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c42d58030832392d0b166d39ca8c9