### PR TITLE
feat: surface allocation validation statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Move portfolio total validation from class editor to main dashboard and show validation badges for asset classes
+- Show class-level validation reasons in target edit panel
 - Replace faulty allocation validation triggers with non-blocking versions and update validation_status
 - Convert Edit Targets panel into resizable floating window with scrollable content
 - Show bold, left-aligned "Asset Allocation for <Class>" title in target edit panel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Move portfolio total validation from class editor to main dashboard and show validation badges for asset classes
 - Replace faulty allocation validation triggers with non-blocking versions and update validation_status
 - Convert Edit Targets panel into resizable floating window with scrollable content
 - Show bold, left-aligned "Asset Allocation for <Class>" title in target edit panel

--- a/DragonShield/DatabaseManager+PortfolioTargets.swift
+++ b/DragonShield/DatabaseManager+PortfolioTargets.swift
@@ -129,17 +129,18 @@ extension DatabaseManager {
 
     // MARK: - New persistence helpers
 
-    /// Fetch the class-level target for a given asset class.
+    /// Fetch the class-level target for a given asset class, including its validation status.
     func fetchClassTarget(classId: Int) -> (
         percent: Double,
         amountCHF: Double,
         targetKind: String,
-        tolerance: Double
+        tolerance: Double,
+        validationStatus: String
     )? {
         LoggingService.shared.log("Fetching ClassTargets for id=\(classId)", type: .info, logger: .database)
-        let query = "SELECT target_percent, target_amount_chf, target_kind, tolerance_percent FROM ClassTargets WHERE asset_class_id = ?;"
+        let query = "SELECT target_percent, target_amount_chf, target_kind, tolerance_percent, validation_status FROM ClassTargets WHERE asset_class_id = ?;"
         var statement: OpaquePointer?
-        var result: (Double, Double, String, Double)?
+        var result: (Double, Double, String, Double, String)?
         if sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK {
             sqlite3_bind_int(statement, 1, Int32(classId))
             if sqlite3_step(statement) == SQLITE_ROW {
@@ -147,13 +148,49 @@ extension DatabaseManager {
                 let amt = sqlite3_column_double(statement, 1)
                 let kind = String(cString: sqlite3_column_text(statement, 2))
                 let tol = sqlite3_column_double(statement, 3)
-                result = (pct, amt, kind, tol)
+                let status = String(cString: sqlite3_column_text(statement, 4))
+                result = (pct, amt, kind, tol, status)
             }
         } else {
             LoggingService.shared.log("Failed to prepare fetchClassTarget: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
         }
         sqlite3_finalize(statement)
-        return result.map { (percent: $0.0, amountCHF: $0.1, targetKind: $0.2, tolerance: $0.3) }
+        return result.map { (percent: $0.0, amountCHF: $0.1, targetKind: $0.2, tolerance: $0.3, validationStatus: $0.4) }
+    }
+
+    /// Fetch validation statuses for all asset classes.
+    func fetchClassValidationStatuses() -> [Int: String] {
+        var results: [Int: String] = [:]
+        let query = "SELECT asset_class_id, validation_status FROM ClassTargets"
+        var statement: OpaquePointer?
+        if sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK {
+            while sqlite3_step(statement) == SQLITE_ROW {
+                let id = Int(sqlite3_column_int(statement, 0))
+                let status = String(cString: sqlite3_column_text(statement, 1))
+                results[id] = status
+            }
+        } else {
+            LoggingService.shared.log("Failed to prepare fetchClassValidationStatuses: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+        sqlite3_finalize(statement)
+        return results
+    }
+
+    /// Fetch validation status for a single asset class.
+    func fetchClassValidationStatus(classId: Int) -> String? {
+        let query = "SELECT validation_status FROM ClassTargets WHERE asset_class_id = ?"
+        var statement: OpaquePointer?
+        var status: String?
+        if sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_int(statement, 1, Int32(classId))
+            if sqlite3_step(statement) == SQLITE_ROW {
+                status = String(cString: sqlite3_column_text(statement, 0))
+            }
+        } else {
+            LoggingService.shared.log("Failed to prepare fetchClassValidationStatus: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+        sqlite3_finalize(statement)
+        return status
     }
 
     /// Fetch all sub-class targets for a given asset class.

--- a/DragonShield/Views/TargetEditPanel.swift
+++ b/DragonShield/Views/TargetEditPanel.swift
@@ -32,8 +32,7 @@ struct TargetEditPanel: View {
     @State private var portfolioTotal: Double = 0
     @State private var tolerance: Double = 5
     @State private var rows: [Row] = []
-    @State private var parentWarning: String? = nil
-    @State private var totalClassPercent: Double = 0
+    @State private var validationStatus: String = "compliant"
     @State private var isInitialLoad = true
     @State private var initialRows: [Int: Row] = [:]
 
@@ -65,7 +64,7 @@ struct TargetEditPanel: View {
             headerSection
             Divider()
             ScrollView {
-                VStack(alignment: .leading, spacing: 24) {
+                VStack(alignment: .leading, spacing: 16) {
                     Text("Sub-Class Targets:")
                         .font(.headline)
 
@@ -133,22 +132,13 @@ struct TargetEditPanel: View {
                                     .multilineTextAlignment(.trailing)
                                     .textFieldStyle(.roundedBorder)
                             }
-                            .padding(.vertical, 8)
+                            .padding(.vertical, 6)
                             Divider()
                         }
                     }
 
                     Text("Remaining to allocate: \(remaining, format: .number.precision(.fractionLength(1))) \(kind == .percent ? "%" : "CHF")")
                         .foregroundColor(remaining == 0 ? .primary : .red)
-
-                    if let warning = parentWarning {
-                        Text(warning)
-                            .padding(8)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .background(Color.red)
-                            .foregroundColor(.white)
-                            .clipShape(RoundedRectangle(cornerRadius: 6))
-                    }
                 }
                 .padding(24)
             }
@@ -166,12 +156,10 @@ struct TargetEditPanel: View {
                 parentPercent = portfolioTotal > 0 ? parentAmount / portfolioTotal * 100 : 0
             }
             updateRows()
-            updateClassTotals()
         }
         .onChange(of: parentAmount) { _, _ in
             guard !isInitialLoad else { return }
             updateRows()
-            updateClassTotals()
         }
         .onChange(of: focusedChfField) { oldValue, newValue in
             if let old = oldValue, old != newValue {
@@ -215,7 +203,6 @@ struct TargetEditPanel: View {
                             parentAmount = portfolioTotal * capped / 100
                             let ratio = String(format: "%.2f", capped / 100)
                             log("CALC %→CHF", "Changed percent \(oldVal)→\(capped) ⇒ CHF=\(ratio)×\(formatChf(portfolioTotal))=\(formatChf(parentAmount))", type: .debug)
-                            updateClassTotals()
                         }
                 }
 
@@ -234,7 +221,6 @@ struct TargetEditPanel: View {
                             if capped != newVal { parentAmount = capped }
                             parentPercent = portfolioTotal > 0 ? capped / portfolioTotal * 100 : parentPercent
                             log("CALC CHF→%", "Changed CHF \(formatChf(oldVal))→\(formatChf(capped)) ⇒ percent=(\(formatChf(capped))÷\(formatChf(portfolioTotal)))×100=\(String(format: "%.1f", parentPercent))", type: .debug)
-                            updateClassTotals()
                         }
                 }
 
@@ -245,10 +231,22 @@ struct TargetEditPanel: View {
                         .multilineTextAlignment(.trailing)
                         .textFieldStyle(.roundedBorder)
                 }
+
+                Spacer()
+
+                VStack(alignment: .leading) {
+                    Text("Validation Status")
+                    Text(validationStatus.capitalized)
+                        .font(.caption)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(colorForStatus(validationStatus))
+                        .foregroundColor(.white)
+                        .clipShape(Capsule())
+                }
             }
             Divider()
             HStack(spacing: 32) {
-                Text("Σ Classes % = \(totalClassPercent, format: .number.precision(.fractionLength(1)))%")
                 Text("Σ Sub-class % = \(sumChildPercent, format: .number.precision(.fractionLength(1)))%")
                 Text("Σ Sub-class CHF = \(formatChf(sumChildAmount))")
             }
@@ -272,19 +270,19 @@ struct TargetEditPanel: View {
     private func load() {
         className = db.fetchAssetClassDetails(id: classId)?.name ?? ""
         portfolioTotal = calculatePortfolioTotal()
-        parentWarning = nil
-
         log("FETCH", "Fetching ClassTargets for id=\(classId)", type: .info)
         if let parent = db.fetchClassTarget(classId: classId) {
             kind = parent.targetKind == "amount" ? .amount : .percent
             parentPercent = parent.percent
             parentAmount = parent.amountCHF
             tolerance = parent.tolerance
+            validationStatus = parent.validationStatus
         } else {
             kind = .percent
             parentPercent = 0
             parentAmount = 0
             tolerance = 0
+            validationStatus = "compliant"
         }
         log("FETCH", "Fetching SubClassTargets for class id=\(classId)", type: .info)
         let subRecs = db.fetchSubClassTargets(classId: classId)
@@ -311,7 +309,6 @@ struct TargetEditPanel: View {
         for r in rows {
             log("EDIT PANEL LOAD", "Loaded sub-class \"\(r.name)\" id=\(r.id): percent=\(r.percent), CHF=\(r.amount), kind=\(r.kind.rawValue), tol=\(r.tolerance)", type: .info)
         }
-        updateClassTotals()
         isInitialLoad = false
     }
 
@@ -388,19 +385,18 @@ struct TargetEditPanel: View {
                                     kind: row.kind.rawValue,
                                     tolerance: row.tolerance)
         }
+        if let status = db.fetchClassValidationStatus(classId: classId) {
+            validationStatus = status
+        }
         NotificationCenter.default.post(name: .targetsUpdated, object: nil)
         dismiss()
     }
 
-    private func updateClassTotals() {
-        let records = db.fetchPortfolioTargetRecords(portfolioId: 1)
-        let others = records.filter { $0.subClassId == nil && $0.classId != classId }.map(\.percent).reduce(0, +)
-        totalClassPercent = others + parentPercent
-        let tol = 0.1
-        if abs(totalClassPercent - 100) > tol {
-            parentWarning = String(format: "Warning: Total Asset Class %% = %.1f%% (expected 100%% ± %.1f%%)", totalClassPercent, tol)
-        } else {
-            parentWarning = nil
+    private func colorForStatus(_ status: String) -> Color {
+        switch status.lowercased() {
+        case "warning": return .warning
+        case "error": return .error
+        default: return .success
         }
     }
 


### PR DESCRIPTION
## Summary
- add validation status badge in class target editor
- show portfolio validation panel and per-class status dots in allocation table
- expose class validation status queries in database layer

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6896c4e304948323af2f7771d2b268a4