### PR TITLE
Redesign full database backup and restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Redesign full database backup and restore with progress logs and disabled partial backup/restore options
 - Sync validation status of class and subclass targets from findings and purge zero-target data
 - Skip validation for asset classes without target allocation and clear related findings
 - Enlarge validation details modal and add close button

--- a/DragonShield/Views/DatabaseManagementView.swift
+++ b/DragonShield/Views/DatabaseManagementView.swift
@@ -130,6 +130,8 @@ struct DatabaseManagementView: View {
                         }
                 }
             }
+            .disabled(true)
+            .opacity(0.5)
 
             VStack(alignment: .leading, spacing: 8) {
                 Text("Transaction Data")
@@ -156,6 +158,8 @@ struct DatabaseManagementView: View {
                         }
                 }
             }
+            .disabled(true)
+            .opacity(0.5)
 
             VStack(alignment: .leading, spacing: 8) {
                 Text("Reports")
@@ -354,7 +358,7 @@ struct DatabaseManagementView: View {
         DispatchQueue.global().async {
             do {
                 try? backupService.updateBackupDirectory(to: url.deletingLastPathComponent())
-                _ = try backupService.performBackup(dbManager: dbManager, dbPath: dbManager.dbFilePath, to: url, tables: backupService.fullTables, label: "Full")
+                _ = try backupService.performBackup(dbManager: dbManager, to: url)
                 DispatchQueue.main.async { processing = false }
             } catch {
                 DispatchQueue.main.async {
@@ -440,7 +444,7 @@ struct DatabaseManagementView: View {
         processing = true
         DispatchQueue.global().async {
             do {
-                let result = try backupService.performRestore(dbManager: dbManager, from: url, tables: backupService.fullTables, label: "Full")
+                let result = try backupService.performRestore(dbManager: dbManager, from: url)
                 DispatchQueue.main.async {
                     processing = false
                     restoreDeltas = result


### PR DESCRIPTION
## Summary
- Rewrite backup service to copy all tables and log progress
- Replace restore flow with integrity checks and delta report
- Disable reference and transaction partial backup and restore options

## Testing
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_689de82076ec8323979b9d2453d84772