### PR TITLE
fix(ui): show stored target metadata and fix cancel in Edit Targets panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Fix Edit Targets panel to preload stored target values before validation
+- Format CHF values in Edit Targets load logs and align metadata label casing
 - Fix Cancel button in Edit Targets panel to discard changes without saving
 - Display sub-class target sums and log totals in Edit Targets panel
 - Show stored target metadata with last updated timestamp in Edit Targets panel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 - Fix Edit Targets panel to preload stored target values before validation
 - Fix Cancel button in Edit Targets panel to discard changes without saving
 - Display sub-class target sums and log totals in Edit Targets panel
+- Show stored target metadata with last updated timestamp in Edit Targets panel
 - Add segmented display mode toggle for Asset Classes tile
 - Move Asset Allocation Errors panel beside legacy targets table
 - Show database schema version in Database Management view and include it in backup file names

--- a/DragonShield/DatabaseManager+PortfolioTargets.swift
+++ b/DragonShield/DatabaseManager+PortfolioTargets.swift
@@ -170,6 +170,44 @@ extension DatabaseManager {
         return results
     }
 
+    /// Returns stored target information for a single asset class.
+    func fetchClassTargetRecord(classId: Int) -> (
+        percent: Double,
+        amountCHF: Double?,
+        targetKind: String,
+        tolerance: Double,
+        updatedAt: String?
+    )? {
+        var result: (
+            percent: Double,
+            amountCHF: Double?,
+            targetKind: String,
+            tolerance: Double,
+            updatedAt: String?
+        )?
+        let query = "SELECT COALESCE(target_percent,0), target_amount_chf, target_kind, tolerance_percent, updated_at FROM TargetAllocation WHERE asset_class_id = ? AND sub_class_id IS NULL"
+        var statement: OpaquePointer?
+        if sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_int(statement, 1, Int32(classId))
+            if sqlite3_step(statement) == SQLITE_ROW {
+                let pct = sqlite3_column_double(statement, 0)
+                let amount = sqlite3_column_type(statement, 1) == SQLITE_NULL ? nil : sqlite3_column_double(statement, 1)
+                let kind = String(cString: sqlite3_column_text(statement, 2))
+                let tol = sqlite3_column_double(statement, 3)
+                let updated = sqlite3_column_type(statement, 4) == SQLITE_NULL ? nil : String(cString: sqlite3_column_text(statement, 4))
+                result = (percent: pct,
+                          amountCHF: amount,
+                          targetKind: kind,
+                          tolerance: tol,
+                          updatedAt: updated)
+            }
+        } else {
+            LoggingService.shared.log("Failed to prepare fetchClassTargetRecord: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+        sqlite3_finalize(statement)
+        return result
+    }
+
     /// Upsert a class-level target percentage.
     func upsertClassTarget(portfolioId: Int, classId: Int, percent: Double, amountChf: Double? = nil, kind: String = "percent", tolerance: Double) {
         let query = """

--- a/DragonShield/Views/TargetEditPanel.swift
+++ b/DragonShield/Views/TargetEditPanel.swift
@@ -34,6 +34,7 @@ struct TargetEditPanel: View {
     @State private var initialKind: TargetKind = .percent
     @State private var initialTolerance: Double = 0
     @State private var initialRows: [Int: Row] = [:]
+    @State private var updatedAt: String = ""
 
     private var subTotal: Double {
         if kind == .percent {
@@ -121,6 +122,22 @@ struct TargetEditPanel: View {
             }
             .padding(8)
             .background(Color.sectionBlue)
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack {
+                    Text("KIND: \(initialKind == .percent ? "%" : "CHF")")
+                    Spacer()
+                    Text("Target %: \(String(format: "%.1f%%", initialPercent))")
+                }
+                HStack {
+                    Text("Target CHF: \(formatChf(initialAmount))")
+                    Spacer()
+                    Text("Last updated: \(updatedAt)")
+                }
+            }
+            .padding(8)
+            .background(Color.yellow.opacity(0.3))
             .clipShape(RoundedRectangle(cornerRadius: 6))
 
             HStack {
@@ -260,18 +277,19 @@ struct TargetEditPanel: View {
         portfolioTotal = calculatePortfolioTotal()
         validationWarnings = []
 
-        let records = db.fetchPortfolioTargetRecords(portfolioId: 1)
-        if let parent = records.first(where: { $0.classId == classId && $0.subClassId == nil }) {
+        if let parent = db.fetchClassTargetRecord(classId: classId) {
             kind = parent.targetKind == "amount" ? .amount : .percent
             parentPercent = parent.percent
             parentAmount = parent.amountCHF ?? portfolioTotal * parent.percent / 100
             tolerance = parent.tolerance
+            updatedAt = parent.updatedAt ?? ""
             initialKind = kind
             initialPercent = parentPercent
             initialAmount = parentAmount
             initialTolerance = tolerance
         }
 
+        let records = db.fetchPortfolioTargetRecords(portfolioId: 1)
         let subs = db.subAssetClasses(for: classId)
         rows = subs.map { sub in
             let rec = records.first { $0.subClassId == sub.id }
@@ -291,9 +309,8 @@ struct TargetEditPanel: View {
         if focusedChfField == nil {
             refreshDrafts()
         }
-        let childPct = rows.map(\.percent).reduce(0, +)
-        let childChf = rows.map(\.amount).reduce(0, +)
-        log("INFO", "EditTargetsPanel load → parent \(String(format: "%.1f", parentPercent))% / \(formatChf(parentAmount)) CHF; children sum \(String(format: "%.1f", childPct))% / \(formatChf(childChf)) CHF", type: .info)
+        let kindStr = kind == .percent ? "%" : "CHF"
+        log("INFO", "EditTargetsPanel load AssetClass=\(className) → kind=\(kindStr), percent=\(parentPercent), CHF=\(parentAmount), tol=\(tolerance), updated=\(updatedAt)", type: .info)
         for r in rows {
             log("EDIT PANEL LOAD", "Loaded sub-class \"\(r.name)\" id=\(r.id): percent=\(r.percent), CHF=\(r.amount), kind=\(r.kind.rawValue), tol=\(r.tolerance)", type: .info)
         }
@@ -438,16 +455,7 @@ struct TargetEditPanel: View {
     }
 
     private func cancel() {
-        isInitialLoad = true
-        log("EDIT PANEL CANCEL", "Discarded changes for \(className)", type: .info)
-        kind = initialKind
-        parentPercent = initialPercent
-        parentAmount = initialAmount
-        tolerance = initialTolerance
-        rows = Array(initialRows.values).sorted { $0.id < $1.id }
-        refreshDrafts()
-        validationWarnings = []
-        isInitialLoad = false
+        log("INFO", "EditTargetsPanel canceled for AssetClass=\(className)", type: .info)
         onClose()
     }
 

--- a/DragonShield/Views/TargetEditPanel.swift
+++ b/DragonShield/Views/TargetEditPanel.swift
@@ -126,7 +126,7 @@ struct TargetEditPanel: View {
 
             VStack(alignment: .leading, spacing: 2) {
                 HStack {
-                    Text("KIND: \(initialKind == .percent ? "%" : "CHF")")
+                    Text("Kind: \(initialKind == .percent ? "%" : "CHF")")
                     Spacer()
                     Text("Target %: \(String(format: "%.1f%%", initialPercent))")
                 }
@@ -310,7 +310,7 @@ struct TargetEditPanel: View {
             refreshDrafts()
         }
         let kindStr = kind == .percent ? "%" : "CHF"
-        log("INFO", "EditTargetsPanel load AssetClass=\(className) → kind=\(kindStr), percent=\(parentPercent), CHF=\(parentAmount), tol=\(tolerance), updated=\(updatedAt)", type: .info)
+        log("INFO", "EditTargetsPanel load AssetClass=\(className) → kind=\(kindStr), percent=\(parentPercent), CHF=\(formatChf(parentAmount)), tol=\(tolerance), updated=\(updatedAt)", type: .info)
         for r in rows {
             log("EDIT PANEL LOAD", "Loaded sub-class \"\(r.name)\" id=\(r.id): percent=\(r.percent), CHF=\(r.amount), kind=\(r.kind.rawValue), tol=\(r.tolerance)", type: .info)
         }


### PR DESCRIPTION
## Summary
- load class-level target allocations from the DB and display their metadata
- dismiss Edit Targets panel on cancel without validation
- log load and cancel events and document changes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688dbd3528bc8323adafd3f3ceb3e4aa