### PR TITLE
fix: avoid duplicate detail expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Activate pencil edit button in Allocation Targets table
 - Fix edit pencil visibility in Allocation Targets table and place it next to Target column
 - Style pencil button for visibility and ensure it opens the edit panel
+- Prevent duplicate detail expansion in legacy Asset Allocation view
 - Show pencil button next to the Target column and open the edit panel on
   double-click
 - Make pencil buttons persistent with row highlight and keyboard activation

--- a/DragonShield/Views/AllocationTargetsTableView.swift
+++ b/DragonShield/Views/AllocationTargetsTableView.swift
@@ -498,13 +498,13 @@ struct AllocationTargetsTableView: View {
             List {
                 headerRow
                 totalsRow
-                OutlineGroup(activeAssets, children: \.children) { asset in
+                OutlineGroup(activeAssets, id: \.id, children: \.children) { asset in
                     tableRow(for: asset)
                 }
                     if !inactiveAssets.isEmpty {
                         Divider()
                         inactiveHeader
-                        OutlineGroup(inactiveAssets, children: \.children) { asset in
+                        OutlineGroup(inactiveAssets, id: \.id, children: \.children) { asset in
                             tableRow(for: asset)
                         }
                     }


### PR DESCRIPTION
## Summary
- prevent OutlineGroup from duplicating detail content by explicitly binding to unique id
- document fix in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c45c9dfdc8323b2b087c8c1e39c8d