### PR TITLE
Sync ClassTargets.validation_status with ValidationFindings

### DIFF
--- a/Archive/tests/test_schema_version.py
+++ b/Archive/tests/test_schema_version.py
@@ -8,4 +8,4 @@ from deploy_db import parse_version
 
 def test_schema_version_updated():
     schema_path = Path(__file__).resolve().parents[1] / 'DragonShield' / 'database' / 'schema.sql'
-    assert parse_version(str(schema_path)) == '4.24'
+    assert parse_version(str(schema_path)) == '4.26'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Sync validation status with ValidationFindings via database triggers
 - Skip validation for asset classes without target allocation and clear related findings
 - Enlarge validation details modal and add close button
 - Add totals row and validation details modal to Asset Allocation view

--- a/DragonShield/database/schema.sql
+++ b/DragonShield/database/schema.sql
@@ -1,10 +1,11 @@
 -- DragonShield/docs/schema.sql
 -- Dragon Shield Database Creation Script
--- Version 4.25 - Apply zero-target skip rule for allocation validation
+-- Version 4.26 - Sync validation_status with ValidationFindings
 -- Created: 2025-05-24
 -- Updated: 2025-08-08
 --
 -- RECENT HISTORY:
+-- - v4.25 -> v4.26: Sync validation_status with ValidationFindings and purge zero-target findings.
 -- - v4.24 -> v4.25: Apply zero-target skip rule for classes with no allocation.
 -- - v4.23 -> v4.24: Add ValidationFindings table for storing validation reasons.
 -- - v4.22 -> v4.23: Replace faulty allocation validation triggers with non-blocking versions and update validation_status.
@@ -723,6 +724,185 @@ HAVING SUM(CASE
            ELSE 0
        END) < 0;
 
