### PR TITLE
fix(targets): load stored CHF value in edit panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ All notable changes to this project will be documented in this file.
 - Show pencil button next to the Target column and open the edit panel on
   double-click
 - Make pencil buttons persistent with row highlight and keyboard activation
+- Show both Target % and Target CHF fields in edit pop-over with automatic conversion
+- Store all asset allocation targets solely in TargetAllocation table and drop obsolete column from PortfolioInstruments
+- Load stored Target CHF in edit pop-over, computing from portfolio total only if missing, and allow saving with non-zero remaining
 - Fix compile errors in Asset Allocation dashboard views
 - Fix caption row overlay placement in Asset Allocation table
 - Remove Double Donut chart from legacy Asset Allocation view

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - Show both Target % and Target CHF fields in edit pop-over with automatic conversion
 - Store all asset allocation targets solely in TargetAllocation table and drop obsolete column from PortfolioInstruments
 - Load stored Target CHF in edit pop-over, computing from portfolio total only if missing, and allow saving with non-zero remaining
+- Pre-populate Target % and CHF fields from database and auto-format CHF with thousands separators
 - Fix compile errors in Asset Allocation dashboard views
 - Fix caption row overlay placement in Asset Allocation table
 - Remove Double Donut chart from legacy Asset Allocation view

--- a/DragonShield/Views/TargetEditPanel.swift
+++ b/DragonShield/Views/TargetEditPanel.swift
@@ -21,6 +21,7 @@ struct TargetEditPanel: View {
     @State private var kind: TargetKind = .percent
     @State private var parentPercent: Double = 0
     @State private var parentAmount: Double = 0
+    @State private var portfolioTotal: Double = 0
     @State private var tolerance: Double = 5
     @State private var rows: [Row] = []
 
@@ -40,15 +41,7 @@ struct TargetEditPanel: View {
         }
     }
 
-    private var canSave: Bool {
-        if kind == .percent {
-            abs(subTotal - 100) < 0.1 && parentPercent >= 0
-        } else {
-            abs(subTotal - parentAmount) < 1.0 && parentAmount >= 0
-        }
-    }
 
-    private var targetLabel: String { kind == .percent ? "Target %" : "Target CHF" }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -66,14 +59,31 @@ struct TargetEditPanel: View {
                     .pickerStyle(.radioGroup)
                     .frame(width: 120)
                 }
