### PR TITLE
feat: split target allocation into hierarchical tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Introduce ClassTargets and SubClassTargets tables with migration log
 - Fix Edit Targets panel to preload stored target values before validation
 - Fix Cancel button in Edit Targets panel to discard changes without saving
 - Display sub-class target sums and log totals in Edit Targets panel

--- a/DragonShield/database/schema.sql
+++ b/DragonShield/database/schema.sql
@@ -1,10 +1,11 @@
 -- DragonShield/docs/schema.sql
 -- Dragon Shield Database Creation Script
--- Version 4.19 - Remove target_allocation_percent column
+-- Version 4.20 - Split TargetAllocation into ClassTargets/SubClassTargets
 -- Created: 2025-05-24
 -- Updated: 2025-07-13
 --
 -- RECENT HISTORY:
+-- - v4.19 -> v4.20: Introduced ClassTargets, SubClassTargets and TargetChangeLog tables.
 -- - v4.17 -> v4.18: Added target_kind and tolerance_percent columns to TargetAllocation.
 -- - v4.7 -> v4.8: Added Institutions table and linked Accounts to it.
 -- - v4.6 -> v4.7: Added db_version configuration row in seed data.
@@ -38,6 +39,9 @@ DROP TABLE IF EXISTS AccountTypes; -- Dropping new table if it exists
 DROP TABLE IF EXISTS PortfolioInstruments;
 DROP TABLE IF EXISTS Portfolios;
 DROP TABLE IF EXISTS Instruments;
+DROP TABLE IF EXISTS SubClassTargets;
+DROP TABLE IF EXISTS ClassTargets;
+DROP TABLE IF EXISTS TargetChangeLog;
 DROP TABLE IF EXISTS AssetSubClasses;
 DROP TABLE IF EXISTS AssetClasses;
 DROP TABLE IF EXISTS FxRateUpdates;
@@ -189,18 +193,42 @@ CREATE TABLE PortfolioInstruments (
 );
 
 CREATE INDEX idx_portfolio_instruments_instrument ON PortfolioInstruments(instrument_id);