+
+CREATE TRIGGER trg_validation_findings_ai_class
+AFTER INSERT ON ValidationFindings
+WHEN NEW.entity_type='class'
+BEGIN
+  UPDATE ClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=NEW.entity_id AND severity='error')
+        OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=NEW.entity_id AND vf.severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=NEW.entity_id AND severity='warning')
+        OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=NEW.entity_id AND vf.severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE id=NEW.entity_id;
+END;
+
+CREATE TRIGGER trg_validation_findings_ai_subclass
+AFTER INSERT ON ValidationFindings
+WHEN NEW.entity_type='subclass'
+BEGIN
+  UPDATE SubClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='subclass' AND entity_id=NEW.entity_id AND severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='subclass' AND entity_id=NEW.entity_id AND severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE id=NEW.entity_id;
+
+  UPDATE ClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=ct.id AND severity='error')
+         OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=ct.id AND vf.severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=ct.id AND severity='warning')
+         OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=ct.id AND vf.severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE ct.id = (SELECT class_target_id FROM SubClassTargets WHERE id = NEW.entity_id);
+END;
+
+CREATE TRIGGER trg_validation_findings_ad_class
+AFTER DELETE ON ValidationFindings
+WHEN OLD.entity_type='class'
+BEGIN
+  UPDATE ClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=OLD.entity_id AND severity='error')
+        OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=OLD.entity_id AND vf.severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=OLD.entity_id AND severity='warning')
+        OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=OLD.entity_id AND vf.severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE id=OLD.entity_id;
+END;
+
+CREATE TRIGGER trg_validation_findings_ad_subclass
+AFTER DELETE ON ValidationFindings
+WHEN OLD.entity_type='subclass'
+BEGIN
+  UPDATE SubClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='subclass' AND entity_id=OLD.entity_id AND severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='subclass' AND entity_id=OLD.entity_id AND severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE id=OLD.entity_id;
+
+  UPDATE ClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=ct.id AND severity='error')
+         OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=ct.id AND vf.severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=ct.id AND severity='warning')
+         OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=ct.id AND vf.severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE ct.id = (SELECT class_target_id FROM SubClassTargets WHERE id = OLD.entity_id);
+END;
+
+CREATE TRIGGER trg_validation_findings_au_class
+AFTER UPDATE ON ValidationFindings
+WHEN OLD.entity_type='class' OR NEW.entity_type='class'
+BEGIN
+  UPDATE ClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=OLD.entity_id AND severity='error')
+        OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=OLD.entity_id AND vf.severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=OLD.entity_id AND severity='warning')
+        OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=OLD.entity_id AND vf.severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE id=OLD.entity_id;
+
+  UPDATE ClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=NEW.entity_id AND severity='error')
+        OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=NEW.entity_id AND vf.severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=NEW.entity_id AND severity='warning')
+        OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=NEW.entity_id AND vf.severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE id=NEW.entity_id;
+END;
+
+CREATE TRIGGER trg_validation_findings_au_subclass
+AFTER UPDATE ON ValidationFindings
+WHEN OLD.entity_type='subclass' OR NEW.entity_type='subclass'
+BEGIN
+  UPDATE SubClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='subclass' AND entity_id=OLD.entity_id AND severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='subclass' AND entity_id=OLD.entity_id AND severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE id=OLD.entity_id;
+
+  UPDATE SubClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='subclass' AND entity_id=NEW.entity_id AND severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='subclass' AND entity_id=NEW.entity_id AND severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE id=NEW.entity_id;
+
+  UPDATE ClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=ct.id AND severity='error')
+         OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=ct.id AND vf.severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=ct.id AND severity='warning')
+         OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=ct.id AND vf.severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE ct.id = (SELECT class_target_id FROM SubClassTargets WHERE id = NEW.entity_id)
+     OR ct.id = (SELECT class_target_id FROM SubClassTargets WHERE id = OLD.entity_id);
+END;
+
+CREATE TRIGGER trg_ct_zero_target_cleanup_insert
+AFTER INSERT ON ClassTargets
+WHEN NEW.target_percent = 0 AND COALESCE(NEW.target_amount_chf,0) = 0
+BEGIN
+  DELETE FROM ValidationFindings WHERE entity_type='class' AND entity_id=NEW.id;
+  DELETE FROM ValidationFindings WHERE entity_type='subclass' AND entity_id IN (
+    SELECT id FROM SubClassTargets WHERE class_target_id = NEW.id
+  );
+  UPDATE SubClassTargets SET validation_status='compliant' WHERE class_target_id = NEW.id;
+  UPDATE ClassTargets SET validation_status='compliant' WHERE id = NEW.id;
+END;
+
+CREATE TRIGGER trg_ct_zero_target_cleanup_update
+AFTER UPDATE ON ClassTargets
+WHEN NEW.target_percent = 0 AND COALESCE(NEW.target_amount_chf,0) = 0
+BEGIN
+  DELETE FROM ValidationFindings WHERE entity_type='class' AND entity_id=NEW.id;
+  DELETE FROM ValidationFindings WHERE entity_type='subclass' AND entity_id IN (
+    SELECT id FROM SubClassTargets WHERE class_target_id = NEW.id
+  );
+  UPDATE SubClassTargets SET validation_status='compliant' WHERE class_target_id = NEW.id;
+  UPDATE ClassTargets SET validation_status='compliant' WHERE id = NEW.id;
+END;
 --=============================================================================
 -- FINAL DATABASE SETUP AND OPTIMIZATION
 --=============================================================================

--- a/DragonShield/database/schema.txt
+++ b/DragonShield/database/schema.txt
@@ -4,6 +4,7 @@
 -- Updated: 2025-07-13
 --
 -- RECENT HISTORY:
+-- - v4.25 -> v4.26: Sync validation_status with ValidationFindings and purge zero-target findings
 -- - v4.24 -> v4.25: Apply zero-target skip rule for classes with no allocation
 -- - v4.20 -> v4.21: Add validation triggers for ClassTargets and SubClassTargets
 -- - v4.19 -> v4.20: Replace TargetAllocation with ClassTargets/SubClassTargets and add TargetChangeLog
