### PR TITLE
fix: skip validation for zero-target asset classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Skip validation for asset classes without target allocation and clear related findings
 - Add totals row and validation details modal to Asset Allocation view
 - Move portfolio total validation from class editor to main dashboard and show validation badges for asset classes
 - Persist class-level validation findings and show them via "Why?" in target edit panel

--- a/DragonShield/Views/TargetEditPanel.swift
+++ b/DragonShield/Views/TargetEditPanel.swift
@@ -55,6 +55,10 @@ struct TargetEditPanel: View {
         }
     }
 
+    private var isZeroTarget: Bool {
+        parentPercent == 0 && parentAmount == 0
+    }
+
     private var sumChildPercent: Double {
         rows.map(\.percent).reduce(0, +)
     }
@@ -140,8 +144,10 @@ struct TargetEditPanel: View {
                         }
                     }
 
-                    Text("Remaining to allocate: \(remaining, format: .number.precision(.fractionLength(1))) \(kind == .percent ? "%" : "CHF")")
-                        .foregroundColor(remaining == 0 ? .primary : .red)
+                    if !isZeroTarget {
+                        Text("Remaining to allocate: \(remaining, format: .number.precision(.fractionLength(1))) \(kind == .percent ? "%" : "CHF")")
+                            .foregroundColor(remaining == 0 ? .primary : .red)
+                    }
                 }
                 .padding(24)
             }
@@ -276,12 +282,14 @@ struct TargetEditPanel: View {
                 }
             }
             Divider()
-            HStack(spacing: 32) {
-                Text("Σ Sub-class % = \(sumChildPercent, format: .number.precision(.fractionLength(1)))%")
-                Text("Σ Sub-class CHF = \(formatChf(sumChildAmount))")
+            if !isZeroTarget {
+                HStack(spacing: 32) {
+                    Text("Σ Sub-class % = \(sumChildPercent, format: .number.precision(.fractionLength(1)))%")
+                    Text("Σ Sub-class CHF = \(formatChf(sumChildAmount))")
+                }
+                .font(.footnote)
+                .foregroundColor(.secondary)
             }
-            .font(.footnote)
-            .foregroundColor(.secondary)
         }
         .padding(24)
         .background(Color.sectionBlue.cornerRadius(8))

--- a/DragonShield/database/schema.sql
+++ b/DragonShield/database/schema.sql
@@ -1,10 +1,11 @@
 -- DragonShield/docs/schema.sql
 -- Dragon Shield Database Creation Script
--- Version 4.24 - Add ValidationFindings table for allocation validation reasons
+-- Version 4.25 - Apply zero-target skip rule for allocation validation
 -- Created: 2025-05-24
 -- Updated: 2025-08-08
 --
 -- RECENT HISTORY:
+-- - v4.24 -> v4.25: Apply zero-target skip rule for classes with no allocation.
 -- - v4.23 -> v4.24: Add ValidationFindings table for storing validation reasons.
 -- - v4.22 -> v4.23: Replace faulty allocation validation triggers with non-blocking versions and update validation_status.
 -- - v4.21 -> v4.22: Add validation status columns to ClassTargets and SubClassTargets.

--- a/DragonShield/database/schema.txt
+++ b/DragonShield/database/schema.txt
@@ -4,6 +4,7 @@
 -- Updated: 2025-07-13
 --
 -- RECENT HISTORY:
+-- - v4.24 -> v4.25: Apply zero-target skip rule for classes with no allocation
 -- - v4.20 -> v4.21: Add validation triggers for ClassTargets and SubClassTargets
 -- - v4.19 -> v4.20: Replace TargetAllocation with ClassTargets/SubClassTargets and add TargetChangeLog
 -- - v4.7 -> v4.8: Added Institutions table and updated Accounts seed data.
