### PR TITLE
fix: show stored targets in edit panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Display stored target percent and CHF in Edit Targets panel on open
 - Add segmented display mode toggle for Asset Classes tile
 - Move Asset Allocation Errors panel beside legacy targets table
 - Show database schema version in Database Management view and include it in backup file names


### PR DESCRIPTION
## Summary
- preload target percent/CHF values from TargetAllocation when opening Edit Targets panel
- log loaded values and run validation before allowing edits
- log original vs final values when saving

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688dadab1d708323a0fee8849544ab16