### PR TITLE
feat(db): add class target tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Introduce ClassTargets and SubClassTargets tables with migration logging
+- Add script to reset database and import legacy data
+- Fix legacy data import script to preserve new tables when loading old data
+- Fix legacy import script to handle column mismatches when copying data
 - Fix Edit Targets panel to preload stored target values before validation
 - Fix Cancel button in Edit Targets panel to discard changes without saving
 - Display sub-class target sums and log totals in Edit Targets panel

--- a/DragonShield/database/schema.txt
+++ b/DragonShield/database/schema.txt
@@ -4,6 +4,7 @@
 -- Updated: 2025-07-13
 --
 -- RECENT HISTORY:
+-- - v4.19 -> v4.20: Replace TargetAllocation with ClassTargets/SubClassTargets and add TargetChangeLog
 -- - v4.7 -> v4.8: Added Institutions table and updated Accounts seed data.
 -- - v4.6 -> v4.7: Added db_version configuration row.
 -- - v4.5 -> v4.6: Seed data split from schema.sql
@@ -29,7 +30,7 @@ INSERT INTO Configuration VALUES ('9', 'table_row_padding', '12.0', 'number', 'V
 INSERT INTO Configuration VALUES ('10', 'table_font_size', '14.0', 'number', 'Font size for text in data table rows (in points)', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('11', 'include_direct_re', 'true', 'boolean', 'Include direct real estate in allocation views', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('12', 'direct_re_target_chf', '0', 'number', 'Target CHF amount for direct real estate', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
-INSERT INTO Configuration VALUES ('13', 'db_version', '4.19', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
+INSERT INTO Configuration VALUES ('13', 'db_version', '4.20', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('CHF', 'Swiss Franc', 'CHF', '1', '0', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('EUR', 'Euro', '€', '1', '1', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('USD', 'US Dollar', '$', '1', '1', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
@@ -348,18 +349,18 @@ INSERT INTO PositionReports VALUES (
 );
 
 -- Target allocations (class level)
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (4, NULL, 40, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (7, NULL, 15, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (2, NULL, 35, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (1, NULL, 15, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (3, NULL, 5, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
+INSERT INTO ClassTargets VALUES ('1', 4, 'percent', 40, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO ClassTargets VALUES ('2', 7, 'percent', 15, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO ClassTargets VALUES ('3', 2, 'percent', 35, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO ClassTargets VALUES ('4', 1, 'percent', 15, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO ClassTargets VALUES ('5', 3, 'percent', 5, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
 
 -- Target allocations (sub-class level)
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (4, 11, 30, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (4, 14, 10, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (7, 18, 10, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (7, 21, 5, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (2, 3, 20, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (2, 4, 15, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (1, 1, 15, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (3, 7, 5, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets VALUES ('1', 1, 11, 'percent', 30, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets VALUES ('2', 1, 14, 'percent', 10, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets VALUES ('3', 2, 18, 'percent', 10, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets VALUES ('4', 2, 21, 'percent', 5, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets VALUES ('5', 3, 3, 'percent', 20, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets VALUES ('6', 3, 4, 'percent', 15, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets VALUES ('7', 4, 1, 'percent', 15, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets VALUES ('8', 5, 7, 'percent', 5, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');

--- a/DragonShield/docs/Dragon_Shield_Database_Management_Plan.md
+++ b/DragonShield/docs/Dragon_Shield_Database_Management_Plan.md
@@ -64,7 +64,7 @@ The system must track the version of the database schema in use. This allows com
   Currencies, ExchangeRates, FxRateUpdates, AssetClasses, AssetSubClasses,
   Instruments, Portfolios, PortfolioInstruments, AccountTypes, Institutions,
   Accounts, TransactionTypes, Transactions, ImportSessions, PositionReports,
-  ImportSessionValueReports and TargetAllocation.
+  ImportSessionValueReports, ClassTargets, SubClassTargets and TargetChangeLog.
 
 ### Step 3: Reference Data Management in UI
 - Build editor views for currencies, institutions, and account types.

--- a/DragonShield/python_scripts/load_legacy_db.py
+++ b/DragonShield/python_scripts/load_legacy_db.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Reset database contents and import data from a legacy database file.
+
+The target database keeps its current schema. All rows are deleted from
+every table and then re-populated with the data taken from a legacy
+database. New tables that did not exist in the legacy file remain and
+are populated by running the migration logic for the former
+``TargetAllocation`` table.
+"""
+import argparse
+import sqlite3
+from pathlib import Path
+from typing import Dict, Iterable
+
+def _row_counts(conn: sqlite3.Connection) -> Dict[str, int]:
+    cur = conn.execute("SELECT name FROM sqlite_master WHERE type='table';")
+    counts = {}
+    for (tbl,) in cur.fetchall():
+        cur2 = conn.execute(f'SELECT COUNT(*) FROM "{tbl}";')
+        counts[tbl] = cur2.fetchone()[0]
+    return counts
+
+def _table_names(conn: sqlite3.Connection, schema: str = "main") -> Iterable[str]:
+    cur = conn.execute(
+        f"SELECT name FROM {schema}.sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%';"
+    )
+    return [name for (name,) in cur.fetchall()]
+
+
+def load_legacy_database(target: Path, legacy: Path) -> Dict[str, int]:
+    """Load data from ``legacy`` into ``target`` preserving the target schema."""
+    with sqlite3.connect(target) as conn:
+        conn.execute("PRAGMA foreign_keys=OFF")
+        conn.execute("ATTACH DATABASE ? AS legacy", (str(legacy),))
+
+        # Remove existing rows from all tables in the target database
+        main_tables = _table_names(conn)
+        for tbl in main_tables:
+            conn.execute(f'DELETE FROM "{tbl}";')
+            conn.execute("DELETE FROM sqlite_sequence WHERE name=?", (tbl,))
+
+        # Copy tables from legacy database
+        legacy_tables = _table_names(conn, "legacy")
+        for tbl in legacy_tables:
+            if tbl in main_tables:
+                # Align columns between schemas. Use only columns that exist in
+                # both tables to avoid mismatches when schemas differ.
+                main_cols = [row[1] for row in conn.execute(f'PRAGMA main.table_info("{tbl}")')]
+                legacy_cols = [row[1] for row in conn.execute(f'PRAGMA legacy.table_info("{tbl}")')]
+                common = [col for col in legacy_cols if col in main_cols]
+                if not common:
+                    continue
+                col_csv = ", ".join(f'"{c}"' for c in common)
+                conn.execute(
+                    f'INSERT INTO "{tbl}" ({col_csv}) SELECT {col_csv} FROM legacy."{tbl}";'
+                )
+            else:
+                create_sql = conn.execute(
+                    "SELECT sql FROM legacy.sqlite_master WHERE type='table' AND name=?", (tbl,)
+                ).fetchone()[0]
+                conn.execute(create_sql)
+                conn.execute(f'INSERT INTO "{tbl}" SELECT * FROM legacy."{tbl}";')
+
+        # Backfill ClassTargets and SubClassTargets from TargetAllocation data
+        if "TargetAllocation" in legacy_tables:
+            conn.executescript(
+                """
+                INSERT INTO ClassTargets (asset_class_id, target_kind, target_percent, target_amount_chf, tolerance_percent, created_at, updated_at)
+                SELECT asset_class_id,
+                       CASE WHEN target_kind IS NOT NULL THEN target_kind
+                            WHEN target_percent IS NOT NULL THEN 'percent'
+                            ELSE 'amount' END,
+                       COALESCE(target_percent,0),
+                       COALESCE(target_amount_chf,0),
+                       COALESCE(tolerance_percent,0),
+                       COALESCE(created_at,CURRENT_TIMESTAMP),
+                       COALESCE(updated_at,CURRENT_TIMESTAMP)
+                FROM TargetAllocation
+                WHERE sub_class_id IS NULL;
+
+                INSERT INTO TargetChangeLog (target_type, target_id, field_name, old_value, new_value, changed_by)
+                SELECT 'class', id, 'migration', NULL, 'backfill', 'script'
+                FROM ClassTargets;
+
+                INSERT INTO SubClassTargets (class_target_id, asset_sub_class_id, target_kind, target_percent, target_amount_chf, tolerance_percent, created_at, updated_at)
+                SELECT ct.id, ta.sub_class_id,
+                       CASE WHEN ta.target_kind IS NOT NULL THEN ta.target_kind
+                            WHEN ta.target_percent IS NOT NULL THEN 'percent'
+                            ELSE 'amount' END,
+                       COALESCE(ta.target_percent,0),
+                       COALESCE(ta.target_amount_chf,0),
+                       COALESCE(ta.tolerance_percent,0),
+                       COALESCE(ta.created_at,CURRENT_TIMESTAMP),
+                       COALESCE(ta.updated_at,CURRENT_TIMESTAMP)
+                FROM TargetAllocation ta
+                JOIN ClassTargets ct ON ct.asset_class_id = ta.asset_class_id
+                WHERE ta.sub_class_id IS NOT NULL;
+
+                INSERT INTO TargetChangeLog (target_type, target_id, field_name, old_value, new_value, changed_by)
+                SELECT 'subclass', id, 'migration', NULL, 'backfill', 'script'
+                FROM SubClassTargets;
+
+                DROP TABLE TargetAllocation;
+                """
+            )
+
+        # Ensure the database version matches the current schema
+        conn.execute("UPDATE Configuration SET value=? WHERE key='db_version'", ("4.20",))
+        conn.commit()
+        conn.execute("DETACH DATABASE legacy")
+        check = conn.execute("PRAGMA integrity_check;").fetchone()[0]
+        if check != "ok":
+            raise RuntimeError("Integrity check failed after import")
+        counts = _row_counts(conn)
+    return counts
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Empty a database and load data from a legacy version"
+    )
+    parser.add_argument("target", type=Path, help="Path to dragonshield.sqlite to overwrite")
+    parser.add_argument("legacy", type=Path, help="Path to legacy dragonshield.sqlite")
+    args = parser.parse_args(argv)
+
+    counts = load_legacy_database(args.target, args.legacy)
+    print("Import Summary")
+    print(f"{'Table':20}Rows")
+    for tbl, cnt in counts.items():
+        print(f"{tbl:20}{cnt}")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/DragonShield/test_data/reference_data.sql
+++ b/DragonShield/test_data/reference_data.sql
@@ -21,7 +21,7 @@ INSERT INTO Configuration VALUES ('9', 'table_row_padding', '12.0', 'number', 'V
 INSERT INTO Configuration VALUES ('10', 'table_font_size', '14.0', 'number', 'Font size for text in data table rows (in points)', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('11', 'include_direct_re', 'true', 'boolean', 'Include direct real estate in allocation views', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('12', 'direct_re_target_chf', '0', 'number', 'Target CHF amount for direct real estate', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
-INSERT INTO Configuration VALUES ('13', 'db_version', '4.18', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
+INSERT INTO Configuration VALUES ('13', 'db_version', '4.20', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 CREATE TABLE Currencies (
     currency_code TEXT PRIMARY KEY,
     currency_name TEXT NOT NULL,

--- a/migrations/007_add_class_target_tables.sql
+++ b/migrations/007_add_class_target_tables.sql
@@ -1,0 +1,74 @@
+CREATE TABLE ClassTargets (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  asset_class_id INTEGER NOT NULL REFERENCES AssetClasses(class_id),
+  target_kind TEXT NOT NULL CHECK(target_kind IN('percent','amount')),
+  target_percent REAL DEFAULT 0,
+  target_amount_chf REAL DEFAULT 0,
+  tolerance_percent REAL DEFAULT 0,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT ck_class_nonneg CHECK(target_percent >= 0 AND target_amount_chf >= 0),
+  CONSTRAINT uq_class UNIQUE(asset_class_id)
+);
+
+CREATE TABLE SubClassTargets (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  class_target_id INTEGER NOT NULL REFERENCES ClassTargets(id) ON DELETE CASCADE,
+  asset_sub_class_id INTEGER NOT NULL REFERENCES AssetSubClasses(sub_class_id),
+  target_kind TEXT NOT NULL CHECK(target_kind IN('percent','amount')),
+  target_percent REAL DEFAULT 0,
+  target_amount_chf REAL DEFAULT 0,
+  tolerance_percent REAL DEFAULT 0,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT ck_sub_nonneg CHECK(target_percent >= 0 AND target_amount_chf >= 0),
+  CONSTRAINT uq_sub UNIQUE(class_target_id, asset_sub_class_id)
+);
+
+CREATE TABLE TargetChangeLog (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  target_type TEXT NOT NULL CHECK(target_type IN('class','subclass')),
+  target_id INTEGER NOT NULL,
+  field_name TEXT NOT NULL,
+  old_value TEXT,
+  new_value TEXT,
+  changed_by TEXT,
+  changed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO ClassTargets (asset_class_id, target_kind, target_percent, target_amount_chf, tolerance_percent, created_at, updated_at)
+SELECT asset_class_id,
+       CASE WHEN target_kind IS NOT NULL THEN target_kind
+            WHEN target_percent IS NOT NULL THEN 'percent'
+            ELSE 'amount' END,
+       COALESCE(target_percent,0),
+       COALESCE(target_amount_chf,0),
+       COALESCE(tolerance_percent,0),
+       COALESCE(updated_at,CURRENT_TIMESTAMP),
+       COALESCE(updated_at,CURRENT_TIMESTAMP)
+FROM TargetAllocation
+WHERE sub_class_id IS NULL;
+
+INSERT INTO TargetChangeLog (target_type, target_id, field_name, old_value, new_value, changed_by)
+SELECT 'class', id, 'migration', NULL, 'backfill', 'script'
+FROM ClassTargets;
+
+INSERT INTO SubClassTargets (class_target_id, asset_sub_class_id, target_kind, target_percent, target_amount_chf, tolerance_percent, created_at, updated_at)
+SELECT ct.id, ta.sub_class_id,
+       CASE WHEN ta.target_kind IS NOT NULL THEN ta.target_kind
+            WHEN ta.target_percent IS NOT NULL THEN 'percent'
+            ELSE 'amount' END,
+       COALESCE(ta.target_percent,0),
+       COALESCE(ta.target_amount_chf,0),
+       COALESCE(ta.tolerance_percent,0),
+       COALESCE(ta.updated_at,CURRENT_TIMESTAMP),
+       COALESCE(ta.updated_at,CURRENT_TIMESTAMP)
+FROM TargetAllocation ta
+JOIN ClassTargets ct ON ct.asset_class_id = ta.asset_class_id
+WHERE ta.sub_class_id IS NOT NULL;
+
+INSERT INTO TargetChangeLog (target_type, target_id, field_name, old_value, new_value, changed_by)
+SELECT 'subclass', id, 'migration', NULL, 'backfill', 'script'
+FROM SubClassTargets;
+
+DROP TABLE TargetAllocation;

--- a/test_data/asset_target_allocation_dataset.sql
+++ b/test_data/asset_target_allocation_dataset.sql
@@ -61,20 +61,20 @@ INSERT INTO PositionReports VALUES (
 );
 
 -- Target allocations (class level)
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (4, NULL, 40, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (7, NULL, 15, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (2, NULL, 35, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (1, NULL, 15, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (3, NULL, 5, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
+INSERT INTO ClassTargets VALUES (1, 4, 'percent', 40, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO ClassTargets VALUES (2, 7, 'percent', 15, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO ClassTargets VALUES (3, 2, 'percent', 35, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO ClassTargets VALUES (4, 1, 'percent', 15, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO ClassTargets VALUES (5, 3, 'percent', 5, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
 
 -- Target allocations (sub-class level)
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (4, 11, 30, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (4, 14, 10, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (7, 18, 10, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (7, 21, 5, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (2, 3, 20, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (2, 4, 15, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (1, 1, 15, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (3, 7, 5, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets VALUES (1, 1, 11, 'percent', 30, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets VALUES (2, 1, 14, 'percent', 10, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets VALUES (3, 2, 18, 'percent', 10, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets VALUES (4, 2, 21, 'percent', 5, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets VALUES (5, 3, 3, 'percent', 20, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets VALUES (6, 3, 4, 'percent', 15, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets VALUES (7, 4, 1, 'percent', 15, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets VALUES (8, 5, 7, 'percent', 5, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
 
 PRAGMA foreign_keys=ON;

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -98,4 +98,12 @@ def test_apply_migrations_and_insert_dates():
     assert 'target_kind' in cols
     assert 'tolerance_percent' in cols
 
+    # Apply seventh migration
+    conn.executescript(read_sql('007_add_class_target_tables.sql'))
+    tables = [row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")]
+    assert 'ClassTargets' in tables
+    assert 'SubClassTargets' in tables
+    assert 'TargetChangeLog' in tables
+    assert 'TargetAllocation' not in tables
+
     conn.close()

--- a/tests/test_schema_version.py
+++ b/tests/test_schema_version.py
@@ -8,4 +8,4 @@ from deploy_db import parse_version
 
 def test_schema_version_updated():
     schema_path = Path(__file__).resolve().parents[1] / 'DragonShield' / 'database' / 'schema.sql'
-    assert parse_version(str(schema_path)) == '4.19'
+    assert parse_version(str(schema_path)) == '4.20'


### PR DESCRIPTION
## Summary
- add ClassTargets, SubClassTargets, and TargetChangeLog tables with migration from TargetAllocation
- update schema version to 4.20 and seed data
- document new tables and adjust tests
- add script to reset database and import legacy data
- handle column mismatches when importing legacy data to new schema

## Testing
- `pytest -q`
- `python3 DragonShield/python_scripts/load_legacy_db.py tmp_target.sqlite tmp_legacy.sqlite`

------
https://chatgpt.com/codex/tasks/task_e_68924f68103c8323bfac3f64fdbe0a85