### PR TITLE
feat: preload targets and show sub-class totals in edit panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Fix Edit Targets panel to preload stored target values before validation
+- Fix Cancel button in Edit Targets panel to discard changes without saving
+- Display sub-class target sums and log totals in Edit Targets panel
 - Add segmented display mode toggle for Asset Classes tile
 - Move Asset Allocation Errors panel beside legacy targets table
 - Show database schema version in Database Management view and include it in backup file names

--- a/DragonShield/Views/TargetEditPanel.swift
+++ b/DragonShield/Views/TargetEditPanel.swift
@@ -29,6 +29,11 @@ struct TargetEditPanel: View {
     @State private var rows: [Row] = []
     @State private var validationWarnings: [String] = []
     @State private var isInitialLoad = true
+    @State private var initialPercent: Double = 0
+    @State private var initialAmount: Double = 0
+    @State private var initialKind: TargetKind = .percent
+    @State private var initialTolerance: Double = 0
+    @State private var initialRows: [Int: Row] = [:]
 
     private var subTotal: Double {
         if kind == .percent {
@@ -44,6 +49,14 @@ struct TargetEditPanel: View {
         } else {
             parentAmount - subTotal
         }
+    }
+
+    private var sumChildPercent: Double {
+        rows.map(\.percent).reduce(0, +)
+    }
+
+    private var sumChildAmount: Double {
+        rows.map(\.amount).reduce(0, +)
     }
 
 
@@ -100,19 +113,25 @@ struct TargetEditPanel: View {
                             }
                     }
                 }
-                HStack {
-                    Text("Tolerance")
-                    Spacer()
-                    TextField("", value: $tolerance, formatter: Self.numberFormatter)
-                        .frame(width: 60)
-                        .multilineTextAlignment(.trailing)
-                        .textFieldStyle(.roundedBorder)
-                    Text("%")
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Σ Sub-class % = \(sumChildPercent, format: .number.precision(.fractionLength(1)))%")
+                    Text("Σ Sub-class CHF = \(formatChf(sumChildAmount))")
                 }
+                .foregroundColor(.secondary)
             }
             .padding(8)
             .background(Color.sectionBlue)
             .clipShape(RoundedRectangle(cornerRadius: 6))
+
+            HStack {
+                Text("Tolerance")
+                Spacer()
+                TextField("", value: $tolerance, formatter: Self.numberFormatter)
+                    .frame(width: 60)
+                    .multilineTextAlignment(.trailing)
+                    .textFieldStyle(.roundedBorder)
+                Text("%")
+            }
 
             Text("Sub-Class Targets:")
                 .font(.headline)
@@ -202,7 +221,7 @@ struct TargetEditPanel: View {
             HStack {
                 Button("Auto-balance") { autoBalance() }
                 Spacer()
-                Button("Cancel") { onClose() }
+                Button("Cancel") { cancel() }
                 Button("Save") { save() }
             }
         }
