### PR TITLE
feat: derive validation status from findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Added
+- Ensure asset class badges reflect ValidationFindings and sync target status columns
 - Sync validation status of class and subclass targets from findings and purge zero-target data
 - Skip validation for asset classes without target allocation and clear related findings
 - Enlarge validation details modal and add close button

--- a/DragonShield/migrations/007_validation_status_views.sql
+++ b/DragonShield/migrations/007_validation_status_views.sql
@@ -1,0 +1,65 @@
+-- 007_validation_status_views.sql
+-- migrate:up
+-- Purpose: Aggregate ValidationFindings into class and subclass validation statuses
+CREATE VIEW IF NOT EXISTS V_SubClassValidationStatus AS
+WITH sub_err AS (
+  SELECT entity_id AS sub_class_id FROM ValidationFindings
+  WHERE entity_type='subclass' AND severity='error'
+),
+sub_warn AS (
+  SELECT entity_id AS sub_class_id FROM ValidationFindings
+  WHERE entity_type='subclass' AND severity='warning'
+)
+SELECT s.sub_class_id,
+       CASE
+         WHEN EXISTS(SELECT 1 FROM sub_err e WHERE e.sub_class_id=s.sub_class_id) THEN 'error'
+         WHEN EXISTS(SELECT 1 FROM sub_warn w WHERE w.sub_class_id=s.sub_class_id) THEN 'warning'
+         ELSE 'compliant'
+       END AS validation_status,
+       (SELECT COUNT(*) FROM ValidationFindings vf
+         WHERE vf.entity_type='subclass' AND vf.entity_id=s.sub_class_id) AS findings_count
+FROM AssetSubClasses s;
+
+CREATE VIEW IF NOT EXISTS V_ClassValidationStatus AS
+WITH class_err AS (
+  SELECT ac.class_id FROM AssetClasses ac
+  WHERE EXISTS (SELECT 1 FROM ValidationFindings vf
+                  WHERE vf.entity_type='class'
+                    AND vf.entity_id=ac.class_id
+                    AND vf.severity='error')
+     OR EXISTS (SELECT 1 FROM ValidationFindings vf
+                  JOIN AssetSubClasses s ON s.sub_class_id=vf.entity_id
+                 WHERE vf.entity_type='subclass'
+                   AND s.class_id=ac.class_id
+                   AND vf.severity='error')
+),
+class_warn AS (
+  SELECT ac.class_id FROM AssetClasses ac
+  WHERE EXISTS (SELECT 1 FROM ValidationFindings vf
+                  WHERE vf.entity_type='class'
+                    AND vf.entity_id=ac.class_id
+                    AND vf.severity='warning')
+     OR EXISTS (SELECT 1 FROM ValidationFindings vf
+                  JOIN AssetSubClasses s ON s.sub_class_id=vf.entity_id
+                 WHERE vf.entity_type='subclass'
+                   AND s.class_id=ac.class_id
+                   AND vf.severity='warning')
+)
+SELECT ac.class_id,
+       CASE
+         WHEN EXISTS (SELECT 1 FROM class_err e WHERE e.class_id=ac.class_id) THEN 'error'
+         WHEN EXISTS (SELECT 1 FROM class_warn w WHERE w.class_id=ac.class_id) THEN 'warning'
+         ELSE 'compliant'
+       END AS validation_status,
+       (
+         SELECT COUNT(*) FROM ValidationFindings vf
+         WHERE (vf.entity_type='class' AND vf.entity_id=ac.class_id)
+            OR (vf.entity_type='subclass' AND vf.entity_id IN (
+                 SELECT sub_class_id FROM AssetSubClasses s WHERE s.class_id=ac.class_id
+               ))
+       ) AS findings_count
+FROM AssetClasses ac;
+
+-- migrate:down
+DROP VIEW IF EXISTS V_ClassValidationStatus;
+DROP VIEW IF EXISTS V_SubClassValidationStatus;

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 5.10
+import PackageDescription
+
+let package = Package(
+    name: "DragonShield",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .library(name: "Database", targets: ["Database"]),
+        .library(name: "Allocation", targets: ["Allocation"])
+    ],
+    targets: [
+        .target(
+            name: "Database",
+            path: "Sources/Database",
+            linkerSettings: [.linkedLibrary("sqlite3")]
+        ),
+        .target(name: "Allocation", dependencies: ["Database"], path: "Sources/Allocation"),
+        .testTarget(name: "Validation", dependencies: ["Database"], path: "Tests/Validation")
+    ]
+)

