### PR TITLE
feat(ui): enlarge validation details popup with close button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Skip validation for asset classes without target allocation and clear related findings
+- Enlarge validation details modal and add close button
 - Add totals row and validation details modal to Asset Allocation view
 - Move portfolio total validation from class editor to main dashboard and show validation badges for asset classes
 - Persist class-level validation findings and show them via "Why?" in target edit panel

--- a/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
+++ b/DragonShield/Views/AllocationDashboard/AllocationDashboardView.swift
@@ -824,6 +824,7 @@ struct ValidationDetailsSheet: View {
     let classNames: [Int: String]
     let subClassNames: [Int: String]
     @State private var filter: SeverityFilter = .all
+    @Environment(\.dismiss) private var dismiss
 
     enum SeverityFilter: String, CaseIterable { case all = "All", errors = "Errors", warnings = "Warnings" }
 
@@ -837,6 +838,24 @@ struct ValidationDetailsSheet: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Validation Details")
+                    .font(.headline)
+                Spacer()
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundColor(.gray)
+                        .frame(width: 32, height: 32)
+                        .background(Color.gray.opacity(0.1))
+                        .clipShape(Circle())
+                        .overlay(Circle().stroke(Color.gray.opacity(0.2), lineWidth: 1))
+                }
+                .buttonStyle(ScaleButtonStyle())
+            }
+
             Picker("", selection: $filter) {
                 ForEach(SeverityFilter.allCases, id: \.rawValue) { f in
                     Text(f.rawValue).tag(f)
@@ -870,7 +889,7 @@ struct ValidationDetailsSheet: View {
             }
         }
         .padding()
-        .frame(minWidth: 400, minHeight: 300)
+        .frame(minWidth: 640, minHeight: 500)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- enlarge validation details modal for clearer viewing
- add dedicated close button to validation modal

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6898677596908323a4e6e3b57c6cf6cd