### PR TITLE
fix: preload stored targets in edit panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Fix Edit Targets panel to preload stored target values before validation
+- Fix Cancel button in Edit Targets panel to discard changes without saving
+- Display sub-class totals in Edit Targets panel
 - Add segmented display mode toggle for Asset Classes tile
 - Move Asset Allocation Errors panel beside legacy targets table
 - Show database schema version in Database Management view and include it in backup file names


### PR DESCRIPTION
## Summary
- ensure edit targets panel loads target values from database on appear before validation
- display summed sub-class percent and CHF totals under target fields
- log initial and final target values when editing asset allocations
- allow cancel to close target edit panel without saving changes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688dadab1d708323a0fee8849544ab16