### PR TITLE
feat(validation): add target sum triggers and warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Fix optional class ID handling in target sum validation warnings
+- Persist parent class targets and warn on total allocation without blocking saves
 - Introduce ClassTargets and SubClassTargets tables with migration logging
 - Add script to reset database and import legacy data
 - Fix legacy data import script to preserve new tables when loading old data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ All notable changes to this project will be documented in this file.
 - Show per-table row count comparison after restore in a modal window
 - Auto-expand stale account sections and open editable account detail window from Dashboard
 - Add validation triggers for ClassTargets/SubClassTargets and surface warnings in allocation editor
+- Bind asset allocation views to ClassTargets and SubClassTargets tables
 - Allow dashboard tiles to resize adaptively with a responsive grid
 - Arrange dashboard tiles in a masonry layout with half-spacing gaps vertically
 - Provide Save/Cancel buttons in Account Detail window with quick saved status

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Fix optional class ID handling in target sum validation warnings
 - Introduce ClassTargets and SubClassTargets tables with migration logging
 - Add script to reset database and import legacy data
 - Fix legacy data import script to preserve new tables when loading old data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ All notable changes to this project will be documented in this file.
 - Label green stale account range as "<1 month / today"
 - Show per-table row count comparison after restore in a modal window
 - Auto-expand stale account sections and open editable account detail window from Dashboard
+- Add validation triggers for ClassTargets/SubClassTargets and surface warnings in allocation editor
 - Allow dashboard tiles to resize adaptively with a responsive grid
 - Arrange dashboard tiles in a masonry layout with half-spacing gaps vertically
 - Provide Save/Cancel buttons in Account Detail window with quick saved status

