### PR TITLE
feat(ui): display validation status in allocation table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Show bold, left-aligned "Asset Allocation for <Class>" title in target edit panel
+- Display validation status icons and deviation bars in Asset Allocation table
 - Ensure backup routines include TargetChangeLog and full reference data
 - Remove legacy Asset Allocation view and navigation link
 - Polish target edit panel layout with fixed width and regrouped inputs for clarity

--- a/DragonShield/DatabaseManager+PortfolioTargets.swift
+++ b/DragonShield/DatabaseManager+PortfolioTargets.swift
@@ -213,7 +213,8 @@ extension DatabaseManager {
         percent: Double,
         amountCHF: Double?,
         targetKind: String,
-        tolerance: Double
+        tolerance: Double,
+        validationStatus: String
     )] {
         var results: [(
             classId: Int?,
@@ -221,7 +222,8 @@ extension DatabaseManager {
             percent: Double,
             amountCHF: Double?,
             targetKind: String,
-            tolerance: Double
+            tolerance: Double,
+            validationStatus: String
         )] = []
         let query = """
             SELECT asset_class_id,
@@ -229,7 +231,8 @@ extension DatabaseManager {
                    target_percent,
                    target_amount_chf,
                    target_kind,
-                   tolerance_percent
+                   tolerance_percent,
+                   validation_status
             FROM ClassTargets
             UNION ALL
             SELECT ct.asset_class_id,
@@ -237,7 +240,8 @@ extension DatabaseManager {
                    s.target_percent,
                    s.target_amount_chf,
                    s.target_kind,
-                   s.tolerance_percent
+                   s.tolerance_percent,
+                   s.validation_status
             FROM SubClassTargets s
             JOIN ClassTargets ct ON s.class_target_id = ct.id;
         """
@@ -250,12 +254,14 @@ extension DatabaseManager {
                 let amount = sqlite3_column_type(statement, 3) == SQLITE_NULL ? nil : sqlite3_column_double(statement, 3)
                 let kind = String(cString: sqlite3_column_text(statement, 4))
                 let tolerance = sqlite3_column_double(statement, 5)
+                let status = String(cString: sqlite3_column_text(statement, 6))
                 results.append((classId: classId,
                                 subClassId: subId,
                                 percent: pct,
                                 amountCHF: amount,
                                 targetKind: kind,
-                                tolerance: tolerance))
+                                tolerance: tolerance,
+                                validationStatus: status))
             }
         } else {
             LoggingService.shared.log("Failed to prepare fetch ClassTargets/SubClassTargets: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)


### PR DESCRIPTION
## Summary
- show portfolio, class and sub-class validation statuses with traffic-light icons
- append deviation bar column to allocation table
- surface validation status and deviation bar change in changelog

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68964f8372fc8323a6bdfe081699ee74