### PR TITLE
Verify full restore against backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ All notable changes to this project will be documented in this file.
 - Fix compile error referencing systemGray6 in tolerance pill background
 - Fix compile errors referencing system gray colours and deprecated onChange API
 - Provide fallback colours for systemGray4-6 on macOS to resolve compile errors
+- Compare restored database table counts with backup and enumerate tables dynamically
 - Refine deviation bar logic in Asset Allocation view
 - Update deviation bar display in Asset Allocation tile
 - Shorten deviation bars to half length in Asset Allocation tile

--- a/DragonShield/Views/DatabaseManagementView.swift
+++ b/DragonShield/Views/DatabaseManagementView.swift
@@ -440,7 +440,7 @@ struct DatabaseManagementView: View {
         processing = true
         DispatchQueue.global().async {
             do {
-                let result = try backupService.performRestore(dbManager: dbManager, from: url, tables: backupService.fullTables, label: "Full")
+                let result = try backupService.performRestore(dbManager: dbManager, from: url, label: "Full")
                 DispatchQueue.main.async {
                     processing = false
                     restoreDeltas = result

--- a/DragonShield/Views/RestoreComparisonView.swift
+++ b/DragonShield/Views/RestoreComparisonView.swift
@@ -26,8 +26,8 @@ struct RestoreComparisonView: View {
                     Text(row.table)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                TableColumn("Pre-Restore Count") { row in
-                    Text(fmt(row.preCount))
+                TableColumn("Backup Count") { row in
+                    Text(fmt(row.backupCount))
                         .frame(maxWidth: .infinity, alignment: .trailing)
                 }
                 TableColumn("Post-Restore Count") { row in

--- a/DragonShieldTests/BackupServiceTests.swift
+++ b/DragonShieldTests/BackupServiceTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import DragonShield
+import SQLite3
+
+final class BackupServiceTests: XCTestCase {
+    func testUserTablesListsAllNonSystemTables() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let dbURL = dir.appendingPathComponent("test.sqlite")
+        var db: OpaquePointer?
+        XCTAssertEqual(SQLITE_OK, sqlite3_open(dbURL.path, &db))
+        defer { sqlite3_close(db) }
+        XCTAssertEqual(SQLITE_OK, sqlite3_exec(db, "CREATE TABLE A(id INTEGER);", nil, nil, nil))
+        XCTAssertEqual(SQLITE_OK, sqlite3_exec(db, "CREATE TABLE B(id INTEGER);", nil, nil, nil))
+        // System tables prefixed with sqlite_ should be ignored
+        let service = BackupService()
+        let tables = service.userTables(at: dbURL.path)
+        XCTAssertEqual(tables, ["A", "B"])
+    }
+}


### PR DESCRIPTION
## Summary
- compare restored database counts to backup using dynamic table list
- show backup counts in restore comparison view
- add unit test for user table enumeration

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_689d7d9c565083239372ec87270840a3