### PR TITLE
Verify backup file after closing SQLite connection

### DIFF
--- a/Archive/tests/test_backup_restore.py
+++ b/Archive/tests/test_backup_restore.py
@@ -1,6 +1,7 @@
 import sqlite3
 from pathlib import Path
 
+import pytest
 
 from DragonShield.python_scripts.backup_restore import backup_database, restore_database
 
@@ -46,3 +47,28 @@ def test_backup_and_restore(tmp_path):
     # backup should still exist
     assert backup_file.exists()
 
+
+def test_restore_rejects_corrupt_backup(tmp_path):
+    db = tmp_path / "dragonshield.sqlite"
+    setup_db(db)
+
+    backup_dir = tmp_path / "backups"
+    backup_file, _ = backup_database(db, backup_dir, "test")
+
+    # modify current database so a restore would change it
+    conn = sqlite3.connect(db)
+    conn.execute("DELETE FROM t1 WHERE id=1")
+    conn.commit()
+    conn.close()
+
+    # corrupt the backup file
+    backup_file.write_bytes(b"not a sqlite database")
+
+    with pytest.raises(RuntimeError):
+        restore_database(db, backup_file)
+
+    # no .old file should be created and DB should remain modified
+    assert not list(tmp_path.glob("dragonshield.sqlite.old.*"))
+    conn = sqlite3.connect(db)
+    assert conn.execute("SELECT COUNT(*) FROM t1").fetchone()[0] == 1
+    conn.close()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Add validation status column with traffic-light icons and deviation bars in Asset Allocation table
 - Fix failed ClassTargets/SubClassTargets upserts so edited targets persist
 - Ensure backup routines include TargetChangeLog and full reference data
+- Fix backup script to verify and close database before deleting corrupt backup
 - Remove legacy Asset Allocation view and navigation link
 - Polish target edit panel layout with fixed width and regrouped inputs for clarity
 - Expand target edit panel to 800×600 and allow dragging to reposition


### PR DESCRIPTION
## Summary
- ensure backup script closes SQLite connections before integrity checks and cleanup
- verify both backup and restored databases with integrity_check and table counts
- test restore handling of corrupt backups and document fix

## Testing
- `make setup` (fails: No rule to make target 'setup')
- `make fmt && make lint` (fails: No rule to make target 'fmt')
- `make migrate` (fails: No rule to make target 'migrate')
- `make build` (fails: No rule to make target 'build')
- `make test` (fails: No rule to make target 'test')
- `python -m black --check DragonShield/python_scripts/backup_restore.py Archive/tests/test_backup_restore.py`
- `python -m pytest Archive/tests/test_backup_restore.py`

------
https://chatgpt.com/codex/tasks/task_e_689d6fc3f8988323864716922bc54dc7