### PR TITLE
feat(ui): convert Edit Targets panel to floating window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Replace faulty allocation validation triggers with non-blocking versions and update validation_status
+- Convert Edit Targets panel into resizable floating window with scrollable content
 - Show bold, left-aligned "Asset Allocation for <Class>" title in target edit panel
 - Add validation status column with traffic-light icons and deviation bars in Asset Allocation table
 - Fix failed ClassTargets/SubClassTargets upserts so edited targets persist

--- a/DragonShield/DragonShieldApp.swift
+++ b/DragonShield/DragonShieldApp.swift
@@ -32,5 +32,15 @@ struct DragonShieldApp: App {
                 Text("Account not found")
             }
         }
+        WindowGroup(id: "targetEdit", for: Int.self) { $classId in
+            if let cid = classId {
+                TargetEditPanel(classId: cid)
+                    .environmentObject(databaseManager)
+            } else {
+                Text("Asset class not found")
+            }
+        }
+        .defaultSize(width: 800, height: 600)
+        .windowResizability(.contentSize)
     }
 }

--- a/DragonShield/Views/AllocationTargetsTableView.swift
+++ b/DragonShield/Views/AllocationTargetsTableView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Foundation
 
 enum AllocationInputMode: String {
     case percent
@@ -401,9 +402,7 @@ struct AllocationTargetsTableView: View {
     @FocusState private var focusedChfField: String?
     @FocusState private var focusedPctField: String?
     @State private var showDetails = true
-    @State private var editingClassId: Int?
-    @State private var panelOffset: CGSize = .zero
-    @State private var lastPanelOffset: CGSize = .zero
+    @Environment(\.openWindow) private var openWindow
     @Environment(\.colorScheme) private var scheme
 
     private let percentFormatter: NumberFormatter = {
@@ -546,35 +545,11 @@ struct AllocationTargetsTableView: View {
             .background(cardBackground)
         }
         .padding(.horizontal, 24)
-        .overlay {
-            if let cid = editingClassId {
-                Color.black.opacity(0.4)
-                    .ignoresSafeArea()
-                    .transition(.opacity)
-                TargetEditPanel(classId: cid) {
-                    viewModel.load(using: dbManager)
-                    refreshDrafts()
-                    withAnimation { editingClassId = nil }
-                }
-                .environmentObject(dbManager)
-                .frame(width: 800, height: 600)
-                .background(Color.white)
-                .clipShape(RoundedRectangle(cornerRadius: 8))
-                .shadow(radius: 20)
-                .offset(panelOffset)
-                .gesture(
-                    DragGesture()
-                        .onChanged { value in
-                            panelOffset = CGSize(width: lastPanelOffset.width + value.translation.width,
-                                                 height: lastPanelOffset.height + value.translation.height)
-                        }
-                        .onEnded { _ in
-                            lastPanelOffset = panelOffset
-                        }
-                )
-            }
-        }
         .onAppear {
+            viewModel.load(using: dbManager)
+            refreshDrafts()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .targetsUpdated)) { _ in
             viewModel.load(using: dbManager)
             refreshDrafts()
         }
@@ -700,9 +675,6 @@ struct AllocationTargetsTableView: View {
     }
 
     private func rowBackground(for asset: AllocationAsset) -> Color {
-        if let cid = editingClassId, asset.id == "class-\(cid)" {
-            return .rowHighlight
-        }
         if viewModel.rowHasWarning(asset) {
             return .paleRed
         }
@@ -849,9 +821,9 @@ struct AllocationTargetsTableView: View {
             if isClass {
                 let cid = Int(asset.id.dropFirst(6))
                 Button {
-                    if let id = cid { editingClassId = id }
+                    if let id = cid { openWindow(id: "targetEdit", value: id) }
                 } label: {
-                    Image(systemName: editingClassId == cid ? "pencil.circle.fill" : "pencil.circle")
+                    Image(systemName: "pencil.circle")
                         .foregroundColor(.accentColor)
                         .frame(width: 16, height: 16)
                 }
@@ -903,7 +875,7 @@ struct AllocationTargetsTableView: View {
         .contentShape(Rectangle())
         .onTapGesture(count: 2) {
             if isClass, let id = Int(asset.id.dropFirst(6)) {
-                editingClassId = id
+                openWindow(id: "targetEdit", value: id)
             }
         }
     }


### PR DESCRIPTION
## Summary
- add dedicated window scene for asset allocation editing
- refactor target editor into resizable view with scrolling content and fixed footer
- trigger editor window from allocation table and dashboard rows

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `pip install -r requirements.txt` *(fails: No matching distribution found for pysqlcipher3)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'DragonShield')*

------
https://chatgpt.com/codex/tasks/task_e_6896bb854d488323aca485af147b8336