### PR TITLE
feat(db): centralise target storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Make pencil buttons persistent with row highlight and keyboard activation
 - Show both Target % and Target CHF fields in edit pop-over with automatic conversion
 - Store all asset allocation targets solely in TargetAllocation table and drop obsolete column from PortfolioInstruments
+- Persist target kind and CHF values correctly when editing allocation targets
 - Fix compile errors in Asset Allocation dashboard views
 - Fix caption row overlay placement in Asset Allocation table
 - Remove Double Donut chart from legacy Asset Allocation view

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project will be documented in this file.
 - Show pencil button next to the Target column and open the edit panel on
   double-click
 - Make pencil buttons persistent with row highlight and keyboard activation
+- Show both Target % and Target CHF fields in edit pop-over with automatic conversion
+- Store all asset allocation targets solely in TargetAllocation table and drop obsolete column from PortfolioInstruments
 - Fix compile errors in Asset Allocation dashboard views
 - Fix caption row overlay placement in Asset Allocation table
 - Remove Double Donut chart from legacy Asset Allocation view

--- a/DragonShield/ViewModels/TargetAllocationViewModel.swift
+++ b/DragonShield/ViewModels/TargetAllocationViewModel.swift
@@ -98,10 +98,20 @@ class TargetAllocationViewModel: ObservableObject {
         _ = dbManager.updateConfiguration(key: "include_direct_re", value: includeDirectRealEstate ? "true" : "false")
         _ = dbManager.updateConfiguration(key: "direct_re_target_chf", value: String(directRealEstateTargetCHF))
         for (classId, pct) in classTargets {
-            dbManager.upsertClassTarget(portfolioId: portfolioId, classId: classId, percent: pct, tolerance: 5)
+            dbManager.upsertClassTarget(portfolioId: portfolioId,
+                                       classId: classId,
+                                       percent: pct,
+                                       amountChf: nil,
+                                       kind: "percent",
+                                       tolerance: 5)
         }
         for (subId, pct) in subClassTargets {
-            dbManager.upsertSubClassTarget(portfolioId: portfolioId, subClassId: subId, percent: pct, tolerance: 5)
+            dbManager.upsertSubClassTarget(portfolioId: portfolioId,
+                                          subClassId: subId,
+                                          percent: pct,
+                                          amountChf: nil,
+                                          kind: "percent",
+                                          tolerance: 5)
         }
     }
 

--- a/DragonShield/Views/AllocationTargetsTableView.swift
+++ b/DragonShield/Views/AllocationTargetsTableView.swift
@@ -384,11 +384,13 @@ final class AllocationTargetsTableViewModel: ObservableObject {
         guard let db else { return }
         if asset.id.hasPrefix("class-") {
             if let classId = Int(asset.id.dropFirst(6)) {
-                db.upsertClassTarget(portfolioId: 1, classId: classId, percent: asset.targetPct, amountChf: asset.targetChf, tolerance: 5)
+                let kind = asset.mode == .percent ? "percent" : "amount"
+                db.upsertClassTarget(portfolioId: 1, classId: classId, percent: asset.targetPct, amountChf: asset.targetChf, kind: kind, tolerance: 5)
             }
         } else if asset.id.hasPrefix("sub-") {
             if let subId = Int(asset.id.dropFirst(4)) {
-                db.upsertSubClassTarget(portfolioId: 1, subClassId: subId, percent: asset.targetPct, amountChf: asset.targetChf, tolerance: 5)
+                let kind = asset.mode == .percent ? "percent" : "amount"
+                db.upsertSubClassTarget(portfolioId: 1, subClassId: subId, percent: asset.targetPct, amountChf: asset.targetChf, kind: kind, tolerance: 5)
             }
         }
     }