@@ -31,7 +32,7 @@ INSERT INTO Configuration VALUES ('9', 'table_row_padding', '12.0', 'number', 'V
 INSERT INTO Configuration VALUES ('10', 'table_font_size', '14.0', 'number', 'Font size for text in data table rows (in points)', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('11', 'include_direct_re', 'true', 'boolean', 'Include direct real estate in allocation views', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('12', 'direct_re_target_chf', '0', 'number', 'Target CHF amount for direct real estate', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
-INSERT INTO Configuration VALUES ('13', 'db_version', '4.24', 'string', 'Database schema version', '2025-08-08 09:04:29', '2025-08-08 09:04:29');
+INSERT INTO Configuration VALUES ('13', 'db_version', '4.25', 'string', 'Database schema version', '2025-08-08 09:04:29', '2025-08-08 09:04:29');
 INSERT INTO Currencies VALUES ('CHF', 'Swiss Franc', 'CHF', '1', '0', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('EUR', 'Euro', '€', '1', '1', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('USD', 'US Dollar', '$', '1', '1', '2025-07-13 09:04:29', '2025-07-13 09:04:29');

--- a/DragonShield/database/schema_neu.sql
+++ b/DragonShield/database/schema_neu.sql
@@ -1,10 +1,11 @@
 -- DragonShield/docs/schema.sql
 -- Dragon Shield Database Creation Script
--- Version 4.24 - Add ValidationFindings table for allocation validation reasons
+-- Version 4.25 - Apply zero-target skip rule for allocation validation
 -- Created: 2025-05-24
 -- Updated: 2025-08-08
 --
 -- RECENT HISTORY:
+-- - v4.24 -> v4.25: Apply zero-target skip rule for classes with no allocation.
 -- - v4.23 -> v4.24: Add ValidationFindings table for storing validation reasons.
 -- - v4.22 -> v4.23: Replace faulty allocation validation triggers with non-blocking versions and update validation_status.
 -- - v4.21 -> v4.22: Add validation status columns to ClassTargets and SubClassTargets.

--- a/DragonShield/migrations/005_apply_zero_target_skip_rule.sql
+++ b/DragonShield/migrations/005_apply_zero_target_skip_rule.sql
@@ -1,0 +1,28 @@
+-- Apply zero-target skip rule: purge findings for classes without allocation and ensure compliant status
+DELETE FROM ValidationFindings
+WHERE entity_type IN ('class','subclass')
+  AND (
+    (entity_type='class' AND entity_id IN (
+        SELECT id FROM ClassTargets WHERE target_percent = 0 AND COALESCE(target_amount_chf,0) = 0
+    ))
+    OR
+    (entity_type='subclass' AND entity_id IN (
+        SELECT sct.id FROM SubClassTargets sct
+        JOIN ClassTargets ct ON ct.id = sct.class_target_id
+        WHERE ct.target_percent = 0 AND COALESCE(ct.target_amount_chf,0) = 0
+    ))
+  );
+
+UPDATE ClassTargets
+SET validation_status = 'compliant'
+WHERE target_percent = 0 AND COALESCE(target_amount_chf,0) = 0;
+
+UPDATE SubClassTargets
+SET validation_status = 'compliant'
+WHERE class_target_id IN (
+    SELECT id FROM ClassTargets
+    WHERE target_percent = 0 AND COALESCE(target_amount_chf,0) = 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_subclass_targets_class_id ON SubClassTargets(class_target_id);
+CREATE INDEX IF NOT EXISTS idx_class_targets_status ON ClassTargets(validation_status);

--- a/DragonShield/migrations/005_apply_zero_target_skip_rule.sql
+++ b/DragonShield/migrations/005_apply_zero_target_skip_rule.sql
@@ -1,28 +1,40 @@
--- Apply zero-target skip rule: purge findings for classes without allocation and ensure compliant status
+-- migrate:up
+-- Apply zero-target skip rule:
+--  • Purge findings for classes/subclasses whose parent class has zero target
+--  • Force their validation_status to 'compliant'
+--  • Add helpful indexes
+
 DELETE FROM ValidationFindings
 WHERE entity_type IN ('class','subclass')
   AND (
     (entity_type='class' AND entity_id IN (
-        SELECT id FROM ClassTargets WHERE target_percent = 0 AND COALESCE(target_amount_chf,0) = 0
+        SELECT id
+        FROM ClassTargets
+        WHERE target_percent = 0 AND COALESCE(target_amount_chf, 0) = 0
     ))
     OR
     (entity_type='subclass' AND entity_id IN (
-        SELECT sct.id FROM SubClassTargets sct
+        SELECT sct.id
+        FROM SubClassTargets sct
         JOIN ClassTargets ct ON ct.id = sct.class_target_id
-        WHERE ct.target_percent = 0 AND COALESCE(ct.target_amount_chf,0) = 0
+        WHERE ct.target_percent = 0 AND COALESCE(ct.target_amount_chf, 0) = 0
     ))
   );
 
 UPDATE ClassTargets
 SET validation_status = 'compliant'
-WHERE target_percent = 0 AND COALESCE(target_amount_chf,0) = 0;
+WHERE target_percent = 0 AND COALESCE(target_amount_chf, 0) = 0;
 
 UPDATE SubClassTargets
 SET validation_status = 'compliant'
 WHERE class_target_id IN (
-    SELECT id FROM ClassTargets
-    WHERE target_percent = 0 AND COALESCE(target_amount_chf,0) = 0
+  SELECT id
+  FROM ClassTargets
+  WHERE target_percent = 0 AND COALESCE(target_amount_chf, 0) = 0
 );
 
 CREATE INDEX IF NOT EXISTS idx_subclass_targets_class_id ON SubClassTargets(class_target_id);
-CREATE INDEX IF NOT EXISTS idx_class_targets_status ON ClassTargets(validation_status);
+CREATE INDEX IF NOT EXISTS idx_class_targets_status     ON ClassTargets(validation_status);
+
+-- migrate:down
+-- No-op (data-pruning migration). If you need to restore, use your DB backup.


### PR DESCRIPTION
## Summary
- Skip validation and clear findings when asset class has zero target allocation
- Hide remaining allocation warnings in target edit panel for zero-target classes
- Add migration to purge zero-target findings and bump schema to v4.25

## Testing
- `pytest` (fails: ModuleNotFoundError: No module named 'DragonShield')

------
https://chatgpt.com/codex/tasks/task_e_68985f6c89308323af7d72fd14829ea9