### PR TITLE
feat: add validation details modal and totals footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Add totals footer and validation details modal in Asset Allocation table
 - Move portfolio total validation from class editor to main dashboard and show validation badges for asset classes
 - Persist class-level validation findings and show them via "Why?" in target edit panel
 - Replace faulty allocation validation triggers with non-blocking versions and update validation_status

--- a/DragonShield/Views/ValidationDetailsView.swift
+++ b/DragonShield/Views/ValidationDetailsView.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+#if canImport(AppKit)
+import AppKit
+#endif
+
+struct ValidationDetailsView: View {
+    let findings: [DatabaseManager.ValidationFinding]
+    @State private var filter: SeverityFilter = .all
+
+    enum SeverityFilter { case all, errors, warnings }
+
+    private var filtered: [DatabaseManager.ValidationFinding] {
+        switch filter {
+        case .all: return findings
+        case .errors: return findings.filter { $0.severity == "error" }
+        case .warnings: return findings.filter { $0.severity == "warning" }
+        }
+    }
+
+    private var grouped: [(String, [DatabaseManager.ValidationFinding])] {
+        let groups = Dictionary(grouping: filtered, by: { $0.entityType })
+        return groups.keys.sorted().map { ($0, groups[$0]!) }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Validation Details")
+                    .font(.headline)
+                Spacer()
+                Picker("", selection: $filter) {
+                    Text("All").tag(SeverityFilter.all)
+                    Text("Errors").tag(SeverityFilter.errors)
+                    Text("Warnings").tag(SeverityFilter.warnings)
+                }
+                .pickerStyle(.segmented)
+                Button("Copy") {
+                    copyToClipboard()
+                }
+            }
+            if findings.isEmpty {
+                Text("No validation findings at this time.")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+            } else {
+                List {
+                    ForEach(grouped, id: \.0) { group, items in
+                        Section(header: Text(label(for: group))) {
+                            ForEach(items) { item in
+                                HStack(alignment: .top, spacing: 8) {
+                                    Text(item.severity.uppercased())
+                                        .font(.caption2)
+                                        .padding(4)
+                                        .background(item.severity == "error" ? Color.red : Color.orange)
+                                        .foregroundColor(.white)
+                                        .clipShape(Capsule())
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(item.code).bold()
+                                        Text(item.message)
+                                        Text(dateString(item.computedAt))
+                                            .font(.caption2)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .padding()
+        .frame(minWidth: 400, minHeight: 300)
+    }
+
+    private func label(for group: String) -> String {
+        switch group {
+        case "portfolio": return "Portfolio-level"
+        case "class": return "Asset Classes"
+        case "subclass": return "Sub-Classes"
+        default: return group
+        }
+    }
+
+    private func dateString(_ date: Date) -> String {
+        let df = DateFormatter()
+        df.dateStyle = .short
+        df.timeStyle = .short
+        return df.string(from: date)
+    }
+
+    private func copyToClipboard() {
+        let text = filtered.map { "\($0.severity.uppercased()) \($0.code): \($0.message)" }.joined(separator: "\n")
+        #if canImport(AppKit)
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+        #endif
+    }
+}


### PR DESCRIPTION
## Summary
- surface validation details via button and modal with filters and copy-to-clipboard
- keep allocation table actionable with fixed totals footer and percentage tooltip
- expose validation findings from database for portfolio, class and subclass scopes

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pysqlcipher3)*
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'DragonShield')*


------
https://chatgpt.com/codex/tasks/task_e_689707808be483238b550cc073863005