--- a/DragonShield/BackupService.swift
+++ b/DragonShield/BackupService.swift
@@ -40,7 +40,7 @@ class BackupService: ObservableObject {
     let transactionTables = [
         "Portfolios", "PortfolioInstruments", "Transactions",
         "PositionReports", "ImportSessions", "ImportSessionValueReports",
-        "ExchangeRates", "TargetAllocation"
+        "ExchangeRates", "ClassTargets", "SubClassTargets"
     ]
 
     var fullTables: [String] {

--- a/DragonShield/DatabaseManager+InstrumentTypes.swift
+++ b/DragonShield/DatabaseManager+InstrumentTypes.swift
@@ -225,7 +225,7 @@ extension DatabaseManager {
             print("❌ Failed to prepare instrument usage check (ID: \(id)): \(String(cString: sqlite3_errmsg(db)))")
         }
 
-        let allocationQuery = "SELECT COUNT(*) FROM TargetAllocation WHERE sub_class_id = ?"
+        let allocationQuery = "SELECT COUNT(*) FROM SubClassTargets WHERE asset_sub_class_id = ?"
         if sqlite3_prepare_v2(db, allocationQuery, -1, &statement, nil) == SQLITE_OK {
             sqlite3_bind_int(statement, 1, Int32(id))
             if sqlite3_step(statement) == SQLITE_ROW {
@@ -250,7 +250,7 @@ extension DatabaseManager {
         }
 
         if info.allocationCount > 0 {
-            details.append(("TargetAllocation", "sub_class_id", info.allocationCount))
+            details.append(("SubClassTargets", "asset_sub_class_id", info.allocationCount))
         }
 
         return details

--- a/DragonShield/DatabaseManager+PortfolioTargets.swift
+++ b/DragonShield/DatabaseManager+PortfolioTargets.swift
@@ -129,6 +129,83 @@ extension DatabaseManager {
 
     // MARK: - New persistence helpers
 
+    /// Fetch the class-level target for a given asset class.
+    func fetchClassTarget(classId: Int) -> (
+        percent: Double,
+        amountCHF: Double,
+        targetKind: String,
+        tolerance: Double
+    )? {
+        LoggingService.shared.log("Fetching ClassTargets for id=\(classId)", type: .info, logger: .database)
+        let query = "SELECT target_percent, target_amount_chf, target_kind, tolerance_percent FROM ClassTargets WHERE asset_class_id = ?;"
+        var statement: OpaquePointer?
+        var result: (Double, Double, String, Double)?
+        if sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_int(statement, 1, Int32(classId))
+            if sqlite3_step(statement) == SQLITE_ROW {
+                let pct = sqlite3_column_double(statement, 0)
+                let amt = sqlite3_column_double(statement, 1)
+                let kind = String(cString: sqlite3_column_text(statement, 2))
+                let tol = sqlite3_column_double(statement, 3)
+                result = (pct, amt, kind, tol)
+            }
+        } else {
+            LoggingService.shared.log("Failed to prepare fetchClassTarget: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+        sqlite3_finalize(statement)
+        return result.map { (percent: $0.0, amountCHF: $0.1, targetKind: $0.2, tolerance: $0.3) }
+    }
+
+    /// Fetch all sub-class targets for a given asset class.
+    func fetchSubClassTargets(classId: Int) -> [(
+        id: Int,
+        name: String,
+        percent: Double,
+        amountCHF: Double,
+        targetKind: String,
+        tolerance: Double
+    )] {
+        LoggingService.shared.log("Fetching SubClassTargets for class id=\(classId)", type: .info, logger: .database)
+        var results: [(
+            id: Int,
+            name: String,
+            percent: Double,
+            amountCHF: Double,
+            targetKind: String,
+            tolerance: Double
+        )] = []
+        let query = """
+            SELECT asc.sub_class_id,
+                   asc.sub_class_name,
+                   COALESCE(s.target_percent,0),
+                   COALESCE(s.target_amount_chf,0),
+                   COALESCE(s.target_kind,'percent'),
+                   COALESCE(s.tolerance_percent,0)
+            FROM AssetSubClasses asc
+            LEFT JOIN ClassTargets ct ON ct.asset_class_id = asc.class_id
+            LEFT JOIN SubClassTargets s ON s.class_target_id = ct.id AND s.asset_sub_class_id = asc.sub_class_id
+            WHERE asc.class_id = ?
+            ORDER BY asc.sort_order, asc.sub_class_name;
+        """
+        var statement: OpaquePointer?
+        if sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_int(statement, 1, Int32(classId))
+            while sqlite3_step(statement) == SQLITE_ROW {
+                let id = Int(sqlite3_column_int(statement, 0))
+                let name = String(cString: sqlite3_column_text(statement, 1))
+                let pct = sqlite3_column_double(statement, 2)
+                let amt = sqlite3_column_double(statement, 3)
+                let kind = String(cString: sqlite3_column_text(statement, 4))
+                let tol = sqlite3_column_double(statement, 5)
+                results.append((id: id, name: name, percent: pct, amountCHF: amt, targetKind: kind, tolerance: tol))
+            }
+        } else {
+            LoggingService.shared.log("Failed to prepare fetchSubClassTargets: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+        sqlite3_finalize(statement)
+        return results
+    }
+
     /// Returns stored target percentages aggregated by asset class or sub-class.
     func fetchPortfolioTargetRecords(portfolioId: Int) -> [(
         classId: Int?,
@@ -146,7 +223,24 @@ extension DatabaseManager {
             targetKind: String,
             tolerance: Double
         )] = []
-        let query = "SELECT asset_class_id, sub_class_id, COALESCE(target_percent,0), target_amount_chf, target_kind, tolerance_percent FROM TargetAllocation;"
+        let query = """
+            SELECT asset_class_id,
+                   NULL AS sub_class_id,
+                   target_percent,
+                   target_amount_chf,
+                   target_kind,
+                   tolerance_percent
+            FROM ClassTargets
+            UNION ALL
+            SELECT ct.asset_class_id,
+                   s.asset_sub_class_id,
+                   s.target_percent,
+                   s.target_amount_chf,
+                   s.target_kind,
+                   s.tolerance_percent
+            FROM SubClassTargets s
+            JOIN ClassTargets ct ON s.class_target_id = ct.id;
+        """
         var statement: OpaquePointer?
         if sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK {
             while sqlite3_step(statement) == SQLITE_ROW {
@@ -164,7 +258,7 @@ extension DatabaseManager {
                                 tolerance: tolerance))
             }
         } else {
-            LoggingService.shared.log("Failed to prepare fetchPortfolioTargetRecords: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            LoggingService.shared.log("Failed to prepare fetch ClassTargets/SubClassTargets: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
         }
         sqlite3_finalize(statement)
         return results
@@ -172,10 +266,11 @@ extension DatabaseManager {
 
     /// Upsert a class-level target percentage.
     func upsertClassTarget(portfolioId: Int, classId: Int, percent: Double, amountChf: Double? = nil, kind: String = "percent", tolerance: Double) {
+        LoggingService.shared.log("Upserting ClassTargets id=\(classId)", type: .info, logger: .database)
         let query = """
-            INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at)
-            VALUES (?, NULL, ?, ?, ?, ?, CURRENT_TIMESTAMP)
-            ON CONFLICT(asset_class_id, sub_class_id)
+            INSERT INTO ClassTargets (asset_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at)
+            VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(asset_class_id)
             DO UPDATE SET target_percent = excluded.target_percent,
                          target_amount_chf = excluded.target_amount_chf,
                          target_kind = excluded.target_kind,
@@ -195,20 +290,21 @@ extension DatabaseManager {
             sqlite3_bind_text(statement, 4, kind, -1, SQLITE_TRANSIENT)
             sqlite3_bind_double(statement, 5, tolerance)
             if sqlite3_step(statement) != SQLITE_DONE {
-                LoggingService.shared.log("Failed to upsert class target: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+                LoggingService.shared.log("Failed to upsert ClassTargets: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
             }
         } else {
-            LoggingService.shared.log("Failed to prepare upsertClassTarget: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            LoggingService.shared.log("Failed to prepare upsert ClassTargets: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
         }
         sqlite3_finalize(statement)
     }
 
     /// Upsert a sub-class-level target percentage.
     func upsertSubClassTarget(portfolioId: Int, subClassId: Int, percent: Double, amountChf: Double? = nil, kind: String = "percent", tolerance: Double) {
+        LoggingService.shared.log("Upserting SubClassTargets id=\(subClassId)", type: .info, logger: .database)
         let query = """
-            INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at)
-            VALUES ((SELECT class_id FROM AssetSubClasses WHERE sub_class_id = ?), ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
-            ON CONFLICT(asset_class_id, sub_class_id)
+            INSERT INTO SubClassTargets (class_target_id, asset_sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at)
+            VALUES ((SELECT id FROM ClassTargets WHERE asset_class_id = (SELECT class_id FROM AssetSubClasses WHERE sub_class_id = ?)), ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(class_target_id, asset_sub_class_id)
             DO UPDATE SET target_percent = excluded.target_percent,
                          target_amount_chf = excluded.target_amount_chf,
                          target_kind = excluded.target_kind,
@@ -229,10 +325,10 @@ extension DatabaseManager {
             sqlite3_bind_text(statement, 5, kind, -1, SQLITE_TRANSIENT)
             sqlite3_bind_double(statement, 6, tolerance)
             if sqlite3_step(statement) != SQLITE_DONE {
-                LoggingService.shared.log("Failed to upsert sub-class target: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+                LoggingService.shared.log("Failed to upsert SubClassTargets: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
             }
         } else {
-            LoggingService.shared.log("Failed to prepare upsertSubClassTarget: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            LoggingService.shared.log("Failed to prepare upsert SubClassTargets: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
         }
         sqlite3_finalize(statement)
     }

--- a/DragonShield/DatabaseManager+PortfolioTargets.swift
+++ b/DragonShield/DatabaseManager+PortfolioTargets.swift
@@ -252,8 +252,9 @@ extension DatabaseManager {
 
         // Child-level per class
         let classGroups = Dictionary(grouping: records, by: { $0.classId })
-        for (classId, rows) in classGroups {
-            guard let parent = rows.first(where: { $0.subClassId == nil }) else { continue }
+        for (classIdOpt, rows) in classGroups {
+            guard let classId = classIdOpt,
+                  let parent = rows.first(where: { $0.subClassId == nil }) else { continue }
             let subs = rows.filter { $0.subClassId != nil }
             let childSum = subs.map { $0.percent }.reduce(0, +)
             if abs(childSum - 100) > parent.tolerance {

--- a/DragonShield/Views/AllocationTargetsTableView.swift
+++ b/DragonShield/Views/AllocationTargetsTableView.swift
@@ -741,6 +741,10 @@ struct AllocationTargetsTableView: View {
         let aggregateDeltaColor: Color = abs(deltaChf) > deltaTol ? .red : .secondary
 
         HStack(spacing: 4) {
+            if viewModel.rowHasWarning(asset) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundColor(.orange)
+            }
             Text(asset.name)
                 .fontWeight((abs(asset.targetPct) > 0.0001 || abs(asset.targetChf) > 0.01) ? .bold : .regular)
         }

--- a/DragonShield/Views/TargetEditPanel.swift
+++ b/DragonShield/Views/TargetEditPanel.swift
@@ -207,15 +207,12 @@ struct TargetEditPanel: View {
                 .foregroundColor(remaining == 0 ? .primary : .red)
 
             if !validationWarnings.isEmpty {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Validation Warnings:")
-                        .font(.headline)
-                        .foregroundColor(.orange)
-                    ForEach(validationWarnings, id: \.self) { warn in
-                        Text(warn)
-                            .foregroundColor(.orange)
-                    }
-                }
+                Text("Warnings: \(validationWarnings.joined(separator: "; "))")
+                    .padding(8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.red.opacity(0.1))
+                    .foregroundColor(.red)
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
             }
 
             HStack {
@@ -297,7 +294,7 @@ struct TargetEditPanel: View {
         for r in rows {
             log("EDIT PANEL LOAD", "Loaded sub-class \"\(r.name)\" id=\(r.id): percent=\(r.percent), CHF=\(r.amount), kind=\(r.kind.rawValue), tol=\(r.tolerance)", type: .info)
         }
-        validationWarnings = validateAll()
+        validationWarnings = db.validateTargetSums(portfolioId: 1)
         isInitialLoad = false
     }
 
@@ -350,93 +347,6 @@ struct TargetEditPanel: View {
         }
     }
 
-    private func validateAll() -> [String] {
-        var warnings: [String] = []
-
-        let records = db.fetchPortfolioTargetRecords(portfolioId: 1)
-        let classes = db.fetchAssetClassesDetailed()
-
-        var classPercents: [Int: Double] = [:]
-        var classAmounts: [Int: Double] = [:]
-
-        // Read parent targets
-        for cls in classes {
-            let rec = records.first { $0.classId == cls.id && $0.subClassId == nil }
-            let percent = cls.id == classId ? parentPercent : (rec?.percent ?? 0)
-            let amount: Double
-            if cls.id == classId {
-                amount = parentAmount
-            } else if let amt = rec?.amountCHF {
-                amount = amt
-            } else {
-                amount = portfolioTotal * percent / 100
-            }
-            classPercents[cls.id] = percent
-            classAmounts[cls.id] = amount
-            log("VALIDATION", "Read asset-class \"\(cls.name)\" id=\(cls.id): percent=\(percent), CHF=\(amount)", type: .debug)
-        }
-
-        let pctSum = classPercents.values.reduce(0, +)
-        log("VALIDATION", String(format: "Parent %% sum=%.1f%%", pctSum), type: .debug)
-        if abs(pctSum - 100) > 0.01 {
-            let msg = String(format: "asset-class %% sum=%.1f%% (expected 100%%)", pctSum)
-            warnings.append(msg)
-            log("VALIDATION WARN", msg, type: .default)
-        }
-
-        let chfSum = classAmounts.values.reduce(0, +)
-        log("VALIDATION", "Parent CHF sum=\(formatChf(chfSum))", type: .debug)
-        if abs(chfSum - portfolioTotal) > 0.01 {
-            let msg = "asset-class CHF sum=\(formatChf(chfSum)) (expected \(formatChf(portfolioTotal)))"
-            warnings.append(msg)
-            log("VALIDATION WARN", msg, type: .default)
-        }
-
-        // Child level validation per class
-        for cls in classes {
-            let parentPct = classPercents[cls.id] ?? 0
-            let parentAmt = classAmounts[cls.id] ?? 0
-            var subPct = 0.0
-            var subAmt = 0.0
-
-            if cls.id == classId {
-                for row in rows {
-                    subPct += row.percent
-                    subAmt += row.amount
-                    log("VALIDATION", "Read sub-class \"\(row.name)\" id=\(row.id) of \"\(cls.name)\": percent=\(row.percent), CHF=\(row.amount)", type: .debug)
-                }
-            } else {
-                let subRecords = records.filter { $0.classId == cls.id && $0.subClassId != nil }
-                let subNames = Dictionary(uniqueKeysWithValues: db.subAssetClasses(for: cls.id).map { ($0.id, $0.name) })
-                for rec in subRecords {
-                    let amt = rec.amountCHF ?? parentAmt * rec.percent / 100
-                    subPct += rec.percent
-                    subAmt += amt
-                    let name = subNames[rec.subClassId ?? 0] ?? "id \(rec.subClassId ?? 0)"
-                    log("VALIDATION", "Read sub-class \"\(name)\" id=\(rec.subClassId ?? 0) of \"\(cls.name)\": percent=\(rec.percent), CHF=\(amt)", type: .debug)
-                }
-            }
-
-            log("VALIDATION", String(format: "\"%@\" sub-class %% sum=%.1f%%", cls.name, subPct), type: .debug)
-            let expectedPct = (parentPct > 0 || parentAmt > 0) ? 100.0 : 0.0
-            if abs(subPct - expectedPct) > 0.01 {
-                let msg = String(format: "\"%@\" sub-class %% sum=%.1f%% (expected %.1f%%)", cls.name, subPct, expectedPct)
-                warnings.append(msg)
-                log("VALIDATION WARN", msg, type: .default)
-            }
-
-            log("VALIDATION", "\"\(cls.name)\" sub-class CHF sum=\(formatChf(subAmt))", type: .debug)
-            let expectedAmt = (parentPct > 0 || parentAmt > 0) ? parentAmt : 0
-            if abs(subAmt - expectedAmt) > 0.01 {
-                let msg = "\"\(cls.name)\" sub-class CHF sum=\(formatChf(subAmt)) (expected \(formatChf(expectedAmt)))"
-                warnings.append(msg)
-                log("VALIDATION WARN", msg, type: .default)
-            }
-        }
-
-        return warnings
-    }
-
     private func cancel() {
         isInitialLoad = true
         log("EDIT PANEL CANCEL", "Discarded changes for \(className)", type: .info)
@@ -469,7 +379,7 @@ struct TargetEditPanel: View {
                                     kind: row.kind.rawValue,
                                     tolerance: row.tolerance)
         }
-        let warnings = validateAll()
+        let warnings = db.validateTargetSums(portfolioId: 1)
         validationWarnings = warnings
         if warnings.isEmpty {
             onClose()

--- a/DragonShield/database/schema.txt
+++ b/DragonShield/database/schema.txt
@@ -4,6 +4,7 @@
 -- Updated: 2025-07-13
 --
 -- RECENT HISTORY:
+-- - v4.20 -> v4.21: Add validation triggers for ClassTargets and SubClassTargets
 -- - v4.19 -> v4.20: Replace TargetAllocation with ClassTargets/SubClassTargets and add TargetChangeLog
 -- - v4.7 -> v4.8: Added Institutions table and updated Accounts seed data.
 -- - v4.6 -> v4.7: Added db_version configuration row.
@@ -30,7 +31,7 @@ INSERT INTO Configuration VALUES ('9', 'table_row_padding', '12.0', 'number', 'V
 INSERT INTO Configuration VALUES ('10', 'table_font_size', '14.0', 'number', 'Font size for text in data table rows (in points)', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('11', 'include_direct_re', 'true', 'boolean', 'Include direct real estate in allocation views', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('12', 'direct_re_target_chf', '0', 'number', 'Target CHF amount for direct real estate', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
-INSERT INTO Configuration VALUES ('13', 'db_version', '4.20', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
+INSERT INTO Configuration VALUES ('13', 'db_version', '4.21', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('CHF', 'Swiss Franc', 'CHF', '1', '0', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('EUR', 'Euro', '€', '1', '1', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('USD', 'US Dollar', '$', '1', '1', '2025-07-13 09:04:29', '2025-07-13 09:04:29');

--- a/DragonShield/python_scripts/load_legacy_db.py
+++ b/DragonShield/python_scripts/load_legacy_db.py
@@ -105,7 +105,7 @@ def load_legacy_database(target: Path, legacy: Path) -> Dict[str, int]:
             )
 
         # Ensure the database version matches the current schema
-        conn.execute("UPDATE Configuration SET value=? WHERE key='db_version'", ("4.20",))
+        conn.execute("UPDATE Configuration SET value=? WHERE key='db_version'", ("4.21",))
         conn.commit()
         conn.execute("DETACH DATABASE legacy")
         check = conn.execute("PRAGMA integrity_check;").fetchone()[0]

--- a/DragonShield/test_data/reference_data.sql
+++ b/DragonShield/test_data/reference_data.sql
@@ -21,7 +21,7 @@ INSERT INTO Configuration VALUES ('9', 'table_row_padding', '12.0', 'number', 'V
 INSERT INTO Configuration VALUES ('10', 'table_font_size', '14.0', 'number', 'Font size for text in data table rows (in points)', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('11', 'include_direct_re', 'true', 'boolean', 'Include direct real estate in allocation views', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('12', 'direct_re_target_chf', '0', 'number', 'Target CHF amount for direct real estate', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
-INSERT INTO Configuration VALUES ('13', 'db_version', '4.20', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
+INSERT INTO Configuration VALUES ('13', 'db_version', '4.21', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 CREATE TABLE Currencies (
     currency_code TEXT PRIMARY KEY,
     currency_name TEXT NOT NULL,

--- a/migrations/008_add_target_validation_triggers.sql
+++ b/migrations/008_add_target_validation_triggers.sql
@@ -1,0 +1,56 @@
+-- Migration 008: Add validation triggers for ClassTargets and SubClassTargets sums
+-- Bump db_version to 4.21
+
+CREATE TRIGGER IF NOT EXISTS trg_validate_class_targets_insert
+AFTER INSERT ON ClassTargets
+BEGIN
+    INSERT INTO TargetChangeLog(target_type, target_id, field_name, new_value, changed_by)
+    SELECT 'class', NEW.id, 'parent_sum_percent',
+           printf('%.2f', total_pct), 'trigger'
+    FROM (SELECT SUM(target_percent) AS total_pct FROM ClassTargets)
+    WHERE ABS(total_pct - 100.0) > 0.1;
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_validate_class_targets_update
+AFTER UPDATE ON ClassTargets
+BEGIN
+    INSERT INTO TargetChangeLog(target_type, target_id, field_name, new_value, changed_by)
+    SELECT 'class', NEW.id, 'parent_sum_percent',
+           printf('%.2f', total_pct), 'trigger'
+    FROM (SELECT SUM(target_percent) AS total_pct FROM ClassTargets)
+    WHERE ABS(total_pct - 100.0) > 0.1;
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_validate_subclass_targets_insert
+AFTER INSERT ON SubClassTargets
+BEGIN
+    INSERT INTO TargetChangeLog(target_type, target_id, field_name, new_value, changed_by)
+    SELECT 'class', NEW.class_target_id, 'child_sum_percent',
+           printf('%.2f', total_pct), 'trigger'
+    FROM (
+        SELECT SUM(target_percent) AS total_pct
+        FROM SubClassTargets
+        WHERE class_target_id = NEW.class_target_id
+    ), (
+        SELECT tolerance_percent AS tol FROM ClassTargets WHERE id = NEW.class_target_id
+    )
+    WHERE ABS(total_pct - 100.0) > tol;
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_validate_subclass_targets_update
+AFTER UPDATE ON SubClassTargets
+BEGIN
+    INSERT INTO TargetChangeLog(target_type, target_id, field_name, new_value, changed_by)
+    SELECT 'class', NEW.class_target_id, 'child_sum_percent',
+           printf('%.2f', total_pct), 'trigger'
+    FROM (
+        SELECT SUM(target_percent) AS total_pct
+        FROM SubClassTargets
+        WHERE class_target_id = NEW.class_target_id
+    ), (
+        SELECT tolerance_percent AS tol FROM ClassTargets WHERE id = NEW.class_target_id
+    )
+    WHERE ABS(total_pct - 100.0) > tol;
+END;
+
+UPDATE Configuration SET value='4.21' WHERE key='db_version';

--- a/tests/test_schema_version.py
+++ b/tests/test_schema_version.py
@@ -8,4 +8,4 @@ from deploy_db import parse_version
 
 def test_schema_version_updated():
     schema_path = Path(__file__).resolve().parents[1] / 'DragonShield' / 'database' / 'schema.sql'
-    assert parse_version(str(schema_path)) == '4.20'
+    assert parse_version(str(schema_path)) == '4.21'

--- a/tests/test_target_validation_triggers.py
+++ b/tests/test_target_validation_triggers.py
@@ -1,0 +1,38 @@
+import sqlite3
+from pathlib import Path
+
+SCHEMA = Path(__file__).resolve().parents[1] / 'DragonShield' / 'database' / 'schema.sql'
+
+
+def load_db():
+    conn = sqlite3.connect(':memory:')
+    with open(SCHEMA, 'r', encoding='utf-8') as f:
+        conn.executescript(f.read())
+    # seed minimal asset classes/subclasses for FK references
+    conn.execute("INSERT INTO AssetClasses (class_code, class_name) VALUES ('A','A')")
+    conn.execute("INSERT INTO AssetClasses (class_code, class_name) VALUES ('B','B')")
+    conn.execute("INSERT INTO AssetSubClasses (class_id, sub_class_code, sub_class_name) VALUES (1,'S1','S1')")
+    conn.execute("INSERT INTO AssetSubClasses (class_id, sub_class_code, sub_class_name) VALUES (1,'S2','S2')")
+    return conn
+
+
+def test_parent_sum_trigger():
+    conn = load_db()
+    # Insert class targets totaling 90%
+    conn.execute("INSERT INTO ClassTargets (asset_class_id, target_kind, target_percent, tolerance_percent) VALUES (1,'percent',60,5)")
+    conn.execute("INSERT INTO ClassTargets (asset_class_id, target_kind, target_percent, tolerance_percent) VALUES (2,'percent',30,5)")
+    row = conn.execute("SELECT new_value FROM TargetChangeLog WHERE field_name='parent_sum_percent'").fetchone()
+    assert row is not None
+    conn.close()
+
+
+def test_child_sum_trigger():
+    conn = load_db()
+    # Parent class target 100%
+    conn.execute("INSERT INTO ClassTargets (asset_class_id, target_kind, target_percent, tolerance_percent) VALUES (1,'percent',100,5)")
+    # Sub targets totaling 70%
+    conn.execute("INSERT INTO SubClassTargets (class_target_id, asset_sub_class_id, target_kind, target_percent, tolerance_percent) VALUES (1,1,'percent',40,5)")
+    conn.execute("INSERT INTO SubClassTargets (class_target_id, asset_sub_class_id, target_kind, target_percent, tolerance_percent) VALUES (1,2,'percent',30,5)")
+    row = conn.execute("SELECT new_value FROM TargetChangeLog WHERE field_name='child_sum_percent'").fetchone()
+    assert row is not None
+    conn.close()


### PR DESCRIPTION
## Summary
- add database triggers for parent/child target sums and bump schema to v4.21
- surface allocation validation warnings in dashboard and edit panel
- expose validation utility in service layer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893b56dda1c83238d59e357ebe59c1d