### PR TITLE
feat(ui): redesign edit targets panel layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Redesign Edit Targets panel layout and title in Asset Allocation view
 - Fix optional class ID handling in target sum validation warnings
 - Persist parent class targets and warn on total allocation without blocking saves
 - Introduce ClassTargets and SubClassTargets tables with migration logging

--- a/DragonShield/Views/TargetEditPanel.swift
+++ b/DragonShield/Views/TargetEditPanel.swift
@@ -64,8 +64,9 @@ struct TargetEditPanel: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            Text("Edit \"\(className)\" Targets")
-                .font(.headline)
+            (Text("Asset Allocations : ") + Text(className).foregroundColor(.darkBlue))
+                .font(.system(size: 20, weight: .bold))
+                .frame(maxWidth: .infinity, alignment: .center)
 
             VStack(spacing: 8) {
                 HStack {
@@ -144,15 +145,19 @@ struct TargetEditPanel: View {
 
             Grid(alignment: .leading, horizontalSpacing: 8, verticalSpacing: 4) {
                 GridRow {
+                    Text("Name")
+                        .frame(maxWidth: .infinity, alignment: .leading)
                     Text("Kind").frame(width: 80)
                     Text("Target %").frame(width: 80, alignment: .trailing)
                     Text("Target CHF").frame(width: 100, alignment: .trailing)
                     Text("Tol %").frame(width: 60, alignment: .trailing)
-                    Text("")
                 }
                 Divider().gridCellColumns(5)
                 ForEach($rows) { $row in
                     GridRow {
+                        Text(row.name)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+
                         Picker("", selection: $row.kind) {
                             Text("%").tag(TargetKind.percent)
                             Text("CHF").tag(TargetKind.amount)
@@ -201,9 +206,6 @@ struct TargetEditPanel: View {
                             .frame(width: 60)
                             .multilineTextAlignment(.trailing)
                             .textFieldStyle(.roundedBorder)
-
-                        Text(row.name)
-                            .frame(maxWidth: .infinity, alignment: .leading)
                     }
                     Divider().background(Color.systemGray4).gridCellColumns(5)
                 }
@@ -229,7 +231,7 @@ struct TargetEditPanel: View {
             }
         }
         .padding()
-        .frame(minWidth: 360)
+        .frame(minWidth: 560)
         .onAppear { load() }
         .onChange(of: kind) { _, _ in
             guard !isInitialLoad else { return }

--- a/DragonShield/helpers/Color+Palette.swift
+++ b/DragonShield/helpers/Color+Palette.swift
@@ -14,6 +14,8 @@ extension Color {
     static let softBlue = Color(red: 229/255, green: 241/255, blue: 255/255)
     /// Blue tint used for target editor headers.
     static let sectionBlue = Color(red: 230/255, green: 244/255, blue: 255/255)
+    /// Dark blue used for asset allocation titles.
+    static let darkBlue = Color(red: 0/255, green: 51/255, blue: 102/255)
     /// Row highlight used when editing in tables.
     static let rowHighlight = Color(red: 245/255, green: 249/255, blue: 255/255)
 


### PR DESCRIPTION
## Summary
- move sub-class names to the first column and widen the edit panel
- restyle panel header with dark blue title text

## Testing
- `pytest`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689445dd52c4832387e83c1dd3e961f3