--- a/DragonShield/database/newdb.dbqlite.sqbpro
+++ b/DragonShield/database/newdb.dbqlite.sqbpro
@@ -227,7 +227,6 @@ CREATE TABLE PortfolioInstruments (
     portfolio_id INTEGER NOT NULL,
     instrument_id INTEGER NOT NULL,
     assigned_date DATE DEFAULT CURRENT_DATE,
-    target_allocation_percent REAL DEFAULT 0,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (portfolio_id, instrument_id),
     FOREIGN KEY (portfolio_id) REFERENCES Portfolios(portfolio_id) ON DELETE CASCADE,

--- a/DragonShield/database/schema.sql
+++ b/DragonShield/database/schema.sql
@@ -1,6 +1,6 @@
 -- DragonShield/docs/schema.sql
 -- Dragon Shield Database Creation Script
--- Version 4.18 - Add target_kind and tolerance_percent columns
+-- Version 4.19 - Remove target_allocation_percent column
 -- Created: 2025-05-24
 -- Updated: 2025-07-13
 --
@@ -182,7 +182,6 @@ CREATE TABLE PortfolioInstruments (
     portfolio_id INTEGER NOT NULL,
     instrument_id INTEGER NOT NULL,
     assigned_date DATE DEFAULT CURRENT_DATE,
-    target_allocation_percent REAL DEFAULT 0,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (portfolio_id, instrument_id),
     FOREIGN KEY (portfolio_id) REFERENCES Portfolios(portfolio_id) ON DELETE CASCADE,

--- a/DragonShield/database/schema.txt
+++ b/DragonShield/database/schema.txt
@@ -29,7 +29,7 @@ INSERT INTO Configuration VALUES ('9', 'table_row_padding', '12.0', 'number', 'V
 INSERT INTO Configuration VALUES ('10', 'table_font_size', '14.0', 'number', 'Font size for text in data table rows (in points)', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('11', 'include_direct_re', 'true', 'boolean', 'Include direct real estate in allocation views', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('12', 'direct_re_target_chf', '0', 'number', 'Target CHF amount for direct real estate', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
-INSERT INTO Configuration VALUES ('13', 'db_version', '4.18', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
+INSERT INTO Configuration VALUES ('13', 'db_version', '4.19', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('CHF', 'Swiss Franc', 'CHF', '1', '0', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('EUR', 'Euro', '€', '1', '1', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('USD', 'US Dollar', '$', '1', '1', '2025-07-13 09:04:29', '2025-07-13 09:04:29');

--- a/DragonShield/docs/dragon_shield_db_documentation.md
+++ b/DragonShield/docs/dragon_shield_db_documentation.md
@@ -253,7 +253,6 @@ Analysis Layer
 - portfolio_id: Portfolio reference
 - instrument_id: Instrument reference
 - assigned_date: Assignment date
-- target_allocation_percent: Target weight
 ```
 
 ### Transaction Management Tables

--- a/migrations/006_remove_portfolio_instrument_target_column.sql
+++ b/migrations/006_remove_portfolio_instrument_target_column.sql
@@ -1,0 +1,15 @@
+CREATE TABLE PortfolioInstruments_new (
+    portfolio_id INTEGER NOT NULL,
+    instrument_id INTEGER NOT NULL,
+    assigned_date DATE DEFAULT CURRENT_DATE,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (portfolio_id, instrument_id),
+    FOREIGN KEY (portfolio_id) REFERENCES Portfolios(portfolio_id) ON DELETE CASCADE,
+    FOREIGN KEY (instrument_id) REFERENCES Instruments(instrument_id) ON DELETE CASCADE
+);
+INSERT INTO PortfolioInstruments_new (portfolio_id, instrument_id, assigned_date, created_at)
+    SELECT portfolio_id, instrument_id, assigned_date, created_at
+    FROM PortfolioInstruments;
+DROP TABLE PortfolioInstruments;
+ALTER TABLE PortfolioInstruments_new RENAME TO PortfolioInstruments;
+CREATE INDEX idx_portfolio_instruments_instrument ON PortfolioInstruments(instrument_id);

--- a/tests/test_schema_version.py
+++ b/tests/test_schema_version.py
@@ -8,4 +8,4 @@ from deploy_db import parse_version
 
 def test_schema_version_updated():
     schema_path = Path(__file__).resolve().parents[1] / 'DragonShield' / 'database' / 'schema.sql'
-    assert parse_version(str(schema_path)) == '4.18'
+    assert parse_version(str(schema_path)) == '4.19'


### PR DESCRIPTION
## Summary
- centralise asset allocation targets in TargetAllocation table
- drop obsolete `target_allocation_percent` column via migration
- document updated PortfolioInstruments table
- bump database schema version to 4.19

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cda9e9c7883238d67facb4a39c431