@@ -32,7 +33,7 @@ INSERT INTO Configuration VALUES ('9', 'table_row_padding', '12.0', 'number', 'V
 INSERT INTO Configuration VALUES ('10', 'table_font_size', '14.0', 'number', 'Font size for text in data table rows (in points)', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('11', 'include_direct_re', 'true', 'boolean', 'Include direct real estate in allocation views', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('12', 'direct_re_target_chf', '0', 'number', 'Target CHF amount for direct real estate', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
-INSERT INTO Configuration VALUES ('13', 'db_version', '4.25', 'string', 'Database schema version', '2025-08-08 09:04:29', '2025-08-08 09:04:29');
+INSERT INTO Configuration VALUES ('13', .26', 'string', 'Database schema version', '2025-08-08 09:04:29', '2025-08-08 09:04:29');
 INSERT INTO Currencies VALUES ('CHF', 'Swiss Franc', 'CHF', '1', '0', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('EUR', 'Euro', '€', '1', '1', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Currencies VALUES ('USD', 'US Dollar', '$', '1', '1', '2025-07-13 09:04:29', '2025-07-13 09:04:29');

--- a/DragonShield/database/schema_neu.sql
+++ b/DragonShield/database/schema_neu.sql
@@ -1,10 +1,11 @@
 -- DragonShield/docs/schema.sql
 -- Dragon Shield Database Creation Script
--- Version 4.25 - Apply zero-target skip rule for allocation validation
+-- Version 4.26 - Sync validation_status with ValidationFindings
 -- Created: 2025-05-24
 -- Updated: 2025-08-08
 --
 -- RECENT HISTORY:
+-- - v4.25 -> v4.26: Sync validation_status with ValidationFindings and purge zero-target findings.
 -- - v4.24 -> v4.25: Apply zero-target skip rule for classes with no allocation.
 -- - v4.23 -> v4.24: Add ValidationFindings table for storing validation reasons.
 -- - v4.22 -> v4.23: Replace faulty allocation validation triggers with non-blocking versions and update validation_status.
@@ -725,6 +726,185 @@ HAVING SUM(CASE
            ELSE 0
        END) < 0;
 
+
+CREATE TRIGGER trg_validation_findings_ai_class
+AFTER INSERT ON ValidationFindings
+WHEN NEW.entity_type='class'
+BEGIN
+  UPDATE ClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=NEW.entity_id AND severity='error')
+        OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=NEW.entity_id AND vf.severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=NEW.entity_id AND severity='warning')
+        OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=NEW.entity_id AND vf.severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE id=NEW.entity_id;
+END;
+
+CREATE TRIGGER trg_validation_findings_ai_subclass
+AFTER INSERT ON ValidationFindings
+WHEN NEW.entity_type='subclass'
+BEGIN
+  UPDATE SubClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='subclass' AND entity_id=NEW.entity_id AND severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='subclass' AND entity_id=NEW.entity_id AND severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE id=NEW.entity_id;
+
+  UPDATE ClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=ct.id AND severity='error')
+         OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=ct.id AND vf.severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=ct.id AND severity='warning')
+         OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=ct.id AND vf.severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE ct.id = (SELECT class_target_id FROM SubClassTargets WHERE id = NEW.entity_id);
+END;
+
+CREATE TRIGGER trg_validation_findings_ad_class
+AFTER DELETE ON ValidationFindings
+WHEN OLD.entity_type='class'
+BEGIN
+  UPDATE ClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=OLD.entity_id AND severity='error')
+        OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=OLD.entity_id AND vf.severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=OLD.entity_id AND severity='warning')
+        OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=OLD.entity_id AND vf.severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE id=OLD.entity_id;
+END;
+
+CREATE TRIGGER trg_validation_findings_ad_subclass
+AFTER DELETE ON ValidationFindings
+WHEN OLD.entity_type='subclass'
+BEGIN
+  UPDATE SubClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='subclass' AND entity_id=OLD.entity_id AND severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='subclass' AND entity_id=OLD.entity_id AND severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE id=OLD.entity_id;
+
+  UPDATE ClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=ct.id AND severity='error')
+         OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=ct.id AND vf.severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=ct.id AND severity='warning')
+         OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=ct.id AND vf.severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE ct.id = (SELECT class_target_id FROM SubClassTargets WHERE id = OLD.entity_id);
+END;
+
+CREATE TRIGGER trg_validation_findings_au_class
+AFTER UPDATE ON ValidationFindings
+WHEN OLD.entity_type='class' OR NEW.entity_type='class'
+BEGIN
+  UPDATE ClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=OLD.entity_id AND severity='error')
+        OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=OLD.entity_id AND vf.severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=OLD.entity_id AND severity='warning')
+        OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=OLD.entity_id AND vf.severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE id=OLD.entity_id;
+
+  UPDATE ClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=NEW.entity_id AND severity='error')
+        OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=NEW.entity_id AND vf.severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=NEW.entity_id AND severity='warning')
+        OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=NEW.entity_id AND vf.severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE id=NEW.entity_id;
+END;
+
+CREATE TRIGGER trg_validation_findings_au_subclass
+AFTER UPDATE ON ValidationFindings
+WHEN OLD.entity_type='subclass' OR NEW.entity_type='subclass'
+BEGIN
+  UPDATE SubClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='subclass' AND entity_id=OLD.entity_id AND severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='subclass' AND entity_id=OLD.entity_id AND severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE id=OLD.entity_id;
+
+  UPDATE SubClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='subclass' AND entity_id=NEW.entity_id AND severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='subclass' AND entity_id=NEW.entity_id AND severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE id=NEW.entity_id;
+
+  UPDATE ClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=ct.id AND severity='error')
+         OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=ct.id AND vf.severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=ct.id AND severity='warning')
+         OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=ct.id AND vf.severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE ct.id = (SELECT class_target_id FROM SubClassTargets WHERE id = NEW.entity_id)
+     OR ct.id = (SELECT class_target_id FROM SubClassTargets WHERE id = OLD.entity_id);
+END;
+
+CREATE TRIGGER trg_ct_zero_target_cleanup_insert
+AFTER INSERT ON ClassTargets
+WHEN NEW.target_percent = 0 AND COALESCE(NEW.target_amount_chf,0) = 0
+BEGIN
+  DELETE FROM ValidationFindings WHERE entity_type='class' AND entity_id=NEW.id;
+  DELETE FROM ValidationFindings WHERE entity_type='subclass' AND entity_id IN (
+    SELECT id FROM SubClassTargets WHERE class_target_id = NEW.id
+  );
+  UPDATE SubClassTargets SET validation_status='compliant' WHERE class_target_id = NEW.id;
+  UPDATE ClassTargets SET validation_status='compliant' WHERE id = NEW.id;
+END;
+
+CREATE TRIGGER trg_ct_zero_target_cleanup_update
+AFTER UPDATE ON ClassTargets
+WHEN NEW.target_percent = 0 AND COALESCE(NEW.target_amount_chf,0) = 0
+BEGIN
+  DELETE FROM ValidationFindings WHERE entity_type='class' AND entity_id=NEW.id;
+  DELETE FROM ValidationFindings WHERE entity_type='subclass' AND entity_id IN (
+    SELECT id FROM SubClassTargets WHERE class_target_id = NEW.id
+  );
+  UPDATE SubClassTargets SET validation_status='compliant' WHERE class_target_id = NEW.id;
+  UPDATE ClassTargets SET validation_status='compliant' WHERE id = NEW.id;
+END;
 --=============================================================================
 -- FINAL DATABASE SETUP AND OPTIMIZATION
 --=============================================================================

