### PR TITLE
feat(allocation): persist and display validation status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ All notable changes to this project will be documented in this file.
 - Mention language code console warnings and how to silence them
 - Log database version correctly at startup
 - Label green stale account range as "<1 month / today"
+- Persist validation status for ClassTargets and SubClassTargets and display colored indicators in allocation views
 - Show per-table row count comparison after restore in a modal window
 - Auto-expand stale account sections and open editable account detail window from Dashboard
 - Add validation triggers for ClassTargets/SubClassTargets and surface warnings in allocation editor

--- a/DragonShield/Views/TargetEditPanel.swift
+++ b/DragonShield/Views/TargetEditPanel.swift
@@ -15,6 +15,7 @@ struct TargetEditPanel: View {
         var amount: Double
         var kind: TargetKind
         var tolerance: Double
+        var validationStatus: String
         var locked: Bool = false
     }
 
@@ -158,6 +159,7 @@ struct TargetEditPanel: View {
                         Divider()
                         ForEach($rows) { $row in
                             HStack {
+                                ValidationStatusDot(status: row.validationStatus)
                                 Text(row.name)
                                     .frame(minWidth: 200, maxWidth: .infinity, alignment: .leading)
 
@@ -302,7 +304,8 @@ struct TargetEditPanel: View {
                        percent: rec.percent,
                        amount: amt,
                        kind: rk,
-                       tolerance: tol)
+                       tolerance: tol,
+                       validationStatus: rec.validationStatus)
         }
         initialRows = Dictionary(uniqueKeysWithValues: rows.map { ($0.id, $0) })
 

--- a/DragonShield/Views/ValidationStatusDot.swift
+++ b/DragonShield/Views/ValidationStatusDot.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct ValidationStatusDot: View {
+    let status: String
+
+    private var color: Color {
+        switch status {
+        case "compliant": return .success
+        case "warning": return .warning
+        case "error": return .error
+        default: return .gray
+        }
+    }
+
+    private var label: String {
+        switch status {
+        case "compliant": return "Compliant"
+        case "warning": return "Warning"
+        case "error": return "Error"
+        default: return "Unknown"
+        }
+    }
+
+    var body: some View {
+        Circle()
+            .fill(color)
+            .frame(width: 8, height: 8)
+            .accessibilityLabel(Text(label))
+    }
+}

--- a/DragonShield/database/schema.sql
+++ b/DragonShield/database/schema.sql
@@ -1,10 +1,11 @@
 -- DragonShield/docs/schema.sql
 -- Dragon Shield Database Creation Script
--- Version 4.21 - Add validation triggers for ClassTargets and SubClassTargets
+-- Version 4.22 - Add validation status columns to ClassTargets and SubClassTargets
 -- Created: 2025-05-24
--- Updated: 2025-07-13
+-- Updated: 2025-08-08
 --
 -- RECENT HISTORY:
+-- - v4.21 -> v4.22: Add validation status columns to ClassTargets and SubClassTargets.
 -- - v4.20 -> v4.21: Add validation triggers for ClassTargets and SubClassTargets sums.
 -- - v4.19 -> v4.20: Replace TargetAllocation with ClassTargets/SubClassTargets and add TargetChangeLog.
 -- - v4.17 -> v4.18: Added target_kind and tolerance_percent columns to TargetAllocation.
@@ -202,6 +203,7 @@ CREATE TABLE ClassTargets (
     target_percent REAL DEFAULT 0,
     target_amount_chf REAL DEFAULT 0,
     tolerance_percent REAL DEFAULT 0,
+    validation_status TEXT NOT NULL DEFAULT 'warning' CHECK(validation_status IN('compliant','warning','error')),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT ck_class_nonneg CHECK(target_percent >= 0 AND target_amount_chf >= 0),
@@ -216,6 +218,7 @@ CREATE TABLE SubClassTargets (
     target_percent REAL DEFAULT 0,
     target_amount_chf REAL DEFAULT 0,
     tolerance_percent REAL DEFAULT 0,
+    validation_status TEXT NOT NULL DEFAULT 'warning' CHECK(validation_status IN('compliant','warning','error')),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT ck_sub_nonneg CHECK(target_percent >= 0 AND target_amount_chf >= 0),

--- a/DragonShield/database/schema.txt
+++ b/DragonShield/database/schema.txt
@@ -1,9 +1,10 @@
 -- DragonShield/docs/schema.txt
 -- Dragon Shield Seed Data
 -- Created: 2025-05-24
--- Updated: 2025-07-13
+-- Updated: 2025-08-08
 --
 -- RECENT HISTORY:
+-- - v4.21 -> v4.22: Add validation status columns to ClassTargets and SubClassTargets
 -- - v4.20 -> v4.21: Add validation triggers for ClassTargets and SubClassTargets
 -- - v4.19 -> v4.20: Replace TargetAllocation with ClassTargets/SubClassTargets and add TargetChangeLog
 -- - v4.7 -> v4.8: Added Institutions table and updated Accounts seed data.
@@ -31,7 +32,7 @@ INSERT INTO Configuration VALUES ('9', 'table_row_padding', '12.0', 'number', 'V
 INSERT INTO Configuration VALUES ('10', 'table_font_size', '14.0', 'number', 'Font size for text in data table rows (in points)', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('11', 'include_direct_re', 'true', 'boolean', 'Include direct real estate in allocation views', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('12', 'direct_re_target_chf', '0', 'number', 'Target CHF amount for direct real estate', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
-INSERT INTO Configuration VALUES ('13', 'db_version', '4.21', 'string', 'Database schema version', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
+INSERT INTO Configuration VALUES ('13', 'db_version', '4.22', 'string', 'Database schema version', '2025-08-08 09:04:29', '2025-08-08 09:04:29');
 INSERT INTO Currencies VALUES ('CHF', 'Swiss Franc', 'CHF', '1', '0', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('EUR', 'Euro', '€', '1', '1', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('USD', 'US Dollar', '$', '1', '1', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
@@ -350,18 +351,18 @@ INSERT INTO PositionReports VALUES (
 );
 
 -- Target allocations (class level)
-INSERT INTO ClassTargets VALUES ('1', 4, 'percent', 40, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
-INSERT INTO ClassTargets VALUES ('2', 7, 'percent', 15, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
-INSERT INTO ClassTargets VALUES ('3', 2, 'percent', 35, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
-INSERT INTO ClassTargets VALUES ('4', 1, 'percent', 15, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
-INSERT INTO ClassTargets VALUES ('5', 3, 'percent', 5, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO ClassTargets VALUES ('1', 4, 'percent', 40, 0, 5.0, 'warning', '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO ClassTargets VALUES ('2', 7, 'percent', 15, 0, 5.0, 'warning', '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO ClassTargets VALUES ('3', 2, 'percent', 35, 0, 5.0, 'warning', '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO ClassTargets VALUES ('4', 1, 'percent', 15, 0, 5.0, 'warning', '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO ClassTargets VALUES ('5', 3, 'percent', 5, 0, 5.0, 'warning', '2025-07-13 10:00:00', '2025-07-13 10:00:00');
 
 -- Target allocations (sub-class level)
-INSERT INTO SubClassTargets VALUES ('1', 1, 11, 'percent', 30, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
-INSERT INTO SubClassTargets VALUES ('2', 1, 14, 'percent', 10, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
-INSERT INTO SubClassTargets VALUES ('3', 2, 18, 'percent', 10, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
-INSERT INTO SubClassTargets VALUES ('4', 2, 21, 'percent', 5, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
-INSERT INTO SubClassTargets VALUES ('5', 3, 3, 'percent', 20, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
-INSERT INTO SubClassTargets VALUES ('6', 3, 4, 'percent', 15, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
-INSERT INTO SubClassTargets VALUES ('7', 4, 1, 'percent', 15, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
-INSERT INTO SubClassTargets VALUES ('8', 5, 7, 'percent', 5, 0, 5.0, '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets VALUES ('1', 1, 11, 'percent', 30, 0, 5.0, 'warning', '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets VALUES ('2', 1, 14, 'percent', 10, 0, 5.0, 'warning', '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets VALUES ('3', 2, 18, 'percent', 10, 0, 5.0, 'warning', '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets VALUES ('4', 2, 21, 'percent', 5, 0, 5.0, 'warning', '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets VALUES ('5', 3, 3, 'percent', 20, 0, 5.0, 'warning', '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets VALUES ('6', 3, 4, 'percent', 15, 0, 5.0, 'warning', '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets VALUES ('7', 4, 1, 'percent', 15, 0, 5.0, 'warning', '2025-07-13 10:00:00', '2025-07-13 10:00:00');
+INSERT INTO SubClassTargets VALUES ('8', 5, 7, 'percent', 5, 0, 5.0, 'warning', '2025-07-13 10:00:00', '2025-07-13 10:00:00');

--- a/DragonShield/migrations/002_add_validation_status.sql
+++ b/DragonShield/migrations/002_add_validation_status.sql
@@ -1,0 +1,42 @@
+-- migrate:up
+ALTER TABLE ClassTargets ADD COLUMN validation_status TEXT NOT NULL DEFAULT 'warning' CHECK(validation_status IN('compliant','warning','error'));
+ALTER TABLE SubClassTargets ADD COLUMN validation_status TEXT NOT NULL DEFAULT 'warning' CHECK(validation_status IN('compliant','warning','error'));
+
+UPDATE ClassTargets
+SET validation_status =
+  CASE
+    WHEN ABS((SELECT SUM(target_percent) FROM ClassTargets) - 100.0) <= tolerance_percent THEN 'compliant'
+    WHEN ABS((SELECT SUM(target_percent) FROM ClassTargets) - 100.0) <= tolerance_percent*2 THEN 'warning'
+    ELSE 'error'
+  END;
+
+UPDATE SubClassTargets
+SET validation_status =
+  CASE
+    WHEN ABS((
+      SELECT SUM(target_percent)
+      FROM SubClassTargets
+      WHERE class_target_id=SubClassTargets.class_target_id
+    ) - 100.0) <= (
+      SELECT tolerance_percent
+      FROM ClassTargets
+      WHERE id=SubClassTargets.class_target_id
+    ) THEN 'compliant'
+    WHEN ABS((
+      SELECT SUM(target_percent)
+      FROM SubClassTargets
+      WHERE class_target_id=SubClassTargets.class_target_id
+    ) - 100.0) <= (
+      SELECT tolerance_percent
+      FROM ClassTargets
+      WHERE id=SubClassTargets.class_target_id
+    )*2 THEN 'warning'
+    ELSE 'error'
+  END;
+
+UPDATE Configuration SET value='4.22' WHERE key='db_version';
+
+-- migrate:down
+ALTER TABLE SubClassTargets DROP COLUMN validation_status;
+ALTER TABLE ClassTargets    DROP COLUMN validation_status;
+UPDATE Configuration SET value='4.21' WHERE key='db_version';


### PR DESCRIPTION
## Summary
- add validation_status column to ClassTargets and SubClassTargets
- show colored compliance dots in allocation views
- bump schema and seed data to v4.22

## Testing
- `dbmate --help` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'DragonShield')*

------
https://chatgpt.com/codex/tasks/task_e_6895c59d21a88323a3f852c2306a57c6