### PR TITLE
fix(backup): include all tables in full backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - Show both Target % and Target CHF fields in edit pop-over with automatic conversion
 - Store all asset allocation targets solely in TargetAllocation table and drop obsolete column from PortfolioInstruments
 - Load stored Target CHF in edit pop-over, computing from portfolio total only if missing, and allow saving with non-zero remaining
+- Include all tables and SQLite metadata in full database backup and restore
 - Add detailed logging and validation to Edit Targets panel
 - Fix Edit Targets validation to sum all asset- and sub-class targets with detailed logging
 - Load and persist target edits with dual-field mode and non-blocking validation warnings

--- a/DragonShield/BackupService.swift
+++ b/DragonShield/BackupService.swift
@@ -31,14 +31,6 @@ class BackupService: ObservableObject {
     private let timeFormatter: DateFormatter
     private let isoFormatter = ISO8601DateFormatter()
 
-    let fullTables = [
-        "Configuration", "Currencies", "ExchangeRates", "FxRateUpdates",
-        "AssetClasses", "AssetSubClasses", "Instruments", "Portfolios",
-        "PortfolioInstruments", "AccountTypes", "Institutions", "Accounts",
-        "TransactionTypes", "Transactions", "ImportSessions", "PositionReports",
-        "ImportSessionValueReports", "TargetAllocation"
-    ]
-
     let referenceTables = [
         "Configuration", "Currencies", "ExchangeRates", "FxRateUpdates",
         "AssetClasses", "AssetSubClasses", "TransactionTypes", "AccountTypes",
@@ -50,6 +42,10 @@ class BackupService: ObservableObject {
         "PositionReports", "ImportSessions", "ImportSessionValueReports",
         "ExchangeRates", "TargetAllocation"
     ]
+
+    var fullTables: [String] {
+        Array(Set(referenceTables + transactionTables)).sorted()
+    }
 
     init() {
         self.timeFormatter = DateFormatter()

--- a/DragonShield/docs/Dragon_Shield_Database_Management_Plan.md
+++ b/DragonShield/docs/Dragon_Shield_Database_Management_Plan.md
@@ -60,6 +60,11 @@ The system must track the version of the database schema in use. This allows com
 - Add "Create Backup" button that saves the current database file.
 - Provide a restore picker to load a selected backup.
 - Include safety warnings before overwriting data.
+- Full database backups now capture every table and row, including Configuration,
+  Currencies, ExchangeRates, FxRateUpdates, AssetClasses, AssetSubClasses,
+  Instruments, Portfolios, PortfolioInstruments, AccountTypes, Institutions,
+  Accounts, TransactionTypes, Transactions, ImportSessions, PositionReports,
+  ImportSessionValueReports and TargetAllocation.
 
 ### Step 3: Reference Data Management in UI
 - Build editor views for currencies, institutions, and account types.

--- a/DragonShield/python_scripts/backup_restore.py
+++ b/DragonShield/python_scripts/backup_restore.py
@@ -13,12 +13,12 @@ from typing import Dict, Tuple
 
 def _row_counts(conn: sqlite3.Connection) -> Dict[str, int]:
     cur = conn.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%';"
+        "SELECT name FROM sqlite_master WHERE type='table';"
     )
     tables = [r[0] for r in cur.fetchall()]
     counts = {}
     for tbl in tables:
-        cur = conn.execute(f"SELECT COUNT(*) FROM {tbl};")
+        cur = conn.execute(f'SELECT COUNT(*) FROM "{tbl}";')
         counts[tbl] = cur.fetchone()[0]
     return counts
 


### PR DESCRIPTION
## Summary
- include SQLite internal tables in backup and restore utilities
- derive full table list from reference and transaction sets in BackupService
- document full database backup coverage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689207f8c3bc8323b0999a6996227803