### PR TITLE
feat(ui): reorder target editor columns and style title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Reorder Edit Targets columns and style pop-up title for clarity
 - Fix optional class ID handling in target sum validation warnings
 - Persist parent class targets and warn on total allocation without blocking saves
 - Introduce ClassTargets and SubClassTargets tables with migration logging

--- a/DragonShield/Views/TargetEditPanel.swift
+++ b/DragonShield/Views/TargetEditPanel.swift
@@ -64,8 +64,10 @@ struct TargetEditPanel: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            Text("Edit \"\(className)\" Targets")
-                .font(.headline)
+            (Text("Asset Allocations : ") +
+             Text(className).foregroundColor(Color(red: 0/255, green: 51/255, blue: 102/255)))
+                .font(.system(size: 20, weight: .bold))
+                .frame(maxWidth: .infinity, alignment: .center)
 
             VStack(spacing: 8) {
                 HStack {
@@ -144,15 +146,18 @@ struct TargetEditPanel: View {
 
             Grid(alignment: .leading, horizontalSpacing: 8, verticalSpacing: 4) {
                 GridRow {
+                    Text("Name").frame(minWidth: 200, alignment: .leading)
                     Text("Kind").frame(width: 80)
                     Text("Target %").frame(width: 80, alignment: .trailing)
                     Text("Target CHF").frame(width: 100, alignment: .trailing)
                     Text("Tol %").frame(width: 60, alignment: .trailing)
-                    Text("")
                 }
                 Divider().gridCellColumns(5)
                 ForEach($rows) { $row in
                     GridRow {
+                        Text(row.name)
+                            .frame(minWidth: 200, maxWidth: .infinity, alignment: .leading)
+
                         Picker("", selection: $row.kind) {
                             Text("%").tag(TargetKind.percent)
                             Text("CHF").tag(TargetKind.amount)
@@ -201,9 +206,6 @@ struct TargetEditPanel: View {
                             .frame(width: 60)
                             .multilineTextAlignment(.trailing)
                             .textFieldStyle(.roundedBorder)
-
-                        Text(row.name)
-                            .frame(maxWidth: .infinity, alignment: .leading)
                     }
                     Divider().background(Color.systemGray4).gridCellColumns(5)
                 }
@@ -229,7 +231,7 @@ struct TargetEditPanel: View {
             }
         }
         .padding()
-        .frame(minWidth: 360)
+        .frame(minWidth: 560)
         .onAppear { load() }
         .onChange(of: kind) { _, _ in
             guard !isInitialLoad else { return }


### PR DESCRIPTION
## Summary
- Center pop-up title with dark-blue asset class name
- Move sub-asset class names to the first column and widen the target editor

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689445dd52c4832387e83c1dd3e961f3