### PR TITLE
feat(allocation): add logging and validation to Edit Targets panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - Show both Target % and Target CHF fields in edit pop-over with automatic conversion
 - Store all asset allocation targets solely in TargetAllocation table and drop obsolete column from PortfolioInstruments
 - Load stored Target CHF in edit pop-over, computing from portfolio total only if missing, and allow saving with non-zero remaining
+- Add detailed logging and validation to Edit Targets panel
 - Pre-populate target amount fields from the database and format CHF values with
   thousands separators on blur
 - Fix compile errors in Asset Allocation dashboard views


### PR DESCRIPTION
## Summary
- log loading and saving of target allocations including sub-classes
- recompute CHF/percent on edit with debug logs
- validate totals before save and alert on errors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d947db5448323b1cc7c3c03c21435