### PR TITLE
Ensure full restore replaces DB atomically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Ensure full database restore checkpoints WAL, removes sidecar files, and verifies all table counts
 - Sync validation status of class and subclass targets from findings and purge zero-target data
 - Skip validation for asset classes without target allocation and clear related findings
 - Enlarge validation details modal and add close button

--- a/DragonShield/Views/DatabaseManagementView.swift
+++ b/DragonShield/Views/DatabaseManagementView.swift
@@ -440,7 +440,7 @@ struct DatabaseManagementView: View {
         processing = true
         DispatchQueue.global().async {
             do {
-                let result = try backupService.performRestore(dbManager: dbManager, from: url, tables: backupService.fullTables, label: "Full")
+                let result = try backupService.performRestore(dbManager: dbManager, from: url, label: "Full")
                 DispatchQueue.main.async {
                     processing = false
                     restoreDeltas = result

--- a/DragonShield/Views/RestoreComparisonView.swift
+++ b/DragonShield/Views/RestoreComparisonView.swift
@@ -26,8 +26,8 @@ struct RestoreComparisonView: View {
                     Text(row.table)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                TableColumn("Pre-Restore Count") { row in
-                    Text(fmt(row.preCount))
+                TableColumn("Backup Count") { row in
+                    Text(fmt(row.backupCount))
                         .frame(maxWidth: .infinity, alignment: .trailing)
                 }
                 TableColumn("Post-Restore Count") { row in

--- a/DragonShieldTests/FullRestoreTests.swift
+++ b/DragonShieldTests/FullRestoreTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+import SQLite3
+@testable import DragonShield
+
+final class FullRestoreTests: XCTestCase {
+    func testUserTablesEnumeratesAll() throws {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent("enumerate.db")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        var db: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(tmp.path, &db), SQLITE_OK)
+        sqlite3_exec(db, "CREATE TABLE Foo(id INTEGER);", nil, nil, nil)
+        sqlite3_exec(db, "CREATE TABLE Bar(id INTEGER);", nil, nil, nil)
+        sqlite3_close(db)
+
+        let service = BackupService()
+        let tables = service.userTables(at: tmp.path)
+        XCTAssertTrue(tables.contains("Foo"))
+        XCTAssertTrue(tables.contains("Bar"))
+    }
+}


### PR DESCRIPTION
## Summary
- checkpoint WAL and remove sidecar files before restoring database
- compare row counts from backup file to post-restore database
- test table discovery for full restore verification

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689d7d9c565083239372ec87270840a3