### PR TITLE
Implement pop-over target editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -446,3 +446,4 @@ All notable changes to this project will be documented in this file.
 - Enhance deviation column with centre line, delta numbers and action icons
 - Add target_kind and tolerance_percent columns to TargetAllocation table
 - Indicate stored target_kind with a bullet when display mode matches
+- Overhaul target edit panel: modal pop-over with class and subclass sections

--- a/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
+++ b/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
@@ -253,6 +253,23 @@ struct AllocationTreeCard: View {
         }
         .onAppear { initializeExpanded() }
         .onChange(of: displayMode) { _, _ in saveMode() }
+        .overlay {
+            if let cid = editingClassId {
+                Color.black.opacity(0.4)
+                    .ignoresSafeArea()
+                    .transition(.opacity)
+                TargetEditPanel(classId: cid) {
+                    viewModel.load(using: dbManager)
+                    withAnimation { editingClassId = nil }
+                }
+                .environmentObject(dbManager)
+                .frame(maxWidth: 420)
+                .padding()
+                .background(Color.white)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .shadow(radius: 20)
+            }
+        }
     }
 
     private var SegmentedPicker: some View {
@@ -299,14 +316,6 @@ struct AllocationTreeCard: View {
                          trackWidth: trackWidth,
                          deltaWidth: deltaWidth,
                          gap: gap)
-                if let cid = Int(parent.id.dropFirst(6)), editingClassId == cid {
-                    TargetEditPanel(classId: cid) {
-                        viewModel.load(using: dbManager)
-                        withAnimation { editingClassId = nil }
-                    }
-                    .environmentObject(dbManager)
-                    .background(Color.white)
-                }
             }
             if expanded[parent.id] == true, let children = parent.children {
                 ForEach(children) { child in

--- a/DragonShield/Views/AllocationTargetsTableView.swift
+++ b/DragonShield/Views/AllocationTargetsTableView.swift
@@ -544,14 +544,22 @@ struct AllocationTargetsTableView: View {
             .background(cardBackground)
         }
         .padding(.horizontal, 24)
-        .overlay(alignment: .trailing) {
+        .overlay {
             if let cid = editingClassId {
+                Color.black.opacity(0.4)
+                    .ignoresSafeArea()
+                    .transition(.opacity)
                 TargetEditPanel(classId: cid) {
                     viewModel.load(using: dbManager)
                     refreshDrafts()
                     withAnimation { editingClassId = nil }
                 }
                 .environmentObject(dbManager)
+                .frame(maxWidth: 420)
+                .padding()
+                .background(Color.white)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .shadow(radius: 20)
             }
         }
         .onAppear {

--- a/DragonShield/helpers/Color+Palette.swift
+++ b/DragonShield/helpers/Color+Palette.swift
@@ -12,6 +12,8 @@ extension Color {
     static let beige = Color(red: 250/255, green: 243/255, blue: 224/255)
     /// Soft blue highlight used for segmented controls and headers.
     static let softBlue = Color(red: 229/255, green: 241/255, blue: 255/255)
+    /// Blue tint used for target editor headers.
+    static let sectionBlue = Color(red: 230/255, green: 244/255, blue: 255/255)
     /// Row highlight used when editing in tables.
     static let rowHighlight = Color(red: 245/255, green: 249/255, blue: 255/255)
 


### PR DESCRIPTION
## Summary
- redesign TargetEditPanel with class and subclass sections
- add `sectionBlue` color for header areas
- display editor as centered pop-over in allocation views
- update changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cd366f3cc8323a360975986f35f6d