### PR TITLE
fix(ui): update target edit panel title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Show bold, left-aligned "Asset Allocation for <Class>" title in target edit panel
 - Ensure backup routines include TargetChangeLog and full reference data
 - Remove legacy Asset Allocation view and navigation link
 - Polish target edit panel layout with fixed width and regrouped inputs for clarity

--- a/DragonShield/Views/TargetEditPanel.swift
+++ b/DragonShield/Views/TargetEditPanel.swift
@@ -66,8 +66,12 @@ struct TargetEditPanel: View {
         VStack(spacing: 0) {
             ScrollView {
                 VStack(alignment: .leading, spacing: 24) {
-                    Text("Edit \"\(className)\" Targets")
-                        .font(.headline)
+                    Text("Asset Allocation for \(className)")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                        .multilineTextAlignment(.leading)
+                        .lineLimit(1)
+                        .accessibilityLabel("Asset Allocation for \(className)")
 
                     VStack(spacing: 16) {
                         HStack(spacing: 24) {


### PR DESCRIPTION
## Summary
- enlarge and bold target edit panel title with left alignment
- document target edit panel title update in changelog

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68953209ebb88323a5bebc221201410f