### PR TITLE
fix: include all tables in full database backups and restores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Ensure full backups and restores include all tables and data
 - Fix Edit Targets panel to preload stored target values before validation
 - Fix Cancel button in Edit Targets panel to discard changes without saving
 - Display sub-class target sums and log totals in Edit Targets panel

--- a/DragonShield/Views/DatabaseManagementView.swift
+++ b/DragonShield/Views/DatabaseManagementView.swift
@@ -354,7 +354,7 @@ struct DatabaseManagementView: View {
         DispatchQueue.global().async {
             do {
                 try? backupService.updateBackupDirectory(to: url.deletingLastPathComponent())
-                _ = try backupService.performBackup(dbManager: dbManager, dbPath: dbManager.dbFilePath, to: url, tables: backupService.fullTables, label: "Full")
+                _ = try backupService.performBackup(dbManager: dbManager, dbPath: dbManager.dbFilePath, to: url, label: "Full")
                 DispatchQueue.main.async { processing = false }
             } catch {
                 DispatchQueue.main.async {
@@ -440,7 +440,7 @@ struct DatabaseManagementView: View {
         processing = true
         DispatchQueue.global().async {
             do {
-                let result = try backupService.performRestore(dbManager: dbManager, from: url, tables: backupService.fullTables, label: "Full")
+                let result = try backupService.performRestore(dbManager: dbManager, from: url, label: "Full")
                 DispatchQueue.main.async {
                     processing = false
                     restoreDeltas = result


### PR DESCRIPTION
## Summary
- enumerate database tables dynamically during full backup
- compare row counts for every table during restore
- record change in changelog

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689207f8c3bc8323b0999a6996227803