-CREATE TABLE TargetAllocation (
-    allocation_id INTEGER PRIMARY KEY AUTOINCREMENT,
-    asset_class_id INTEGER NOT NULL,
-    sub_class_id INTEGER,
-    target_percent REAL,
-    target_amount_chf REAL,
-    target_kind TEXT NOT NULL DEFAULT 'percent' CHECK(target_kind IN('percent','amount')),
-    tolerance_percent REAL NOT NULL DEFAULT 5.0,
-    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE(asset_class_id, sub_class_id),
-    FOREIGN KEY (asset_class_id) REFERENCES AssetClasses(class_id),
-    FOREIGN KEY (sub_class_id) REFERENCES AssetSubClasses(sub_class_id)
+CREATE TABLE ClassTargets (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    asset_class_id INTEGER NOT NULL REFERENCES AssetClasses(class_id),
+    target_kind TEXT NOT NULL CHECK(target_kind IN('percent','amount')),
+    target_percent REAL DEFAULT 0,
+    target_amount_chf REAL DEFAULT 0,
+    tolerance_percent REAL DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT ck_class_nonneg CHECK(target_percent >= 0 AND target_amount_chf >= 0),
+    CONSTRAINT uq_class UNIQUE(asset_class_id)
+);
+
+CREATE TABLE SubClassTargets (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    class_target_id INTEGER NOT NULL REFERENCES ClassTargets(id) ON DELETE CASCADE,
+    asset_sub_class_id INTEGER NOT NULL REFERENCES AssetSubClasses(sub_class_id),
+    target_kind TEXT NOT NULL CHECK(target_kind IN('percent','amount')),
+    target_percent REAL DEFAULT 0,
+    target_amount_chf REAL DEFAULT 0,
+    tolerance_percent REAL DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT ck_sub_nonneg CHECK(target_percent >= 0 AND target_amount_chf >= 0),
+    CONSTRAINT uq_sub UNIQUE(class_target_id, asset_sub_class_id)
+);
+
+CREATE TABLE TargetChangeLog (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    target_type TEXT NOT NULL CHECK(target_type IN('class','subclass')),
+    target_id INTEGER NOT NULL,
+    field_name TEXT NOT NULL,
+    old_value TEXT,
+    new_value TEXT,
+    changed_by TEXT,
+    changed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
 --=============================================================================

--- a/DragonShield/database/schema.txt
+++ b/DragonShield/database/schema.txt
@@ -4,6 +4,7 @@
 -- Updated: 2025-07-13
 --
 -- RECENT HISTORY:
+-- - v4.19 -> v4.20: Replace TargetAllocation with ClassTargets and SubClassTargets and add TargetChangeLog.
 -- - v4.7 -> v4.8: Added Institutions table and updated Accounts seed data.
 -- - v4.6 -> v4.7: Added db_version configuration row.
 -- - v4.5 -> v4.6: Seed data split from schema.sql
@@ -29,7 +30,7 @@ INSERT INTO Configuration VALUES ('9', 'table_row_padding', '12.0', 'number', 'V
 INSERT INTO Configuration VALUES ('10', 'table_font_size', '14.0', 'number', 'Font size for text in data table rows (in points)', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('11', 'include_direct_re', 'true', 'boolean', 'Include direct real estate in allocation views', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('12', 'direct_re_target_chf', '0', 'number', 'Target CHF amount for direct real estate', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
-INSERT INTO Configuration VALUES ('13', 'db_version', '4.19', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
+INSERT INTO Configuration VALUES ('13', 'db_version', '4.20', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('CHF', 'Swiss Franc', 'CHF', '1', '0', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('EUR', 'Euro', '€', '1', '1', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('USD', 'US Dollar', '$', '1', '1', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
@@ -347,19 +348,19 @@ INSERT INTO PositionReports VALUES (
     28, 6, 9, 3, 16, 1000000, 1, 1, '2025-07-01', 'USDC liquidity', '2025-07-01', '2025-07-13 10:00:00'
 );
 
--- Target allocations (class level)
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (4, NULL, 40, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (7, NULL, 15, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (2, NULL, 35, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (1, NULL, 15, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (3, NULL, 5, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
+-- Class target seed data
+INSERT INTO ClassTargets (id, asset_class_id, target_kind, target_percent, target_amount_chf, tolerance_percent, created_at, updated_at) VALUES (1, 4, 'percent', 40, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO ClassTargets (id, asset_class_id, target_kind, target_percent, target_amount_chf, tolerance_percent, created_at, updated_at) VALUES (2, 7, 'percent', 15, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO ClassTargets (id, asset_class_id, target_kind, target_percent, target_amount_chf, tolerance_percent, created_at, updated_at) VALUES (3, 2, 'percent', 35, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO ClassTargets (id, asset_class_id, target_kind, target_percent, target_amount_chf, tolerance_percent, created_at, updated_at) VALUES (4, 1, 'percent', 15, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO ClassTargets (id, asset_class_id, target_kind, target_percent, target_amount_chf, tolerance_percent, created_at, updated_at) VALUES (5, 3, 'percent', 5, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
 
--- Target allocations (sub-class level)
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (4, 11, 30, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (4, 14, 10, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (7, 18, 10, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (7, 21, 5, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (2, 3, 20, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (2, 4, 15, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (1, 1, 15, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
-INSERT INTO TargetAllocation (asset_class_id, sub_class_id, target_percent, target_amount_chf, target_kind, tolerance_percent, updated_at) VALUES (3, 7, 5, NULL, 'percent', 5.0, '2025-07-13 10:00:00');
+-- Sub-class target seed data
+INSERT INTO SubClassTargets (id, class_target_id, asset_sub_class_id, target_kind, target_percent, target_amount_chf, tolerance_percent, created_at, updated_at) VALUES (1, 1, 11, 'percent', 30, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets (id, class_target_id, asset_sub_class_id, target_kind, target_percent, target_amount_chf, tolerance_percent, created_at, updated_at) VALUES (2, 1, 14, 'percent', 10, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets (id, class_target_id, asset_sub_class_id, target_kind, target_percent, target_amount_chf, tolerance_percent, created_at, updated_at) VALUES (3, 2, 18, 'percent', 10, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets (id, class_target_id, asset_sub_class_id, target_kind, target_percent, target_amount_chf, tolerance_percent, created_at, updated_at) VALUES (4, 2, 21, 'percent', 5, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets (id, class_target_id, asset_sub_class_id, target_kind, target_percent, target_amount_chf, tolerance_percent, created_at, updated_at) VALUES (5, 3, 3, 'percent', 20, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets (id, class_target_id, asset_sub_class_id, target_kind, target_percent, target_amount_chf, tolerance_percent, created_at, updated_at) VALUES (6, 3, 4, 'percent', 15, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets (id, class_target_id, asset_sub_class_id, target_kind, target_percent, target_amount_chf, tolerance_percent, created_at, updated_at) VALUES (7, 4, 1, 'percent', 15, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets (id, class_target_id, asset_sub_class_id, target_kind, target_percent, target_amount_chf, tolerance_percent, created_at, updated_at) VALUES (8, 5, 7, 'percent', 5, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');

--- a/migrations/007_split_target_allocation.sql
+++ b/migrations/007_split_target_allocation.sql
@@ -1,0 +1,82 @@
+-- Migration: Split TargetAllocation into ClassTargets and SubClassTargets
+
+-- 1. Create ClassTargets table
+CREATE TABLE IF NOT EXISTS ClassTargets (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    asset_class_id INTEGER NOT NULL REFERENCES AssetClasses(class_id),
+    target_kind TEXT NOT NULL CHECK(target_kind IN('percent','amount')),
+    target_percent REAL DEFAULT 0,
+    target_amount_chf REAL DEFAULT 0,
+    tolerance_percent REAL DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT ck_class_nonneg CHECK(target_percent >= 0 AND target_amount_chf >= 0),
+    CONSTRAINT uq_class UNIQUE(asset_class_id)
+);
+
+-- 2. Create SubClassTargets table
+CREATE TABLE IF NOT EXISTS SubClassTargets (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    class_target_id INTEGER NOT NULL REFERENCES ClassTargets(id) ON DELETE CASCADE,
+    asset_sub_class_id INTEGER NOT NULL REFERENCES AssetSubClasses(sub_class_id),
+    target_kind TEXT NOT NULL CHECK(target_kind IN('percent','amount')),
+    target_percent REAL DEFAULT 0,
+    target_amount_chf REAL DEFAULT 0,
+    tolerance_percent REAL DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT ck_sub_nonneg CHECK(target_percent >= 0 AND target_amount_chf >= 0),
+    CONSTRAINT uq_sub UNIQUE(class_target_id, asset_sub_class_id)
+);
+
+-- 3. Create TargetChangeLog table
+CREATE TABLE IF NOT EXISTS TargetChangeLog (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    target_type TEXT NOT NULL CHECK(target_type IN('class','subclass')),
+    target_id INTEGER NOT NULL,
+    field_name TEXT NOT NULL,
+    old_value TEXT,
+    new_value TEXT,
+    changed_by TEXT,
+    changed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- 4. Backfill ClassTargets from TargetAllocation
+INSERT INTO ClassTargets (asset_class_id, target_kind, target_percent, target_amount_chf, tolerance_percent, created_at, updated_at)
+SELECT asset_class_id,
+       CASE
+           WHEN target_kind IS NOT NULL THEN target_kind
+           WHEN target_percent IS NOT NULL THEN 'percent'
+           ELSE 'amount'
+       END,
+       COALESCE(target_percent, 0),
+       COALESCE(target_amount_chf, 0),
+       COALESCE(tolerance_percent, 0),
+       COALESCE(updated_at, CURRENT_TIMESTAMP),
+       COALESCE(updated_at, CURRENT_TIMESTAMP)
+FROM TargetAllocation
+WHERE sub_class_id IS NULL;
+
+-- 5. Backfill SubClassTargets from TargetAllocation
+INSERT INTO SubClassTargets (class_target_id, asset_sub_class_id, target_kind, target_percent, target_amount_chf, tolerance_percent, created_at, updated_at)
+SELECT ct.id,
+       ta.sub_class_id,
+       CASE
+           WHEN ta.target_kind IS NOT NULL THEN ta.target_kind
+           WHEN ta.target_percent IS NOT NULL THEN 'percent'
+           ELSE 'amount'
+       END,
+       COALESCE(ta.target_percent, 0),
+       COALESCE(ta.target_amount_chf, 0),
+       COALESCE(ta.tolerance_percent, 0),
+       COALESCE(ta.updated_at, CURRENT_TIMESTAMP),
+       COALESCE(ta.updated_at, CURRENT_TIMESTAMP)
+FROM TargetAllocation ta
+JOIN ClassTargets ct ON ct.asset_class_id = ta.asset_class_id
+WHERE ta.sub_class_id IS NOT NULL;
+
+-- 6. Log migration
+INSERT INTO TargetChangeLog (target_type, target_id, field_name, old_value, new_value, changed_by)
+SELECT 'class', id, 'migration', NULL, 'backfill', 'script' FROM ClassTargets;
+INSERT INTO TargetChangeLog (target_type, target_id, field_name, old_value, new_value, changed_by)
+SELECT 'subclass', id, 'migration', NULL, 'backfill', 'script' FROM SubClassTargets;

--- a/tests/test_schema_version.py
+++ b/tests/test_schema_version.py
@@ -8,4 +8,4 @@ from deploy_db import parse_version
 
 def test_schema_version_updated():
     schema_path = Path(__file__).resolve().parents[1] / 'DragonShield' / 'database' / 'schema.sql'
-    assert parse_version(str(schema_path)) == '4.19'
+    assert parse_version(str(schema_path)) == '4.20'


### PR DESCRIPTION
## Summary
- add ClassTargets, SubClassTargets, and TargetChangeLog tables
- backfill new target hierarchy and audit entries via migration script
- bump schema version to 4.20 with updated seed data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68924f51ebe48323acfe07a3a503df23