--- a/Sources/Allocation/AllocationTargetsTableView.swift
+++ b/Sources/Allocation/AllocationTargetsTableView.swift
@@ -1,0 +1,154 @@
+import SwiftUI
+
+@MainActor
+public final class AllocationTargetsTableViewModel: ObservableObject {
+    public struct SubClassItem: Identifiable {
+        public let id: Int
+        public let name: String
+        public var validationStatus: String
+    }
+
+    public struct ClassItem: Identifiable {
+        public let id: Int
+        public let name: String
+        public var validationStatus: String
+        public var subClasses: [SubClassItem]
+    }
+
+    @Published public var classes: [ClassItem]
+
+    public init(classes: [ClassItem]) {
+        self.classes = classes
+    }
+
+    public func load(using db: DBGateway) {
+        let classStatuses = db.fetchClassValidationStatuses()
+        let subStatuses = db.fetchSubClassValidationStatuses()
+        classes = classes.map { cls in
+            var updated = cls
+            updated.validationStatus = classStatuses[cls.id] ?? "compliant"
+            updated.subClasses = cls.subClasses.map { sub in
+                var s = sub
+                s.validationStatus = subStatuses[sub.id] ?? "compliant"
+                return s
+            }
+            return updated
+        }
+        db.syncValidationStatusTables()
+    }
+
+    public func setStatus(_ status: String, for scope: ValidationDetailsView.Scope) {
+        switch scope {
+        case let .class(id, _):
+            if let idx = classes.firstIndex(where: { $0.id == id }) {
+                classes[idx].validationStatus = status
+            }
+        case let .subClass(id, _):
+            for cIdx in classes.indices {
+                if let sIdx = classes[cIdx].subClasses.firstIndex(where: { $0.id == id }) {
+                    classes[cIdx].subClasses[sIdx].validationStatus = status
+                    break
+                }
+            }
+        }
+    }
+
+    public func findings(for scope: ValidationDetailsView.Scope, db: DBGateway) -> [ValidationFinding] {
+        switch scope {
+        case let .class(id, _):
+            return db.fetchValidationFindingsForClass(id)
+        case let .subClass(id, _):
+            return db.fetchValidationFindingsForSubClass(id)
+        }
+    }
+}
+
+public struct AllocationTargetsTableView: View {
+    @ObservedObject private var viewModel: AllocationTargetsTableViewModel
+    private let db: DBGateway
+    @State private var presentedScope: ValidationDetailsView.Scope?
+
+    public init(viewModel: AllocationTargetsTableViewModel, db: DBGateway) {
+        self.viewModel = viewModel
+        self.db = db
+    }
+
+    public var body: some View {
+        List {
+            ForEach(viewModel.classes) { cls in
+                Section(header: headerView(for: cls)) {
+                    ForEach(cls.subClasses) { sub in
+                        HStack {
+                            Text(sub.name)
+                            Spacer()
+                            StatusBadge(status: sub.validationStatus)
+                            if sub.validationStatus != "compliant" {
+                                Button("Why?") {
+                                    let scope: ValidationDetailsView.Scope = .subClass(id: sub.id, name: sub.name)
+                                    let records = viewModel.findings(for: scope, db: db)
+                                    guard !records.isEmpty else {
+                                        viewModel.setStatus("compliant", for: scope)
+                                        db.syncValidationStatusTables()
+                                        return
+                                    }
+                                    presentedScope = scope
+                                }
+                                .accessibilityLabel("Why? button for \(sub.name)")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .onAppear { viewModel.load(using: db) }
+        .sheet(item: $presentedScope) { scope in
+            ValidationDetailsView(scope: scope, findings: viewModel.findings(for: scope, db: db))
+        }
+    }
+
+    private func headerView(for cls: AllocationTargetsTableViewModel.ClassItem) -> some View {
+        HStack {
+            Text(cls.name)
+            Spacer()
+            StatusBadge(status: cls.validationStatus)
+            if cls.validationStatus != "compliant" {
+                Button("Why?") {
+                    let scope: ValidationDetailsView.Scope = .class(id: cls.id, name: cls.name)
+                    let records = viewModel.findings(for: scope, db: db)
+                    guard !records.isEmpty else {
+                        viewModel.setStatus("compliant", for: scope)
+                        db.syncValidationStatusTables()
+                        return
+                    }
+                    presentedScope = scope
+                }
+                .accessibilityLabel("Why? button for \(cls.name)")
+            }
+        }
+    }
+}
+
+struct StatusBadge: View {
+    let status: String
+
+    var body: some View {
+        Text(status.capitalized)
+            .font(.caption)
+            .padding(4)
+            .foregroundColor(.white)
+            .background(color)
+            .cornerRadius(4)
+    }
+
+    private var color: Color {
+        switch status {
+        case "error":
+            return .red
+        case "warning":
+            return .yellow
+        default:
+            return .green
+        }
+    }
+}
+

--- a/Sources/Allocation/ValidationDetailsView.swift
+++ b/Sources/Allocation/ValidationDetailsView.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+public struct ValidationDetailsView: View {
+    public enum Scope: Identifiable {
+        case `class`(id: Int, name: String)
+        case subClass(id: Int, name: String)
+
+        public var id: String {
+            switch self {
+            case let .class(id, _): return "class-\(id)"
+            case let .subClass(id, _): return "subclass-\(id)"
+            }
+        }
+
+        var title: String {
+            switch self {
+            case let .class(_, name): return name
+            case let .subClass(_, name): return name
+            }
+        }
+    }
+
+    private let findings: [ValidationFinding]
+    private let scope: Scope
+
+    public init(scope: Scope, findings: [ValidationFinding]) {
+        self.scope = scope
+        self.findings = findings
+    }
+
+    public var body: some View {
+        NavigationView {
+            List(findings) { finding in
+                HStack(alignment: .top, spacing: 8) {
+                    Text(icon(for: finding.severity))
+                        .bold()
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(finding.code).bold()
+                        Text(finding.message)
+                        Text(scopeName(for: finding))
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    Spacer()
+                    Text(finding.computedAt)
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .navigationTitle(scope.title)
+        }
+    }
+
+    private func icon(for severity: String) -> String {
+        switch severity {
+        case "error": return "E"
+        case "warning": return "W"
+        default: return ""
+        }
+    }
+
+    private func scopeName(for finding: ValidationFinding) -> String {
+        if finding.entityType == "subclass" {
+            return finding.subClassName ?? ""
+        } else {
+            return scope.title
+        }
+    }
+}
+

--- a/Sources/Database/DatabaseManager.swift
+++ b/Sources/Database/DatabaseManager.swift
@@ -1,0 +1,197 @@
+import Foundation
+import SQLite3
+
+public struct ValidationFinding: Identifiable, Equatable {
+    public let id: Int
+    public let entityType: String
+    public let entityId: Int
+    public let severity: String
+    public let code: String
+    public let message: String
+    public let detailsJSON: String?
+    public let computedAt: String
+    public let subClassName: String?
+}
+
+public protocol DBGateway {
+    func fetchClassValidationStatuses() -> [Int: String]
+    func fetchSubClassValidationStatuses() -> [Int: String]
+    func fetchValidationFindingsForClass(_ classId: Int) -> [ValidationFinding]
+    func fetchValidationFindingsForSubClass(_ subId: Int) -> [ValidationFinding]
+    func syncValidationStatusTables()
+}
+
+public final class DatabaseManager: DBGateway {
+    var db: OpaquePointer?
+    private let queue = DispatchQueue(label: "db.serial.queue")
+
+    public init(path: String) throws {
+        let flags = SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX
+        if sqlite3_open_v2(path, &db, flags, nil) != SQLITE_OK {
+            let msg = db.flatMap { String(cString: sqlite3_errmsg($0)) } ?? "Unknown error"
+            throw NSError(domain: "SQLite", code: 1, userInfo: [NSLocalizedDescriptionKey: msg])
+        }
+        sqlite3_exec(db, "PRAGMA foreign_keys=ON;", nil, nil, nil)
+        sqlite3_exec(db, "PRAGMA journal_mode=WAL;", nil, nil, nil)
+        sqlite3_exec(db, "PRAGMA synchronous=NORMAL;", nil, nil, nil)
+        sqlite3_exec(db, "PRAGMA busy_timeout=5000;", nil, nil, nil)
+    }
+
+    deinit {
+        if let pointer = db {
+            sqlite3_close_v2(pointer)
+        }
+    }
+
+    private func string(from statement: OpaquePointer?, index: Int32) -> String {
+        guard let cStr = sqlite3_column_text(statement, index) else { return "" }
+        return String(cString: cStr)
+    }
+
+    public func fetchClassValidationStatuses() -> [Int: String] {
+        queue.sync {
+            var results: [Int: String] = [:]
+            let sql = "SELECT class_id, validation_status FROM V_ClassValidationStatus;"
+            var stmt: OpaquePointer?
+            if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+                defer { sqlite3_finalize(stmt) }
+                while sqlite3_step(stmt) == SQLITE_ROW {
+                    let id = Int(sqlite3_column_int(stmt, 0))
+                    let status = string(from: stmt, index: 1)
+                    results[id] = status
+                }
+            }
+            return results
+        }
+    }
+
+    public func fetchSubClassValidationStatuses() -> [Int: String] {
+        queue.sync {
+            var results: [Int: String] = [:]
+            let sql = "SELECT sub_class_id, validation_status FROM V_SubClassValidationStatus;"
+            var stmt: OpaquePointer?
+            if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+                defer { sqlite3_finalize(stmt) }
+                while sqlite3_step(stmt) == SQLITE_ROW {
+                    let id = Int(sqlite3_column_int(stmt, 0))
+                    let status = string(from: stmt, index: 1)
+                    results[id] = status
+                }
+            }
+            return results
+        }
+    }
+
+    public func fetchValidationFindingsForClass(_ classId: Int) -> [ValidationFinding] {
+        queue.sync {
+            var findings: [ValidationFinding] = []
+            let sql = """
+            SELECT vf.id,
+                   vf.entity_type,
+                   vf.entity_id,
+                   vf.severity,
+                   vf.code,
+                   vf.message,
+                   vf.details_json,
+                   vf.computed_at,
+                   CASE
+                     WHEN vf.entity_type='subclass' THEN (SELECT name FROM AssetSubClasses s WHERE s.sub_class_id=vf.entity_id)
+                     ELSE NULL
+                   END AS sub_class_name
+            FROM ValidationFindings vf
+            WHERE (vf.entity_type='class' AND vf.entity_id=?)
+               OR (vf.entity_type='subclass' AND vf.entity_id IN (
+                    SELECT sub_class_id FROM AssetSubClasses WHERE class_id=?
+               ))
+            ORDER BY CASE vf.severity WHEN 'error' THEN 2 WHEN 'warning' THEN 1 ELSE 0 END DESC,
+                     vf.code ASC,
+                     vf.computed_at DESC;
+            """
+            var stmt: OpaquePointer?
+            if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+                sqlite3_bind_int(stmt, 1, Int32(classId))
+                sqlite3_bind_int(stmt, 2, Int32(classId))
+                defer { sqlite3_finalize(stmt) }
+                while sqlite3_step(stmt) == SQLITE_ROW {
+                    findings.append(parseFinding(stmt))
+                }
+            }
+            return findings
+        }
+    }
+
+    public func fetchValidationFindingsForSubClass(_ subId: Int) -> [ValidationFinding] {
+        queue.sync {
+            var findings: [ValidationFinding] = []
+            let sql = """
+            SELECT vf.id,
+                   vf.entity_type,
+                   vf.entity_id,
+                   vf.severity,
+                   vf.code,
+                   vf.message,
+                   vf.details_json,
+                   vf.computed_at,
+                   (SELECT name FROM AssetSubClasses s WHERE s.sub_class_id=vf.entity_id) AS sub_class_name
+            FROM ValidationFindings vf
+            WHERE vf.entity_type='subclass' AND vf.entity_id=?
+            ORDER BY CASE vf.severity WHEN 'error' THEN 2 WHEN 'warning' THEN 1 ELSE 0 END DESC,
+                     vf.code ASC,
+                     vf.computed_at DESC;
+            """
+            var stmt: OpaquePointer?
+            if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+                sqlite3_bind_int(stmt, 1, Int32(subId))
+                defer { sqlite3_finalize(stmt) }
+                while sqlite3_step(stmt) == SQLITE_ROW {
+                    findings.append(parseFinding(stmt))
+                }
+            }
+            return findings
+        }
+    }
+
+    public func syncValidationStatusTables() {
+        queue.sync {
+            let classUpdate = """
+            UPDATE ClassTargets
+            SET validation_status = (
+              SELECT validation_status FROM V_ClassValidationStatus v
+              WHERE v.class_id = ClassTargets.class_id
+            );
+            """
+            sqlite3_exec(db, classUpdate, nil, nil, nil)
+
+            let subUpdate = """
+            UPDATE SubClassTargets
+            SET validation_status = (
+              SELECT validation_status FROM V_SubClassValidationStatus v
+              WHERE v.sub_class_id = SubClassTargets.sub_class_id
+            );
+            """
+            sqlite3_exec(db, subUpdate, nil, nil, nil)
+        }
+    }
+
+    
+    public func execute(_ sql: String) -> Int32 {
+        queue.sync {
+            sqlite3_exec(db, sql, nil, nil, nil)
+        }
+    }
+
+    private func parseFinding(_ stmt: OpaquePointer?) -> ValidationFinding {
+        ValidationFinding(
+            id: Int(sqlite3_column_int(stmt, 0)),
+            entityType: string(from: stmt, index: 1),
+            entityId: Int(sqlite3_column_int(stmt, 2)),
+            severity: string(from: stmt, index: 3),
+            code: string(from: stmt, index: 4),
+            message: string(from: stmt, index: 5),
+            detailsJSON: sqlite3_column_text(stmt, 6).map { String(cString: $0) },
+            computedAt: string(from: stmt, index: 7),
+            subClassName: sqlite3_column_text(stmt, 8).map { String(cString: $0) }
+        )
+    }
+}
+

--- a/Tests/Validation/ValidationStatusTests.swift
+++ b/Tests/Validation/ValidationStatusTests.swift
@@ -1,0 +1,154 @@
+import XCTest
+import SQLite3
+@testable import Database
+
+final class ValidationStatusTests: XCTestCase {
+    private func makeDB() throws -> DatabaseManager {
+        let path = NSTemporaryDirectory().appending("test-\(UUID().uuidString).sqlite")
+        var rawDB: OpaquePointer?
+        guard sqlite3_open(path, &rawDB) == SQLITE_OK else {
+            throw XCTSkip("Unable to open sqlite3 database")
+        }
+        defer { sqlite3_close(rawDB) }
+        let schema = """
+        CREATE TABLE AssetClasses(class_id INTEGER PRIMARY KEY, name TEXT);
+        CREATE TABLE AssetSubClasses(sub_class_id INTEGER PRIMARY KEY, class_id INTEGER, name TEXT);
+        CREATE TABLE ValidationFindings(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            entity_type TEXT NOT NULL,
+            entity_id INTEGER NOT NULL,
+            severity TEXT NOT NULL,
+            code TEXT NOT NULL,
+            message TEXT NOT NULL,
+            details_json TEXT,
+            computed_at TEXT DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE ClassTargets(class_id INTEGER PRIMARY KEY, validation_status TEXT);
+        CREATE TABLE SubClassTargets(sub_class_id INTEGER PRIMARY KEY, class_id INTEGER, validation_status TEXT);
+        """
+        guard sqlite3_exec(rawDB, schema, nil, nil, nil) == SQLITE_OK else {
+            throw XCTSkip("Failed to create schema")
+        }
+        let views = """
+        CREATE VIEW IF NOT EXISTS V_SubClassValidationStatus AS
+        WITH sub_err AS (
+          SELECT entity_id AS sub_class_id FROM ValidationFindings
+          WHERE entity_type='subclass' AND severity='error'
+        ),
+        sub_warn AS (
+          SELECT entity_id AS sub_class_id FROM ValidationFindings
+          WHERE entity_type='subclass' AND severity='warning'
+        )
+        SELECT s.sub_class_id,
+               CASE
+                 WHEN EXISTS(SELECT 1 FROM sub_err e WHERE e.sub_class_id=s.sub_class_id) THEN 'error'
+                 WHEN EXISTS(SELECT 1 FROM sub_warn w WHERE w.sub_class_id=s.sub_class_id) THEN 'warning'
+                 ELSE 'compliant'
+               END AS validation_status,
+               (SELECT COUNT(*) FROM ValidationFindings vf
+                 WHERE vf.entity_type='subclass' AND vf.entity_id=s.sub_class_id) AS findings_count
+        FROM AssetSubClasses s;
+
+        CREATE VIEW IF NOT EXISTS V_ClassValidationStatus AS
+        WITH class_err AS (
+          SELECT ac.class_id FROM AssetClasses ac
+          WHERE EXISTS (SELECT 1 FROM ValidationFindings vf
+                          WHERE vf.entity_type='class'
+                            AND vf.entity_id=ac.class_id
+                            AND vf.severity='error')
+             OR EXISTS (SELECT 1 FROM ValidationFindings vf
+                          JOIN AssetSubClasses s ON s.sub_class_id=vf.entity_id
+                         WHERE vf.entity_type='subclass'
+                           AND s.class_id=ac.class_id
+                           AND vf.severity='error')
+        ),
+        class_warn AS (
+          SELECT ac.class_id FROM AssetClasses ac
+          WHERE EXISTS (SELECT 1 FROM ValidationFindings vf
+                          WHERE vf.entity_type='class'
+                            AND vf.entity_id=ac.class_id
+                            AND vf.severity='warning')
+             OR EXISTS (SELECT 1 FROM ValidationFindings vf
+                          JOIN AssetSubClasses s ON s.sub_class_id=vf.entity_id
+                         WHERE vf.entity_type='subclass'
+                           AND s.class_id=ac.class_id
+                           AND vf.severity='warning')
+        )
+        SELECT ac.class_id,
+               CASE
+                 WHEN EXISTS (SELECT 1 FROM class_err e WHERE e.class_id=ac.class_id) THEN 'error'
+                 WHEN EXISTS (SELECT 1 FROM class_warn w WHERE w.class_id=ac.class_id) THEN 'warning'
+                 ELSE 'compliant'
+               END AS validation_status,
+               (
+                 SELECT COUNT(*) FROM ValidationFindings vf
+                 WHERE (vf.entity_type='class' AND vf.entity_id=ac.class_id)
+                    OR (vf.entity_type='subclass' AND vf.entity_id IN (
+                         SELECT sub_class_id FROM AssetSubClasses s WHERE s.class_id=ac.class_id
+                       ))
+               ) AS findings_count
+        FROM AssetClasses ac;
+        """
+        guard sqlite3_exec(rawDB, views, nil, nil, nil) == SQLITE_OK else {
+            throw XCTSkip("Failed to create views")
+        }
+        try sqlite3_exec(rawDB, "INSERT INTO AssetClasses(class_id,name) VALUES (1,'Class');", nil, nil, nil).unwrap()
+        try sqlite3_exec(rawDB, "INSERT INTO AssetSubClasses(sub_class_id,class_id,name) VALUES (10,1,'Sub');", nil, nil, nil).unwrap()
+        try sqlite3_exec(rawDB, "INSERT INTO ClassTargets(class_id,validation_status) VALUES (1,'compliant');", nil, nil, nil).unwrap()
+        try sqlite3_exec(rawDB, "INSERT INTO SubClassTargets(sub_class_id,class_id,validation_status) VALUES (10,1,'compliant');", nil, nil, nil).unwrap()
+        return try DatabaseManager(path: path)
+    }
+
+    func testStatusesAndFindingsAggregation() throws {
+        let db = try makeDB()
+        db.syncValidationStatusTables()
+        XCTAssertEqual(db.fetchClassValidationStatuses()[1], "compliant")
+        XCTAssertEqual(db.fetchSubClassValidationStatuses()[10], "compliant")
+        assertTargetStatus(db, classStatus: "compliant", subStatus: "compliant")
+
+        _ = db.execute("INSERT INTO ValidationFindings(entity_type,entity_id,severity,code,message) VALUES('subclass',10,'warning','W1','warn');")
+        db.syncValidationStatusTables()
+        XCTAssertEqual(db.fetchSubClassValidationStatuses()[10], "warning")
+        XCTAssertEqual(db.fetchClassValidationStatuses()[1], "warning")
+        assertTargetStatus(db, classStatus: "warning", subStatus: "warning")
+
+        _ = db.execute("INSERT INTO ValidationFindings(entity_type,entity_id,severity,code,message) VALUES('class',1,'error','E1','err');")
+        db.syncValidationStatusTables()
+        XCTAssertEqual(db.fetchClassValidationStatuses()[1], "error")
+        assertTargetStatus(db, classStatus: "error", subStatus: "warning")
+
+        _ = db.execute("INSERT INTO ValidationFindings(entity_type,entity_id,severity,code,message) VALUES('subclass',10,'error','E2','boom');")
+        db.syncValidationStatusTables()
+        XCTAssertEqual(db.fetchSubClassValidationStatuses()[10], "error")
+        XCTAssertEqual(db.fetchClassValidationStatuses()[1], "error")
+        assertTargetStatus(db, classStatus: "error", subStatus: "error")
+
+        let classFindings = db.fetchValidationFindingsForClass(1)
+        XCTAssertEqual(classFindings.map { $0.code }, ["E1", "E2", "W1"])
+        let subFindings = db.fetchValidationFindingsForSubClass(10)
+        XCTAssertEqual(subFindings.map { $0.code }, ["E2", "W1"])
+    }
+
+    private func assertTargetStatus(_ db: DatabaseManager, classStatus: String, subStatus: String, file: StaticString = #filePath, line: UInt = #line) {
+        var stmt: OpaquePointer?
+        sqlite3_prepare_v2(db.db, "SELECT validation_status FROM ClassTargets WHERE class_id=1;", -1, &stmt, nil)
+        defer { sqlite3_finalize(stmt) }
+        _ = sqlite3_step(stmt)
+        let cStatus = String(cString: sqlite3_column_text(stmt, 0))
+        XCTAssertEqual(cStatus, classStatus, file: file, line: line)
+
+        var stmt2: OpaquePointer?
+        sqlite3_prepare_v2(db.db, "SELECT validation_status FROM SubClassTargets WHERE sub_class_id=10;", -1, &stmt2, nil)
+        defer { sqlite3_finalize(stmt2) }
+        _ = sqlite3_step(stmt2)
+        let sStatus = String(cString: sqlite3_column_text(stmt2, 0))
+        XCTAssertEqual(sStatus, subStatus, file: file, line: line)
+    }
+}
+
+private extension Int32 {
+    func unwrap() throws {
+        if self != SQLITE_OK { throw NSError(domain: "SQLite", code: Int(self)) }
+    }
+}
+


### PR DESCRIPTION
## Summary
- aggregate findings into class and subclass validation status views
- expose database APIs to sync target tables and fetch ordered findings
- update allocation table view to show subclass statuses and suppress stale "Why?" links
- list finding severity, code, scope, and timestamp in ValidationDetailsView
- test status aggregation and table syncing

## Testing
- `swift build` *(fails: no such module 'SQLite3')*
- `swift test` *(fails: no such module 'SQLite3')*
- `apt-get update` *(fails: repository 403 Forbidden)*
- `dbmate --migrations-dir "DragonShield/migrations" --url "$DATABASE_URL" status` *(fails: command not found: dbmate)*
- `sqlite3 /tmp/test.sqlite "SELECT * FROM V_ClassValidationStatus LIMIT 1;"` *(fails: no such table: V_ClassValidationStatus)*
- `sqlite3 /tmp/test.sqlite "SELECT * FROM V_ClassValidationStatus;"` *(fails: no such table: V_ClassValidationStatus)*

------
https://chatgpt.com/codex/tasks/task_e_689a24641200832388f62f842bfe7a46