@@ -210,6 +229,7 @@ struct TargetEditPanel: View {
         .frame(minWidth: 360)
         .onAppear { load() }
         .onChange(of: kind) { _, _ in
+            guard !isInitialLoad else { return }
             if kind == .percent {
                 parentAmount = portfolioTotal * parentPercent / 100
             } else {
@@ -218,6 +238,7 @@ struct TargetEditPanel: View {
             updateRows()
         }
         .onChange(of: parentAmount) { _, _ in
+            guard !isInitialLoad else { return }
             updateRows()
         }
         .onChange(of: focusedChfField) { oldValue, newValue in
@@ -245,6 +266,10 @@ struct TargetEditPanel: View {
             parentPercent = parent.percent
             parentAmount = parent.amountCHF ?? portfolioTotal * parent.percent / 100
             tolerance = parent.tolerance
+            initialKind = kind
+            initialPercent = parentPercent
+            initialAmount = parentAmount
+            initialTolerance = tolerance
         }
 
         let subs = db.subAssetClasses(for: classId)
@@ -260,15 +285,19 @@ struct TargetEditPanel: View {
                        kind: rk,
                        tolerance: rec?.tolerance ?? tolerance)
         }
+        initialRows = Dictionary(uniqueKeysWithValues: rows.map { ($0.id, $0) })
 
         updateRows()
         if focusedChfField == nil {
             refreshDrafts()
         }
-        log("EDIT PANEL LOAD", "Loading \"\(className)\" id=\(classId): percent=\(parentPercent), CHF=\(parentAmount), kind=\(kind.rawValue), tol=\(tolerance)", type: .info)
+        let childPct = rows.map(\.percent).reduce(0, +)
+        let childChf = rows.map(\.amount).reduce(0, +)
+        log("INFO", "EditTargetsPanel load → parent \(String(format: "%.1f", parentPercent))% / \(formatChf(parentAmount)) CHF; children sum \(String(format: "%.1f", childPct))% / \(formatChf(childChf)) CHF", type: .info)
         for r in rows {
-            log("EDIT PANEL LOAD", "Loading sub-class \"\(r.name)\" id=\(r.id): percent=\(r.percent), CHF=\(r.amount), kind=\(r.kind.rawValue), tol=\(r.tolerance)", type: .info)
+            log("EDIT PANEL LOAD", "Loaded sub-class \"\(r.name)\" id=\(r.id): percent=\(r.percent), CHF=\(r.amount), kind=\(r.kind.rawValue), tol=\(r.tolerance)", type: .info)
         }
+        validationWarnings = validateAll()
         isInitialLoad = false
     }
 
@@ -408,22 +437,37 @@ struct TargetEditPanel: View {
         return warnings
     }
 
+    private func cancel() {
+        isInitialLoad = true
+        log("EDIT PANEL CANCEL", "Discarded changes for \(className)", type: .info)
+        kind = initialKind
+        parentPercent = initialPercent
+        parentAmount = initialAmount
+        tolerance = initialTolerance
+        rows = Array(initialRows.values).sorted { $0.id < $1.id }
+        refreshDrafts()
+        validationWarnings = []
+        isInitialLoad = false
+        onClose()
+    }
+
     private func save() {
+        log("EDIT PANEL SAVE", "\(className): percent \(initialPercent)→\(parentPercent), CHF \(initialAmount)→\(parentAmount), kind \(initialKind.rawValue)→\(kind.rawValue), tol \(initialTolerance)→\(tolerance)", type: .info)
         db.upsertClassTarget(portfolioId: 1,
                              classId: classId,
                              percent: parentPercent,
                              amountChf: parentAmount,
                              kind: kind.rawValue,
                              tolerance: tolerance)
-        log("DB WRITE", "Saving \"\(className)\" id=\(classId): percent=\(parentPercent), CHF=\(parentAmount), kind=\(kind.rawValue), tol=\(tolerance)", type: .info)
         for row in rows {
+            let initial = initialRows[row.id]
+            log("EDIT PANEL SAVE", "sub-class \"\(row.name)\" id=\(row.id): percent \(initial?.percent ?? 0)→\(row.percent), CHF \(initial?.amount ?? 0)→\(row.amount), kind \(initial?.kind.rawValue ?? row.kind.rawValue)→\(row.kind.rawValue), tol \(initial?.tolerance ?? row.tolerance)→\(row.tolerance)", type: .info)
             db.upsertSubClassTarget(portfolioId: 1,
                                     subClassId: row.id,
                                     percent: row.percent,
                                     amountChf: row.amount,
                                     kind: row.kind.rawValue,
                                     tolerance: row.tolerance)
-            log("DB WRITE", "Saving sub-class \"\(row.name)\" id=\(row.id): percent=\(row.percent), CHF=\(row.amount), kind=\(row.kind.rawValue), tol=\(row.tolerance)", type: .info)
         }
         let warnings = validateAll()
         validationWarnings = warnings


### PR DESCRIPTION
## Summary
- ensure edit targets panel loads target values from database on appear before validation
- display read-only sub-class target totals and log child sums on panel load
- log initial and final target values when editing asset allocations
- allow cancel to close target edit panel without saving changes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688dadab1d708323a0fee8849544ab16