-                HStack {
-                    Text(targetLabel)
-                    Spacer()
-                    TextField("", value: kind == .percent ? $parentPercent : $parentAmount,
-                              formatter: Self.numberFormatter)
-                        .frame(width: 80)
-                        .multilineTextAlignment(.trailing)
-                        .textFieldStyle(.roundedBorder)
+                HStack(spacing: 16) {
+                    VStack(alignment: .leading) {
+                        Text("Target %")
+                        TextField("", value: $parentPercent, formatter: Self.percentFormatter)
+                            .frame(width: 80)
+                            .multilineTextAlignment(.trailing)
+                            .textFieldStyle(.roundedBorder)
+                            .disabled(kind != .percent)
+                            .onChange(of: parentPercent) { newVal in
+                                guard kind == .percent else { return }
+                                parentAmount = portfolioTotal * newVal / 100
+                            }
+                    }
+                    VStack(alignment: .leading) {
+                        Text("Target CHF")
+                        TextField("", value: $parentAmount, formatter: Self.chfFormatter)
+                            .frame(width: 100)
+                            .multilineTextAlignment(.trailing)
+                            .textFieldStyle(.roundedBorder)
+                            .disabled(kind != .amount)
+                            .onChange(of: parentAmount) { newVal in
+                                guard kind == .amount else { return }
+                                parentPercent = portfolioTotal > 0 ? newVal / portfolioTotal * 100 : 0
+                            }
+                    }
                 }
                 HStack {
                     Text("Tolerance")
@@ -95,11 +105,12 @@ struct TargetEditPanel: View {
             Grid(alignment: .leading, horizontalSpacing: 8, verticalSpacing: 4) {
                 GridRow {
                     Text("Kind").frame(width: 80)
-                    Text("Value").frame(width: 80, alignment: .trailing)
+                    Text("Target %").frame(width: 80, alignment: .trailing)
+                    Text("Target CHF").frame(width: 100, alignment: .trailing)
                     Text("Tol %").frame(width: 60, alignment: .trailing)
                     Text("")
                 }
-                Divider().gridCellColumns(4)
+                Divider().gridCellColumns(5)
                 ForEach($rows) { $row in
                     GridRow {
                         Picker("", selection: $row.kind) {
@@ -108,12 +119,33 @@ struct TargetEditPanel: View {
                         }
                         .pickerStyle(.radioGroup)
                         .frame(width: 80)
+                        .onChange(of: row.kind) { _, newKind in
+                            if newKind == .percent {
+                                row.percent = parentAmount > 0 ? row.amount / parentAmount * 100 : 0
+                            } else {
+                                row.amount = parentAmount * row.percent / 100
+                            }
+                        }
 
-                        TextField("", value: row.kind == .percent ? $row.percent : $row.amount,
-                                  formatter: Self.numberFormatter)
+                        TextField("", value: $row.percent, formatter: Self.percentFormatter)
                             .frame(width: 80)
                             .multilineTextAlignment(.trailing)
                             .textFieldStyle(.roundedBorder)
+                            .disabled(row.kind != .percent)
+                            .onChange(of: row.percent) { newVal in
+                                guard row.kind == .percent else { return }
+                                row.amount = parentAmount * newVal / 100
+                            }
+
+                        TextField("", value: $row.amount, formatter: Self.chfFormatter)
+                            .frame(width: 100)
+                            .multilineTextAlignment(.trailing)
+                            .textFieldStyle(.roundedBorder)
+                            .disabled(row.kind != .amount)
+                            .onChange(of: row.amount) { newVal in
+                                guard row.kind == .amount else { return }
+                                row.percent = parentAmount > 0 ? newVal / parentAmount * 100 : 0
+                            }
 
                         TextField("", value: $row.tolerance, formatter: Self.numberFormatter)
                             .frame(width: 60)
@@ -123,7 +155,7 @@ struct TargetEditPanel: View {
                         Text(row.name)
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
-                    Divider().background(Color.systemGray4).gridCellColumns(4)
+                    Divider().background(Color.systemGray4).gridCellColumns(5)
                 }
             }
 
@@ -135,33 +167,79 @@ struct TargetEditPanel: View {
                 Spacer()
                 Button("Cancel") { onClose() }
                 Button("Save") { save() }
-                    .disabled(!canSave)
             }
         }
         .padding()
         .frame(minWidth: 360)
         .onAppear { load() }
+        .onChange(of: kind) { _, _ in
+            if kind == .percent {
+                parentAmount = portfolioTotal * parentPercent / 100
+            } else {
+                parentPercent = portfolioTotal > 0 ? parentAmount / portfolioTotal * 100 : 0
+            }
+            updateRows()
+        }
+        .onChange(of: parentAmount) { _, _ in
+            updateRows()
+        }
     }
 
     private func load() {
         className = db.fetchAssetClassDetails(id: classId)?.name ?? ""
+        portfolioTotal = calculatePortfolioTotal()
+
         let records = db.fetchPortfolioTargetRecords(portfolioId: 1)
         if let parent = records.first(where: { $0.classId == classId && $0.subClassId == nil }) {
             kind = parent.targetKind == "amount" ? .amount : .percent
             parentPercent = parent.percent
-            parentAmount = parent.amountCHF ?? 0
+            parentAmount = parent.amountCHF ?? portfolioTotal * parent.percent / 100
             tolerance = parent.tolerance
         }
+
         let subs = db.subAssetClasses(for: classId)
         rows = subs.map { sub in
             let rec = records.first { $0.subClassId == sub.id }
             let rk = rec?.targetKind == "amount" ? TargetKind.amount : TargetKind.percent
+            let pct = rec?.percent ?? 0
+            let amt = rec?.amountCHF ?? parentAmount * pct / 100
             return Row(id: sub.id,
                        name: sub.name,
-                       percent: rec?.percent ?? 0,
-                       amount: rec?.amountCHF ?? 0,
+                       percent: pct,
+                       amount: amt,
                        kind: rk,
                        tolerance: rec?.tolerance ?? tolerance)
+        }
+
+        updateRows()
+    }
+
+    private func calculatePortfolioTotal() -> Double {
+        var total = 0.0
+        var rateCache: [String: Double] = [:]
+        for p in db.fetchPositionReports() {
+            guard let price = p.currentPrice else { continue }
+            var value = p.quantity * price
+            let currency = p.instrumentCurrency.uppercased()
+            if currency != "CHF" {
+                if rateCache[currency] == nil {
+                    rateCache[currency] = db.fetchExchangeRates(currencyCode: currency, upTo: nil).first?.rateToChf
+                }
+                guard let r = rateCache[currency] else { continue }
+                value *= r
+            }
+            total += value
+        }
+        return total
+    }
+
+    private func updateRows() {
+        for idx in rows.indices {
+            if rows[idx].kind == .percent {
+                rows[idx].amount = parentAmount * rows[idx].percent / 100
+            } else {
+                rows[idx].percent = parentAmount > 0 ? rows[idx].amount / parentAmount * 100 : 0
+            }
         }
     }
 
@@ -202,6 +280,20 @@ struct TargetEditPanel: View {
         let f = NumberFormatter()
         f.numberStyle = .decimal
         f.maximumFractionDigits = 1
+        return f
+    }()
+
+    private static let percentFormatter: NumberFormatter = {
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        f.maximumFractionDigits = 1
+        return f
+    }()
+
+    private static let chfFormatter: NumberFormatter = {
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        f.maximumFractionDigits = 0
         return f
     }()
 }

--- a/DragonShield/database/newdb.dbqlite.sqbpro
+++ b/DragonShield/database/newdb.dbqlite.sqbpro
@@ -227,7 +227,6 @@ CREATE TABLE PortfolioInstruments (
     portfolio_id INTEGER NOT NULL,
     instrument_id INTEGER NOT NULL,
     assigned_date DATE DEFAULT CURRENT_DATE,
-    target_allocation_percent REAL DEFAULT 0,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (portfolio_id, instrument_id),
     FOREIGN KEY (portfolio_id) REFERENCES Portfolios(portfolio_id) ON DELETE CASCADE,

--- a/DragonShield/database/schema.sql
+++ b/DragonShield/database/schema.sql
@@ -1,6 +1,6 @@
 -- DragonShield/docs/schema.sql
 -- Dragon Shield Database Creation Script
--- Version 4.18 - Add target_kind and tolerance_percent columns
+-- Version 4.19 - Remove target_allocation_percent column
 -- Created: 2025-05-24
 -- Updated: 2025-07-13
 --
@@ -182,7 +182,6 @@ CREATE TABLE PortfolioInstruments (
     portfolio_id INTEGER NOT NULL,
     instrument_id INTEGER NOT NULL,
     assigned_date DATE DEFAULT CURRENT_DATE,
-    target_allocation_percent REAL DEFAULT 0,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (portfolio_id, instrument_id),
     FOREIGN KEY (portfolio_id) REFERENCES Portfolios(portfolio_id) ON DELETE CASCADE,

--- a/DragonShield/database/schema.txt
+++ b/DragonShield/database/schema.txt
@@ -29,7 +29,7 @@ INSERT INTO Configuration VALUES ('9', 'table_row_padding', '12.0', 'number', 'V
 INSERT INTO Configuration VALUES ('10', 'table_font_size', '14.0', 'number', 'Font size for text in data table rows (in points)', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('11', 'include_direct_re', 'true', 'boolean', 'Include direct real estate in allocation views', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('12', 'direct_re_target_chf', '0', 'number', 'Target CHF amount for direct real estate', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
-INSERT INTO Configuration VALUES ('13', 'db_version', '4.18', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
+INSERT INTO Configuration VALUES ('13', 'db_version', '4.19', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('CHF', 'Swiss Franc', 'CHF', '1', '0', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('EUR', 'Euro', '€', '1', '1', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('USD', 'US Dollar', '$', '1', '1', '2025-07-13 09:04:29', '2025-07-13 09:04:29');

--- a/DragonShield/docs/dragon_shield_db_documentation.md
+++ b/DragonShield/docs/dragon_shield_db_documentation.md
@@ -253,7 +253,6 @@ Analysis Layer
 - portfolio_id: Portfolio reference
 - instrument_id: Instrument reference
 - assigned_date: Assignment date
-- target_allocation_percent: Target weight
 ```
 
 ### Transaction Management Tables

--- a/migrations/006_remove_portfolio_instrument_target_column.sql
+++ b/migrations/006_remove_portfolio_instrument_target_column.sql
@@ -1,0 +1,15 @@
+CREATE TABLE PortfolioInstruments_new (
+    portfolio_id INTEGER NOT NULL,
+    instrument_id INTEGER NOT NULL,
+    assigned_date DATE DEFAULT CURRENT_DATE,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (portfolio_id, instrument_id),
+    FOREIGN KEY (portfolio_id) REFERENCES Portfolios(portfolio_id) ON DELETE CASCADE,
+    FOREIGN KEY (instrument_id) REFERENCES Instruments(instrument_id) ON DELETE CASCADE
+);
+INSERT INTO PortfolioInstruments_new (portfolio_id, instrument_id, assigned_date, created_at)
+    SELECT portfolio_id, instrument_id, assigned_date, created_at
+    FROM PortfolioInstruments;
+DROP TABLE PortfolioInstruments;
+ALTER TABLE PortfolioInstruments_new RENAME TO PortfolioInstruments;
+CREATE INDEX idx_portfolio_instruments_instrument ON PortfolioInstruments(instrument_id);

--- a/tests/test_schema_version.py
+++ b/tests/test_schema_version.py
@@ -8,4 +8,4 @@ from deploy_db import parse_version
 
 def test_schema_version_updated():
     schema_path = Path(__file__).resolve().parents[1] / 'DragonShield' / 'database' / 'schema.sql'
-    assert parse_version(str(schema_path)) == '4.18'
+    assert parse_version(str(schema_path)) == '4.19'


### PR DESCRIPTION
## Summary
- retrieve stored CHF amounts on target edit panel and recalc only if missing
- keep class and sub-class amounts synced with stored percent values
- clarify changelog note about saved CHF loading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cda9e9c7883238d67facb4a39c431