### PR TITLE
feat(ui): reorder target editor columns and widen panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Reorder Edit Targets columns, widen panel to 800 px with proportional column widths, and style pop-up title for clarity
 - Fix optional class ID handling in target sum validation warnings
 - Persist parent class targets and warn on total allocation without blocking saves
 - Introduce ClassTargets and SubClassTargets tables with migration logging


### PR DESCRIPTION
## Summary
- Center pop-up title with dark-blue asset class name
- Move sub-asset class names to the first column and widen the target editor to 800px with proportional columns

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689445dd52c4832387e83c1dd3e961f3