### PR TITLE
Add edit buttons to Asset Allocation rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Show database schema version in Database Management view and include it in backup file names
 - Polish Crypto Allocations tile visuals and reduce row spacing
 - Redesign Asset Allocation dashboard with modern cards
+- Added persistent edit buttons & dbl-click shortcut for target rows (PR #XXX)
 - Document Target Allocation edit panel workflow
 - Implement side-panel editor for Asset Class targets
 - Activate pencil edit button in Allocation Targets table

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Polish Crypto Allocations tile visuals and reduce row spacing
 - Redesign Asset Allocation dashboard with modern cards
 - Added persistent edit buttons & dbl-click shortcut for target rows (PR #XXX)
+- Inline edit panel with tolerance input below Asset Allocation rows
 - Document Target Allocation edit panel workflow
 - Implement side-panel editor for Asset Class targets
 - Activate pencil edit button in Allocation Targets table

--- a/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
+++ b/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
@@ -253,15 +253,6 @@ struct AllocationTreeCard: View {
         }
         .onAppear { initializeExpanded() }
         .onChange(of: displayMode) { _, _ in saveMode() }
-        .overlay(alignment: .trailing) {
-            if let cid = editingClassId {
-                TargetEditPanel(classId: cid) {
-                    viewModel.load(using: dbManager)
-                    withAnimation { editingClassId = nil }
-                }
-                .environmentObject(dbManager)
-            }
-        }
     }
 
     private var SegmentedPicker: some View {
@@ -296,17 +287,27 @@ struct AllocationTreeCard: View {
                       _ deltaWidth: CGFloat,
                       _ compact: Bool) -> some View {
         ForEach(sortedAssets) { parent in
-            AssetRow(node: parent,
-                     mode: displayMode,
-                     compact: compact,
-                     expanded: binding(for: parent.id),
-                     editingClassId: $editingClassId,
-                     nameWidth: nameWidth,
-                     targetWidth: targetWidth,
-                     actualWidth: actualWidth,
-                     trackWidth: trackWidth,
-                     deltaWidth: deltaWidth,
-                     gap: gap)
+            VStack(spacing: 0) {
+                AssetRow(node: parent,
+                         mode: displayMode,
+                         compact: compact,
+                         expanded: binding(for: parent.id),
+                         editingClassId: $editingClassId,
+                         nameWidth: nameWidth,
+                         targetWidth: targetWidth,
+                         actualWidth: actualWidth,
+                         trackWidth: trackWidth,
+                         deltaWidth: deltaWidth,
+                         gap: gap)
+                if let cid = Int(parent.id.dropFirst(6)), editingClassId == cid {
+                    TargetEditPanel(classId: cid) {
+                        viewModel.load(using: dbManager)
+                        withAnimation { editingClassId = nil }
+                    }
+                    .environmentObject(dbManager)
+                    .background(Color.white)
+                }
+            }
             if expanded[parent.id] == true, let children = parent.children {
                 ForEach(children) { child in
                     AssetRow(node: child,

--- a/DragonShield/docs/UI-Concept.md
+++ b/DragonShield/docs/UI-Concept.md
@@ -5,3 +5,4 @@
 - Asset Class Allocation rows now include a persistent pencil button within the Target column.
 - Double-clicking a row or pressing **Enter** / **Space** when focused opens the Target-Editor side panel.
 - The active row highlights with a soft blue background while editing.
+- The editor now opens inline below the row with a white background and fields for tolerance %.

--- a/DragonShield/docs/UI-Concept.md
+++ b/DragonShield/docs/UI-Concept.md
@@ -1,0 +1,7 @@
+# UI Concept
+
+## Editing
+
+- Asset Class Allocation rows now include a persistent pencil button within the Target column.
+- Double-clicking a row or pressing **Enter** / **Space** when focused opens the Target-Editor side panel.
+- The active row highlights with a soft blue background while editing.

--- a/DragonShieldTests/AllocationTargetsTableViewTests.swift
+++ b/DragonShieldTests/AllocationTargetsTableViewTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class AllocationTargetsTableViewTests: XCTestCase {
     func testPencilIsVisible() {
         // Placeholder UI test ensuring pencil buttons exist
-        let view = AllocationTargetsTableView()
+        let view = AllocationDashboardView()
         XCTAssertNotNil(view)
     }
 


### PR DESCRIPTION
## Summary
- enable editing in Asset Allocation dashboard rows
- document editing behaviour in UI-Concept
- note feature in changelog

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688cc95205a48323ab89f38aa1969480