### PR TITLE
Implement modal target editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -446,3 +446,4 @@ All notable changes to this project will be documented in this file.
 - Enhance deviation column with centre line, delta numbers and action icons
 - Add target_kind and tolerance_percent columns to TargetAllocation table
 - Indicate stored target_kind with a bullet when display mode matches
+- Rework Target Edit panel as a centered modal with grouped class and subclass settings

--- a/DragonShield/Views/AllocationTargetsTableView.swift
+++ b/DragonShield/Views/AllocationTargetsTableView.swift
@@ -544,14 +544,24 @@ struct AllocationTargetsTableView: View {
             .background(cardBackground)
         }
         .padding(.horizontal, 24)
-        .overlay(alignment: .trailing) {
+        .overlay {
             if let cid = editingClassId {
-                TargetEditPanel(classId: cid) {
-                    viewModel.load(using: dbManager)
-                    refreshDrafts()
-                    withAnimation { editingClassId = nil }
+                ZStack {
+                    Color.black.opacity(0.4)
+                        .ignoresSafeArea()
+                        .onTapGesture { withAnimation { editingClassId = nil } }
+                    TargetEditPanel(classId: cid) {
+                        viewModel.load(using: dbManager)
+                        refreshDrafts()
+                        withAnimation { editingClassId = nil }
+                    }
+                    .environmentObject(dbManager)
+                    .background(Color(NSColor.windowBackgroundColor))
+                    .cornerRadius(12)
+                    .shadow(radius: 20)
                 }
-                .environmentObject(dbManager)
+                .transition(.opacity)
+                .zIndex(1)
             }
         }
         .onAppear {

--- a/DragonShield/Views/TargetEditPanel.swift
+++ b/DragonShield/Views/TargetEditPanel.swift
@@ -5,143 +5,227 @@ struct TargetEditPanel: View {
     let classId: Int
     let onClose: () -> Void
 
+    @State private var className: String = ""
     @State private var kind: TargetKind = .percent
-    @State private var parentValue: Double = 0
-    @State private var rows: [Row] = []
+    @State private var parentPercent: Double = 0
+    @State private var parentAmount: Double = 0
     @State private var tolerance: Double = 5
+    @State private var rows: [Row] = []
 
     struct Row: Identifiable {
         let id: Int
         let name: String
-        var value: Double
-        var locked: Bool = false
+        var kind: TargetKind
+        var percent: Double
+        var amount: Double
+        var tolerance: Double
     }
 
     enum TargetKind: String, CaseIterable { case percent, amount }
 
-    private var total: Double { rows.map(\.value).reduce(0, +) }
-
-    private var remaining: Double {
-        kind == .percent ? (100 - total) : (parentValue - total)
-    }
-
-    private var parentOK: Bool {
+    private var total: Double {
         if kind == .percent {
-            abs(total - 100) < 0.1
+            rows.reduce(0) { $0 + $1.percent }
         } else {
-            abs(total - parentValue) < 1.0
+            rows.reduce(0) { $0 + $1.amount }
         }
     }
 
-    private var canSave: Bool { parentOK && parentValue >= 0 && rows.allSatisfy { $0.value >= 0 } }
+    private var remaining: Double {
+        if kind == .percent {
+            parentPercent - total
+        } else {
+            parentAmount - total
+        }
+    }
+
+    private var remainingText: String {
+        let suffix = kind == .percent ? "%" : "CHF"
+        let val = remaining
+        let formatted = Self.numberFormatter.string(from: NSNumber(value: abs(val))) ?? "0"
+        if val == 0 {
+            return "Remaining to allocate: 0\(suffix)"
+        }
+        let sign = val < 0 ? "–" : ""
+        return "Remaining to allocate: \(sign)\(formatted) \(suffix)"
+    }
+
+    private var bindingForParentValue: Binding<Double> {
+        Binding<Double>(
+            get: { kind == .percent ? parentPercent : parentAmount },
+            set: { newVal in
+                if kind == .percent { parentPercent = newVal } else { parentAmount = newVal }
+            }
+        )
+    }
+
+    private func binding(for row: Row) -> Binding<Double> {
+        Binding<Double>(
+            get: { row.kind == .percent ? row.percent : row.amount },
+            set: { newVal in
+                if let idx = rows.firstIndex(where: { $0.id == row.id }) {
+                    if row.kind == .percent { rows[idx].percent = newVal } else { rows[idx].amount = newVal }
+                }
+            }
+        )
+    }
+
+    private var canSave: Bool {
+        if kind == .percent {
+            abs(total - parentPercent) < 0.1
+        } else {
+            abs(total - parentAmount) < 1.0
+        }
+    }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            HStack {
-                Button("Back") { onClose() }
-                Spacer()
-                Text("Edit targets")
-                    .font(.headline)
-            }
-            .padding(.bottom)
-
-            HStack {
-                Text("Target Kind")
-                Spacer()
-                Picker("Target Kind", selection: $kind) {
-                    Text("%").tag(TargetKind.percent)
-                    Text("CHF").tag(TargetKind.amount)
-                }
-                .pickerStyle(.radioGroup)
-                .frame(width: 120)
-            }
-
-            HStack {
-                Text("Target Value")
-                Spacer()
-                TextField("", value: $parentValue, formatter: Self.numberFormatter)
-                    .frame(width: 80)
-                    .multilineTextAlignment(.trailing)
-                    .textFieldStyle(.roundedBorder)
-                Text(kind == .percent ? "%" : "CHF")
-            }
-
-            HStack {
-                Text("Tolerance")
-                Spacer()
-                TextField("", value: $tolerance, formatter: Self.numberFormatter)
-                    .frame(width: 60)
-                    .multilineTextAlignment(.trailing)
-                    .textFieldStyle(.roundedBorder)
-                Text("%")
-            }
-
-            Text("Sub-Class Targets")
+        VStack(spacing: 16) {
+            Text("Edit \"\(className)\" Targets")
                 .font(.headline)
-
-            Grid(alignment: .trailing, horizontalSpacing: 8, verticalSpacing: 4) {
-                ForEach($rows) { $row in
+            VStack {
+                Grid(horizontalSpacing: 16, verticalSpacing: 8) {
                     GridRow {
-                        Text(row.name)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                        TextField("", value: $row.value, formatter: Self.numberFormatter)
+                        Text("Target Kind")
+                        Text(kind == .percent ? "Target %" : "Target CHF")
+                        Text("Tolerance (%)")
+                    }
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    GridRow {
+                        Picker("Target Kind", selection: $kind) {
+                            Text("%").tag(TargetKind.percent)
+                            Text("CHF").tag(TargetKind.amount)
+                        }
+                        .pickerStyle(.radioGroup)
+                        .frame(width: 100, alignment: .leading)
+
+                        TextField("", value: bindingForParentValue, formatter: Self.numberFormatter)
+                            .frame(width: 80)
+                            .multilineTextAlignment(.trailing)
+                            .textFieldStyle(.roundedBorder)
+
+                        TextField("", value: $tolerance, formatter: Self.numberFormatter)
                             .frame(width: 60)
                             .multilineTextAlignment(.trailing)
                             .textFieldStyle(.roundedBorder)
-                        Text(kind == .percent ? "%" : "CHF")
+                    }
+                }
+                .padding(8)
+                .background(Color.groupBlue)
+                .cornerRadius(8)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Sub-Class Targets:")
+                    .font(.headline)
+                Grid(horizontalSpacing: 16, verticalSpacing: 4) {
+                    GridRow {
+                        Text("%  CHF")
+                        Text("Value")
+                        Text("Tolerance")
+                        Text("")
+                    }
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    ForEach($rows) { $row in
+                        GridRow {
+                            Picker("", selection: $row.kind) {
+                                Text("%").tag(TargetKind.percent)
+                                Text("CHF").tag(TargetKind.amount)
+                            }
+                            .pickerStyle(.radioGroup)
+                            .frame(width: 80, alignment: .leading)
+
+                            TextField("", value: binding(for: row), formatter: Self.numberFormatter)
+                                .frame(width: 80)
+                                .multilineTextAlignment(.trailing)
+                                .textFieldStyle(.roundedBorder)
+
+                            TextField("", value: $row.tolerance, formatter: Self.numberFormatter)
+                                .frame(width: 60)
+                                .multilineTextAlignment(.trailing)
+                                .textFieldStyle(.roundedBorder)
+
+                            Text(row.name)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        Divider()
                     }
                 }
             }
 
-            Text("Remaining to allocate: \(remaining, format: .number.precision(.fractionLength(1))) \(kind == .percent ? "%" : "CHF")")
+            Text(remainingText)
                 .foregroundColor(remaining == 0 ? .primary : .red)
+                .frame(maxWidth: .infinity, alignment: .leading)
 
             HStack {
-                Button("Auto-balance") { autoBalance() }
+                Button("Auto-Balance", action: autoBalance)
                 Spacer()
                 Button("Cancel") { onClose() }
                 Button("Save") { save() }
                     .disabled(!canSave)
             }
+            .padding(.top)
         }
-        .padding()
-        .frame(maxWidth: 320)
-        .background(Color.white)
-        .onAppear { load() }
-        .transition(.move(edge: .trailing))
+        .padding(20)
+        .frame(maxWidth: 400)
+        .onAppear(perform: load)
     }
 
     private func load() {
+        className = db.fetchAssetClassDetails(id: classId)?.name ?? ""
         let records = db.fetchPortfolioTargetRecords(portfolioId: 1)
         if let parent = records.first(where: { $0.classId == classId && $0.subClassId == nil }) {
-            if parent.targetKind == "amount" { kind = .amount } else { kind = .percent }
-            parentValue = kind == .percent ? parent.percent : (parent.amountCHF ?? 0)
+            kind = TargetKind(rawValue: parent.targetKind) ?? .percent
+            parentPercent = parent.percent
+            parentAmount = parent.amountCHF ?? 0
             tolerance = parent.tolerance
         }
         let subs = db.subAssetClasses(for: classId)
         rows = subs.map { sub in
             let rec = records.first(where: { $0.subClassId == sub.id })
-            let val = kind == .percent ? (rec?.percent ?? 0) : (rec?.amountCHF ?? 0)
-            return Row(id: sub.id, name: sub.name, value: val)
+            return Row(
+                id: sub.id,
+                name: sub.name,
+                kind: TargetKind(rawValue: rec?.targetKind ?? kind.rawValue) ?? kind,
+                percent: rec?.percent ?? 0,
+                amount: rec?.amountCHF ?? 0,
+                tolerance: rec?.tolerance ?? tolerance
+            )
         }
     }
 
     private func autoBalance() {
-        let unlocked = rows.indices.filter { !rows[$0].locked }
-        guard !unlocked.isEmpty else { return }
-        let share = remaining / Double(unlocked.count)
-        for idx in unlocked { rows[idx].value += share }
-        // minor adjustment to remove rounding drift
-        if let last = unlocked.last { rows[last].value += remaining - share * Double(unlocked.count) }
+        guard !rows.isEmpty else { return }
+        let share = remaining / Double(rows.count)
+        for idx in rows.indices {
+            if kind == .percent {
+                rows[idx].percent += share
+            } else {
+                rows[idx].amount += share
+            }
+        }
+        if let last = rows.indices.last {
+            if kind == .percent {
+                rows[last].percent += remaining - share * Double(rows.count)
+            } else {
+                rows[last].amount += remaining - share * Double(rows.count)
+            }
+        }
     }
 
     private func save() {
-        if kind == .percent {
-            db.upsertClassTarget(portfolioId: 1, classId: classId, percent: parentValue, tolerance: tolerance)
-            for r in rows { db.upsertSubClassTarget(portfolioId: 1, subClassId: r.id, percent: r.value, tolerance: tolerance) }
-        } else {
-            db.upsertClassTarget(portfolioId: 1, classId: classId, percent: 0, amountChf: parentValue, tolerance: tolerance)
-            for r in rows { db.upsertSubClassTarget(portfolioId: 1, subClassId: r.id, percent: 0, amountChf: r.value, tolerance: tolerance) }
+        db.upsertClassTarget(portfolioId: 1,
+                             classId: classId,
+                             percent: parentPercent,
+                             amountChf: parentAmount,
+                             tolerance: tolerance)
+        for row in rows {
+            db.upsertSubClassTarget(portfolioId: 1,
+                                    subClassId: row.id,
+                                    percent: row.percent,
+                                    amountChf: row.amount,
+                                    tolerance: row.tolerance)
         }
         onClose()
     }

--- a/DragonShield/helpers/Color+Palette.swift
+++ b/DragonShield/helpers/Color+Palette.swift
@@ -12,6 +12,8 @@ extension Color {
     static let beige = Color(red: 250/255, green: 243/255, blue: 224/255)
     /// Soft blue highlight used for segmented controls and headers.
     static let softBlue = Color(red: 229/255, green: 241/255, blue: 255/255)
+    /// Very light blue used for modal background groups.
+    static let groupBlue = Color(red: 230/255, green: 244/255, blue: 255/255)
     /// Row highlight used when editing in tables.
     static let rowHighlight = Color(red: 245/255, green: 249/255, blue: 255/255)
 


### PR DESCRIPTION
## Summary
- redesign Target Edit panel as modal popover
- allow subclass target kind overrides and store CHF + percentage
- add very light blue color for modal group sections

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cd366f3cc8323a360975986f35f6d