### PR TITLE
fix(targets): resolve TargetEditPanel build errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Resolve TargetEditPanel build errors by adding class target fetch helper and removing duplicate color definitions
 - Fix Edit Targets panel to preload stored target values before validation
 - Fix Cancel button in Edit Targets panel to discard changes without saving
 - Display sub-class target sums and log totals in Edit Targets panel

--- a/DragonShield/DatabaseManager+PortfolioTargets.swift
+++ b/DragonShield/DatabaseManager+PortfolioTargets.swift
@@ -170,6 +170,54 @@ extension DatabaseManager {
         return results
     }
 
+    /// Fetches the stored target values for a single asset class.
+    /// - Parameter classId: The asset class identifier.
+    /// - Returns: Tuple containing target details or `nil` if not found.
+    func fetchClassTargetRecord(classId: Int) -> (
+        percent: Double,
+        amountCHF: Double?,
+        targetKind: String,
+        tolerance: Double,
+        updatedAt: String?
+    )? {
+        let query = """
+            SELECT COALESCE(target_percent,0), target_amount_chf, target_kind,
+                   tolerance_percent, updated_at
+            FROM TargetAllocation
+            WHERE asset_class_id = ? AND sub_class_id IS NULL
+            LIMIT 1;
+        """
+        var statement: OpaquePointer?
+        var result: (
+            percent: Double,
+            amountCHF: Double?,
+            targetKind: String,
+            tolerance: Double,
+            updatedAt: String?
+        )? = nil
+        if sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_int(statement, 1, Int32(classId))
+            if sqlite3_step(statement) == SQLITE_ROW {
+                let pct = sqlite3_column_double(statement, 0)
+                let amount = sqlite3_column_type(statement, 1) == SQLITE_NULL ? nil : sqlite3_column_double(statement, 1)
+                let kind = String(cString: sqlite3_column_text(statement, 2))
+                let tol = sqlite3_column_double(statement, 3)
+                let updated = sqlite3_column_type(statement, 4) == SQLITE_NULL ? nil : String(cString: sqlite3_column_text(statement, 4))
+                result = (
+                    percent: pct,
+                    amountCHF: amount,
+                    targetKind: kind,
+                    tolerance: tol,
+                    updatedAt: updated
+                )
+            }
+        } else {
+            LoggingService.shared.log("Failed to prepare fetchClassTargetRecord: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+        sqlite3_finalize(statement)
+        return result
+    }
+
     /// Upsert a class-level target percentage.
     func upsertClassTarget(portfolioId: Int, classId: Int, percent: Double, amountChf: Double? = nil, kind: String = "percent", tolerance: Double) {
         let query = """

--- a/DragonShield/Views/TargetEditPanel.swift
+++ b/DragonShield/Views/TargetEditPanel.swift
@@ -574,11 +574,6 @@ struct TargetEditPanel: View {
     }()
 }
 
-extension Color {
-    static let sectionBlue = Color(red: 0.9, green: 0.95, blue: 1.0)
-    static let systemGray4 = Color(red: 0.82, green: 0.82, blue: 0.84)
-}
-
 struct TargetEditPanel_Previews: PreviewProvider {
     static var previews: some View {
         TargetEditPanel(classId: 1, onClose: {})


### PR DESCRIPTION
## Summary
- add DatabaseManager.fetchClassTargetRecord helper
- rely on shared color palette in TargetEditPanel
- document build fix in changelog

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e040b265483239021f06b65234b2d