### PR TITLE
feat(allocation): add totals row and validation details modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Add totals row and validation details modal to Asset Allocation view
 - Move portfolio total validation from class editor to main dashboard and show validation badges for asset classes
 - Persist class-level validation findings and show them via "Why?" in target edit panel
 - Replace faulty allocation validation triggers with non-blocking versions and update validation_status


### PR DESCRIPTION
## Summary
- show overall Target %, Target CHF, and Actual CHF totals in Asset Allocation table with validation color cue
- surface portfolio validation issues via new "Validation Details" modal and button
- expose validation findings through DatabaseManager and view model

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689707808be483238b550cc073863005