### PR TITLE
Fix backup process to close database before integrity check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Close backup database before integrity checks and verify restores to prevent 'vnode unlinked while in use' errors
 - Sync validation status of class and subclass targets from findings and purge zero-target data
 - Skip validation for asset classes without target allocation and clear related findings
 - Enlarge validation details modal and add close button


### PR DESCRIPTION
## Summary
- close backup database before verification to avoid `vnode unlinked while in use`
- verify backup files and restored databases with separate connections
- document robust backup/restore routine

## Testing
- ⚠️ `make setup` (no rule)
- ⚠️ `make fmt && make lint` (no rule)
- ⚠️ `make migrate` (no rule)
- ⚠️ `make build` (no rule)
- ⚠️ `make test` (no rule)
- ⚠️ `python -m pytest` (missing modules)
- ✅ `python -m pytest Archive/tests/test_backup_restore.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d6fc3f8988323864716922bc54dc7