### PR TITLE
Ensure reliable SQLite backups and filter noisy logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Verify SQLite backups read-only, discard corrupt files, and suppress known system warnings in backup logs
 - Sync validation status of class and subclass targets from findings and purge zero-target data
 - Skip validation for asset classes without target allocation and clear related findings
 - Enlarge validation details modal and add close button

--- a/DragonShield/BackupService.swift
+++ b/DragonShield/BackupService.swift
@@ -161,11 +161,11 @@ class BackupService: ObservableObject {
         guard sqlite3_open_v2(dbPath, &src, SQLITE_OPEN_READONLY | SQLITE_OPEN_FULLMUTEX, nil) == SQLITE_OK, let src else {
             throw NSError(domain: "SQLite", code: 1, userInfo: [NSLocalizedDescriptionKey: "Unable to open source database"])
         }
-        defer { sqlite3_close(src) }
+        defer { if let src = src { sqlite3_close(src) } }
         guard sqlite3_open_v2(destination.path, &dst, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX, nil) == SQLITE_OK, let dst else {
             throw NSError(domain: "SQLite", code: 1, userInfo: [NSLocalizedDescriptionKey: "Unable to create backup database"])
         }
-        defer { sqlite3_close(dst) }
+        defer { if let dst = dst { sqlite3_close(dst) } }
 
         guard let backup = sqlite3_backup_init(dst, "main", src, "main") else {
             throw NSError(domain: "SQLite", code: 1, userInfo: [NSLocalizedDescriptionKey: "backup init failed"])
@@ -175,12 +175,18 @@ class BackupService: ObservableObject {
             throw NSError(domain: "SQLite", code: 1, userInfo: [NSLocalizedDescriptionKey: "backup finish failed"])
         }
 
+        // ensure single-file backup independent of WAL
+        sqlite3_exec(dst, "PRAGMA journal_mode=DELETE;", nil, nil, nil)
+
+        let counts = rowCounts(db: dst, tables: tables)
+
+        sqlite3_close(dst)
+        dst = nil
+
         guard checkIntegrity(path: destination.path) else {
             try? FileManager.default.removeItem(at: destination)
             throw NSError(domain: "SQLite", code: 1, userInfo: [NSLocalizedDescriptionKey: "Integrity check failed"])
         }
-
-        let counts = rowCounts(db: dst, tables: tables)
 
         let ts = Date()
         UserDefaults.standard.set(ts, forKey: UserDefaultsKeys.lastBackupTimestamp)

--- a/DragonShieldTests/BackupServiceTests.swift
+++ b/DragonShieldTests/BackupServiceTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import DragonShield
+
+final class BackupServiceTests: XCTestCase {
+    func testShouldDisplayLogFiltersNoise() {
+        let service = BackupService()
+        XCTAssertFalse(service.shouldDisplayLog("warning: /private/var/db/DetachedSignatures"))
+        XCTAssertFalse(service.shouldDisplayLog("error default.metallib missing"))
+        XCTAssertTrue(service.shouldDisplayLog("[2024-01-01] Backup test.db Success"))
+    }
+}


### PR DESCRIPTION
## Summary
- verify backups via read-only integrity check and delete file if corrupted
- filter known system warnings from backup logs
- add unit test for log filtering

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689b8871edcc8323b4b961f6847c14ad