### PR TITLE
feat(ui): add validation status column with deviation bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Show bold, left-aligned "Asset Allocation for <Class>" title in target edit panel
+- Display validation status icons with deviation bars in Allocation Targets table
 - Ensure backup routines include TargetChangeLog and full reference data
 - Remove legacy Asset Allocation view and navigation link
 - Polish target edit panel layout with fixed width and regrouped inputs for clarity


### PR DESCRIPTION
## Summary
- show traffic-light status icons and deviation bars in Allocation Targets table
- document validation status column in changelog

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68964f8372fc8323a6bdfe081699ee74