### PR TITLE
feat: atomic full restore with verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Perform full database restore with WAL cleanup, atomic file replace, and per-table verification
 - Sync validation status of class and subclass targets from findings and purge zero-target data
 - Skip validation for asset classes without target allocation and clear related findings
 - Enlarge validation details modal and add close button

--- a/DragonShield/Views/DatabaseManagementView.swift
+++ b/DragonShield/Views/DatabaseManagementView.swift
@@ -440,7 +440,7 @@ struct DatabaseManagementView: View {
         processing = true
         DispatchQueue.global().async {
             do {
-                let result = try backupService.performRestore(dbManager: dbManager, from: url, tables: backupService.fullTables, label: "Full")
+                let result = try backupService.performRestore(dbManager: dbManager, from: url, label: "Full")
                 DispatchQueue.main.async {
                     processing = false
                     restoreDeltas = result

--- a/DragonShield/Views/RestoreComparisonView.swift
+++ b/DragonShield/Views/RestoreComparisonView.swift
@@ -26,8 +26,8 @@ struct RestoreComparisonView: View {
                     Text(row.table)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                TableColumn("Pre-Restore Count") { row in
-                    Text(fmt(row.preCount))
+                TableColumn("Backup Count") { row in
+                    Text(fmt(row.backupCount))
                         .frame(maxWidth: .infinity, alignment: .trailing)
                 }
                 TableColumn("Post-Restore Count") { row in

--- a/DragonShieldTests/BackupServiceTests.swift
+++ b/DragonShieldTests/BackupServiceTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import DragonShield
+import SQLite3
+
+final class BackupServiceTests: XCTestCase {
+    func testUserTablesListsAllUserTables() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let dbURL = dir.appendingPathComponent("temp.sqlite")
+        var db: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(dbURL.path, &db), SQLITE_OK)
+        defer { sqlite3_close(db) }
+        XCTAssertEqual(sqlite3_exec(db, "CREATE TABLE Foo(id INTEGER);", nil, nil, nil), SQLITE_OK)
+        XCTAssertEqual(sqlite3_exec(db, "CREATE TABLE Bar(id INTEGER);", nil, nil, nil), SQLITE_OK)
+        let svc = BackupService()
+        let names = svc.userTables(in: dbURL.path)
+        XCTAssertTrue(names.contains("Foo"))
+        XCTAssertTrue(names.contains("Bar"))
+    }
+}


### PR DESCRIPTION
## Summary
- make full database restore WAL-safe with atomic replace and integrity check
- verify restored tables by comparing backup counts to post-restore counts
- show backup vs post-restore counts in restore comparison view

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d7d9c565083239372ec87270840a3