### PR TITLE
feat(allocation): pin totals row and highlight target percent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Pin totals row in Allocation Targets table and color-code target percentage total
 - Move portfolio total validation from class editor to main dashboard and show validation badges for asset classes
 - Persist class-level validation findings and show them via "Why?" in target edit panel
 - Replace faulty allocation validation triggers with non-blocking versions and update validation_status


### PR DESCRIPTION
## Summary
- fix totals row at bottom of Allocation Targets table and always display column sums
- color-code target percent total with amber/red based on tolerance and add tooltip

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689707808be483238b550cc073863005