--- a/DragonShield/migrations/006_sync_validation_status.sql
+++ b/DragonShield/migrations/006_sync_validation_status.sql
@@ -1,0 +1,262 @@
+-- migrate:up
+-- Sync validation_status with ValidationFindings and purge zero-target findings
+BEGIN;
+
+-- 1) Purge stale findings for zero-target classes
+DELETE FROM ValidationFindings
+WHERE entity_type IN ('class','subclass')
+  AND (
+    (entity_type='class' AND entity_id IN (
+        SELECT id FROM ClassTargets
+        WHERE target_percent = 0 AND COALESCE(target_amount_chf,0) = 0
+    ))
+    OR
+    (entity_type='subclass' AND entity_id IN (
+        SELECT sct.id
+        FROM SubClassTargets sct
+        JOIN ClassTargets ct ON ct.id = sct.class_target_id
+        WHERE ct.target_percent = 0 AND COALESCE(ct.target_amount_chf,0) = 0
+    ))
+  );
+
+-- 2) Recompute SubClassTargets statuses
+UPDATE SubClassTargets AS sct
+SET validation_status = (
+  CASE
+    WHEN EXISTS (
+      SELECT 1 FROM ValidationFindings vf
+      WHERE vf.entity_type='subclass' AND vf.entity_id=sct.id AND vf.severity='error'
+    ) THEN 'error'
+    WHEN EXISTS (
+      SELECT 1 FROM ValidationFindings vf
+      WHERE vf.entity_type='subclass' AND vf.entity_id=sct.id AND vf.severity='warning'
+    ) THEN 'warning'
+    ELSE 'compliant'
+  END
+);
+
+-- 3) Recompute ClassTargets statuses considering subclasses
+UPDATE ClassTargets AS ct
+SET validation_status = (
+  CASE
+    WHEN EXISTS (
+      SELECT 1 FROM ValidationFindings vf
+      WHERE vf.entity_type='class' AND vf.entity_id=ct.id AND vf.severity='error'
+    ) OR EXISTS (
+      SELECT 1 FROM ValidationFindings vf
+      JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id
+      WHERE s.class_target_id=ct.id AND vf.severity='error'
+    ) THEN 'error'
+    WHEN EXISTS (
+      SELECT 1 FROM ValidationFindings vf
+      WHERE vf.entity_type='class' AND vf.entity_id=ct.id AND vf.severity='warning'
+    ) OR EXISTS (
+      SELECT 1 FROM ValidationFindings vf
+      JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id
+      WHERE s.class_target_id=ct.id AND vf.severity='warning'
+    ) THEN 'warning'
+    ELSE 'compliant'
+  END
+);
+
+-- 4) Trigger: after INSERT on ValidationFindings
+CREATE TRIGGER trg_validation_findings_ai_class
+AFTER INSERT ON ValidationFindings
+WHEN NEW.entity_type='class'
+BEGIN
+  UPDATE ClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=NEW.entity_id AND severity='error')
+        OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=NEW.entity_id AND vf.severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=NEW.entity_id AND severity='warning')
+        OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=NEW.entity_id AND vf.severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE id=NEW.entity_id;
+END;
+
+CREATE TRIGGER trg_validation_findings_ai_subclass
+AFTER INSERT ON ValidationFindings
+WHEN NEW.entity_type='subclass'
+BEGIN
+  UPDATE SubClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='subclass' AND entity_id=NEW.entity_id AND severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='subclass' AND entity_id=NEW.entity_id AND severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE id=NEW.entity_id;
+
+  UPDATE ClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=ct.id AND severity='error')
+         OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=ct.id AND vf.severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=ct.id AND severity='warning')
+         OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=ct.id AND vf.severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE ct.id = (SELECT class_target_id FROM SubClassTargets WHERE id = NEW.entity_id);
+END;
+
+-- 5) Trigger: after DELETE on ValidationFindings
+CREATE TRIGGER trg_validation_findings_ad_class
+AFTER DELETE ON ValidationFindings
+WHEN OLD.entity_type='class'
+BEGIN
+  UPDATE ClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=OLD.entity_id AND severity='error')
+        OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=OLD.entity_id AND vf.severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=OLD.entity_id AND severity='warning')
+        OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=OLD.entity_id AND vf.severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE id=OLD.entity_id;
+END;
+
+CREATE TRIGGER trg_validation_findings_ad_subclass
+AFTER DELETE ON ValidationFindings
+WHEN OLD.entity_type='subclass'
+BEGIN
+  UPDATE SubClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='subclass' AND entity_id=OLD.entity_id AND severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='subclass' AND entity_id=OLD.entity_id AND severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE id=OLD.entity_id;
+
+  UPDATE ClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=ct.id AND severity='error')
+         OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=ct.id AND vf.severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=ct.id AND severity='warning')
+         OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=ct.id AND vf.severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE ct.id = (SELECT class_target_id FROM SubClassTargets WHERE id = OLD.entity_id);
+END;
+
+-- 6) Trigger: after UPDATE on ValidationFindings (recompute for old and new)
+CREATE TRIGGER trg_validation_findings_au_class
+AFTER UPDATE ON ValidationFindings
+WHEN OLD.entity_type='class' OR NEW.entity_type='class'
+BEGIN
+  UPDATE ClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=OLD.entity_id AND severity='error')
+        OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=OLD.entity_id AND vf.severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=OLD.entity_id AND severity='warning')
+        OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=OLD.entity_id AND vf.severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE id=OLD.entity_id;
+
+  UPDATE ClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=NEW.entity_id AND severity='error')
+        OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=NEW.entity_id AND vf.severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=NEW.entity_id AND severity='warning')
+        OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=NEW.entity_id AND vf.severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE id=NEW.entity_id;
+END;
+
+CREATE TRIGGER trg_validation_findings_au_subclass
+AFTER UPDATE ON ValidationFindings
+WHEN OLD.entity_type='subclass' OR NEW.entity_type='subclass'
+BEGIN
+  UPDATE SubClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='subclass' AND entity_id=OLD.entity_id AND severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='subclass' AND entity_id=OLD.entity_id AND severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE id=OLD.entity_id;
+
+  UPDATE SubClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='subclass' AND entity_id=NEW.entity_id AND severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='subclass' AND entity_id=NEW.entity_id AND severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE id=NEW.entity_id;
+
+  UPDATE ClassTargets
+  SET validation_status = (
+    CASE
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=ct.id AND severity='error')
+         OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=ct.id AND vf.severity='error') THEN 'error'
+      WHEN EXISTS (SELECT 1 FROM ValidationFindings WHERE entity_type='class' AND entity_id=ct.id AND severity='warning')
+         OR EXISTS (SELECT 1 FROM ValidationFindings vf JOIN SubClassTargets s ON vf.entity_type='subclass' AND vf.entity_id=s.id WHERE s.class_target_id=ct.id AND vf.severity='warning') THEN 'warning'
+      ELSE 'compliant'
+    END
+  )
+  WHERE ct.id = (SELECT class_target_id FROM SubClassTargets WHERE id = NEW.entity_id)
+     OR ct.id = (SELECT class_target_id FROM SubClassTargets WHERE id = OLD.entity_id);
+END;
+
+-- 7) Triggers to purge findings when class target becomes zero
+CREATE TRIGGER trg_ct_zero_target_cleanup_insert
+AFTER INSERT ON ClassTargets
+WHEN NEW.target_percent = 0 AND COALESCE(NEW.target_amount_chf,0) = 0
+BEGIN
+  DELETE FROM ValidationFindings WHERE entity_type='class' AND entity_id=NEW.id;
+  DELETE FROM ValidationFindings WHERE entity_type='subclass' AND entity_id IN (
+    SELECT id FROM SubClassTargets WHERE class_target_id = NEW.id
+  );
+  UPDATE SubClassTargets SET validation_status='compliant' WHERE class_target_id = NEW.id;
+  UPDATE ClassTargets SET validation_status='compliant' WHERE id = NEW.id;
+END;
+
+CREATE TRIGGER trg_ct_zero_target_cleanup_update
+AFTER UPDATE ON ClassTargets
+WHEN NEW.target_percent = 0 AND COALESCE(NEW.target_amount_chf,0) = 0
+BEGIN
+  DELETE FROM ValidationFindings WHERE entity_type='class' AND entity_id=NEW.id;
+  DELETE FROM ValidationFindings WHERE entity_type='subclass' AND entity_id IN (
+    SELECT id FROM SubClassTargets WHERE class_target_id = NEW.id
+  );
+  UPDATE SubClassTargets SET validation_status='compliant' WHERE class_target_id = NEW.id;
+  UPDATE ClassTargets SET validation_status='compliant' WHERE id = NEW.id;
+END;
+
+-- 8) Bump db_version
+UPDATE Configuration SET value='4.26' WHERE key='db_version';
+
+COMMIT;
+
+-- migrate:down
+-- Drop validation status sync triggers (data restoration not attempted)
+BEGIN;
+DROP TRIGGER IF EXISTS trg_validation_findings_ai_class;
+DROP TRIGGER IF EXISTS trg_validation_findings_ai_subclass;
+DROP TRIGGER IF EXISTS trg_validation_findings_ad_class;
+DROP TRIGGER IF EXISTS trg_validation_findings_ad_subclass;
+DROP TRIGGER IF EXISTS trg_validation_findings_au_class;
+DROP TRIGGER IF EXISTS trg_validation_findings_au_subclass;
+DROP TRIGGER IF EXISTS trg_ct_zero_target_cleanup_insert;
+DROP TRIGGER IF EXISTS trg_ct_zero_target_cleanup_update;
+UPDATE Configuration SET value='4.24' WHERE key='db_version';
+COMMIT;

