### PR TITLE
feat(ui): show class validation badge in target editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Show validation badge for selected asset class and remove portfolio totals from editor
 - Replace faulty allocation validation triggers with non-blocking versions and update validation_status
 - Convert Edit Targets panel into resizable floating window with scrollable content
 - Show bold, left-aligned "Asset Allocation for <Class>" title in target edit panel

--- a/DragonShield/DatabaseManager+PortfolioTargets.swift
+++ b/DragonShield/DatabaseManager+PortfolioTargets.swift
@@ -134,12 +134,13 @@ extension DatabaseManager {
         percent: Double,
         amountCHF: Double,
         targetKind: String,
-        tolerance: Double
+        tolerance: Double,
+        validationStatus: String
     )? {
         LoggingService.shared.log("Fetching ClassTargets for id=\(classId)", type: .info, logger: .database)
-        let query = "SELECT target_percent, target_amount_chf, target_kind, tolerance_percent FROM ClassTargets WHERE asset_class_id = ?;"
+        let query = "SELECT target_percent, target_amount_chf, target_kind, tolerance_percent, validation_status FROM ClassTargets WHERE asset_class_id = ?;"
         var statement: OpaquePointer?
-        var result: (Double, Double, String, Double)?
+        var result: (Double, Double, String, Double, String)?
         if sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK {
             sqlite3_bind_int(statement, 1, Int32(classId))
             if sqlite3_step(statement) == SQLITE_ROW {
@@ -147,13 +148,14 @@ extension DatabaseManager {
                 let amt = sqlite3_column_double(statement, 1)
                 let kind = String(cString: sqlite3_column_text(statement, 2))
                 let tol = sqlite3_column_double(statement, 3)
-                result = (pct, amt, kind, tol)
+                let status = String(cString: sqlite3_column_text(statement, 4))
+                result = (pct, amt, kind, tol, status)
             }
         } else {
             LoggingService.shared.log("Failed to prepare fetchClassTarget: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
         }
         sqlite3_finalize(statement)
-        return result.map { (percent: $0.0, amountCHF: $0.1, targetKind: $0.2, tolerance: $0.3) }
+        return result.map { (percent: $0.0, amountCHF: $0.1, targetKind: $0.2, tolerance: $0.3, validationStatus: $0.4) }
     }
 
     /// Fetch all sub-class targets for a given asset class.


### PR DESCRIPTION
## Summary
- display validation status badge for asset classes in target editor
- remove portfolio-wide totals from class editor and reduce row spacing
- expose validation_status when fetching class targets

## Testing
- `python -m pytest` *(fails: No module named 'db_tool')*

------
https://chatgpt.com/codex/tasks/task_e_6896c4e304948323af2f7771d2b268a4