### PR TITLE
feat(ui): show validation status column in asset allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ All notable changes to this project will be documented in this file.
 - Update deviation bar display in Asset Allocation tile
 - Shorten deviation bars to half length in Asset Allocation tile
 - Remove plus/minus icons from deviation column in Asset Allocation tile
+- Display validation status column with traffic-light icons and deviation bars in Asset Allocation table
 - Prompt to confirm option quantity multiplier during position import
 - Show institutions ranked by AUM in new dashboard tile
 - Document troubleshooting steps for missing `default.metallib` warning

--- a/DragonShield/Views/AllocationDashboard/AllocationDashboardViewModel.swift
+++ b/DragonShield/Views/AllocationDashboard/AllocationDashboardViewModel.swift
@@ -15,6 +15,14 @@ final class AllocationDashboardViewModel: ObservableObject {
 
         var deviationPct: Double { actualPct - targetPct }
         var deviationChf: Double { actualChf - targetChf }
+        var deviationPercent: Double { abs(deviationPct) }
+        var validationStatus: String {
+            let dev = deviationPercent
+            let tol = tolerancePercent
+            if dev > tol * 2 { return "error" }
+            if dev > tol { return "warning" }
+            return "compliant"
+        }
         var relativeDev: Double {
             guard targetPct != 0 else { return 0 }
             return (actualPct - targetPct) / targetPct


### PR DESCRIPTION
## Summary
- add validation status property and deviation percent to allocation assets
- render traffic-light status and deviation bar column in allocation table
- note validation status column in changelog

## Testing
- `PYTHONPATH=/workspace/DragonShield pytest Archive/tests/test_allocation_deviation.py`
- `PYTHONPATH=/workspace/DragonShield pytest` *(fails: No module named 'risk_metrics')*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689636c2beac83238b7f090db2244747