### PR TITLE
fix: include all tables in backup lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Ensure backup routines include TargetChangeLog and full reference data
 - Polish target edit panel layout with fixed width and regrouped inputs for clarity
 - Expand target edit panel to 800×600 and allow dragging to reposition
 - Fix optional class ID handling in target sum validation warnings

--- a/DragonShield/BackupService.swift
+++ b/DragonShield/BackupService.swift
@@ -40,7 +40,7 @@ class BackupService: ObservableObject {
     let transactionTables = [
         "Portfolios", "PortfolioInstruments", "Transactions",
         "PositionReports", "ImportSessions", "ImportSessionValueReports",
-        "ExchangeRates", "ClassTargets", "SubClassTargets"
+        "ExchangeRates", "ClassTargets", "SubClassTargets", "TargetChangeLog"
     ]
 
     var fullTables: [String] {

--- a/DragonShield/python_scripts/db_tool.py
+++ b/DragonShield/python_scripts/db_tool.py
@@ -34,12 +34,15 @@ DEFAULT_TARGET_DIR = (
 )
 
 REFERENCE_TABLES = [
+    "Configuration",
     "Currencies",
-    "Institutions",
-    "AccountTypes",
-    "TransactionTypes",
+    "ExchangeRates",
+    "FxRateUpdates",
     "AssetClasses",
     "AssetSubClasses",
+    "TransactionTypes",
+    "AccountTypes",
+    "Institutions",
     "Instruments",
     "Accounts",
 ]


### PR DESCRIPTION
## Summary
- ensure TargetChangeLog participates in transaction backups
- expand reference table list in db_tool to cover configuration and exchange rates
- document backup list completeness

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894f51a5e488323b3174f34598d1114