--- a/DragonShield/python_scripts/load_legacy_db.py
+++ b/DragonShield/python_scripts/load_legacy_db.py
@@ -105,7 +105,7 @@ def load_legacy_database(target: Path, legacy: Path) -> Dict[str, int]:
             )
 
         # Ensure the database version matches the current schema
-        conn.execute("UPDATE Configuration SET value=? WHERE key='db_version'", ("4.24",))
+        conn.execute("UPDATE Configuration SET value=? WHERE key='db_version'", ("4.26",))
         conn.commit()
         conn.execute("DETACH DATABASE legacy")
         check = conn.execute("PRAGMA integrity_check;").fetchone()[0]

--- a/DragonShield/test_data/reference_data.sql
+++ b/DragonShield/test_data/reference_data.sql
@@ -21,7 +21,7 @@ INSERT INTO Configuration VALUES ('9', 'table_row_padding', '12.0', 'number', 'V
 INSERT INTO Configuration VALUES ('10', 'table_font_size', '14.0', 'number', 'Font size for text in data table rows (in points)', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('11', 'include_direct_re', 'true', 'boolean', 'Include direct real estate in allocation views', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
 INSERT INTO Configuration VALUES ('12', 'direct_re_target_chf', '0', 'number', 'Target CHF amount for direct real estate', '2025-07-13 09:04:29', '2025-07-13 09:04:29');
-INSERT INTO Configuration VALUES ('13', 'db_version', '4.24', 'string', 'Database schema version', '2025-08-08 09:04:29', '2025-08-08 09:04:29');
+INSERT INTO Configuration VALUES ('13', 'db_version', '4.26', 'string', 'Database schema version', '2025-08-08 09:04:29', '2025-08-08 09:04:29');
 CREATE TABLE Currencies (
     currency_code TEXT PRIMARY KEY,
     currency_name TEXT NOT NULL,


### PR DESCRIPTION
## Summary
- backfill and trigger to keep class/subclass validation_status derived from ValidationFindings
- bump schema and seed data to db_version 4.26
- document status sync in changelog

## Testing
- `dbmate --version` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `curl -L https://github.com/amacneil/dbmate/releases/download/v2.9.0/dbmate-linux-amd64` *(fails: CONNECT tunnel 403)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'DragonShield')*

------
https://chatgpt.com/codex/tasks/task_e_6898ee053aac8323b93c9e570a0a8594