### PR TITLE
Fix summary row expansion bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Make pencil buttons persistent with row highlight and keyboard activation
 - Fix compile errors in Asset Allocation dashboard views
 - Fix caption row overlay placement in Asset Allocation table
+- Fix duplicate expansion when tapping summary rows in legacy Asset Allocation table
 - Remove Double Donut chart from legacy Asset Allocation view
 - Remove Delta Bar section from legacy Asset Allocation view
 - Display overview bar in legacy Asset Allocation view

--- a/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
+++ b/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
@@ -445,7 +445,7 @@ struct AssetRow: View {
     var body: some View {
         let diffPct = relativeDeviation * 100
         HStack(spacing: gap) {
-            if node.children != nil {
+            if let children = node.children, !children.isEmpty {
                 Button(action: { expanded.toggle() }) {
                     Image(systemName: "chevron.right")
                         .rotationEffect(.degrees(expanded ? 90 : 0))


### PR DESCRIPTION
## Summary
- prevent expandable caret on summary rows in AllocationDashboardView
- note fix in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c490429048323bdb964728f64cf7d