### PR TITLE
Fix instrument report generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Fix instrument report generation by parsing seed data and removing sqlite dependency
 - Sync validation status of class and subclass targets from findings and purge zero-target data
 - Skip validation for asset classes without target allocation and clear related findings
 - Enlarge validation details modal and add close button


### PR DESCRIPTION
## Summary
- parse Instruments seed data directly to generate XLSX report
- ensure script locates db schema and imports real pandas

## Testing
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift)*
- `python3 DragonShield/python_scripts/generate_instrument_report.py /tmp/test.xlsx` *(fails: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68a09d9321fc83238e828dc0ba31681f