### PR TITLE
feat(ui): add validation status column with deviation bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Show bold, left-aligned "Asset Allocation for <Class>" title in target edit panel
+ - Add validation status column with traffic-light icons and deviation bars in Asset Allocation table
 - Ensure backup routines include TargetChangeLog and full reference data
 - Remove legacy Asset Allocation view and navigation link
 - Polish target edit panel layout with fixed width and regrouped inputs for clarity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Show bold, left-aligned "Asset Allocation for <Class>" title in target edit panel
- - Add validation status column with traffic-light icons and deviation bars in Asset Allocation table
+- Add validation status column with traffic-light icons and deviation bars in Asset Allocation table
+- Fix failed ClassTargets/SubClassTargets upserts so edited targets persist
 - Ensure backup routines include TargetChangeLog and full reference data
 - Remove legacy Asset Allocation view and navigation link
 - Polish target edit panel layout with fixed width and regrouped inputs for clarity


### PR DESCRIPTION
## Summary
- add traffic-light status icons and deviation bars to asset allocation table
- expose validation status widths and headers for new column

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_689636c2beac83238b7f090db2244747