### PR TITLE
fix: generate instrument report via read-only export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project will be documented in this file.
 - Ensure backup routines include TargetChangeLog and full reference data
 - Fix backup script to verify and close database before deleting corrupt backup
 - Remove legacy Asset Allocation view and navigation link
+- Generate full instrument report via read-only SQLite and atomic CSV export
+- Share DatabaseManager with AssetManager and open report database in immutable read-only mode
 - Polish target edit panel layout with fixed width and regrouped inputs for clarity
 - Expand target edit panel to 800×600 and allow dragging to reposition
 - Fix optional class ID handling in target sum validation warnings

--- a/DragonShield/AssetManager.swift
+++ b/DragonShield/AssetManager.swift
@@ -12,9 +12,10 @@ struct DragonAsset: Identifiable {
 
 class AssetManager: ObservableObject {
     @Published var assets: [DragonAsset] = []
-    private let dbManager = DatabaseManager()
-    
-    init() {
+    private let dbManager: DatabaseManager
+
+    init(dbManager: DatabaseManager) {
+        self.dbManager = dbManager
         loadAssets()
     }
     

--- a/DragonShield/DragonShieldApp.swift
+++ b/DragonShield/DragonShieldApp.swift
@@ -3,9 +3,15 @@ import SwiftUI
 
 @main
 struct DragonShieldApp: App {
-    // Create a single instance of DatabaseManager to be used throughout the app
-    @StateObject private var databaseManager = DatabaseManager()
-    @StateObject private var assetManager = AssetManager() // Assuming you also have this
+    // Share a single DatabaseManager across the app and asset manager
+    @StateObject private var databaseManager: DatabaseManager
+    @StateObject private var assetManager: AssetManager
+
+    init() {
+        let dbManager = DatabaseManager()
+        _databaseManager = StateObject(wrappedValue: dbManager)
+        _assetManager = StateObject(wrappedValue: AssetManager(dbManager: dbManager))
+    }
 
     var body: some Scene {
         WindowGroup {
@@ -14,8 +20,8 @@ struct DragonShieldApp: App {
             } detail: {
                 DashboardView()
             }
-            .environmentObject(assetManager) // Your existing one
-            .environmentObject(databaseManager) // <<<< ADD THIS LINE
+            .environmentObject(assetManager)
+            .environmentObject(databaseManager)
             .toolbar {
                 ToolbarItem(placement: .navigation) {
                     ModeBadge()

--- a/DragonShield/ReportDB.swift
+++ b/DragonShield/ReportDB.swift
@@ -1,0 +1,47 @@
+import Foundation
+import SQLite3
+
+final class ReportDB {
+    private var handle: OpaquePointer?
+
+    init(path: String) throws {
+        let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? path
+        let uri = "file:\(encodedPath)?mode=ro&immutable=1"
+        let flags = SQLITE_OPEN_READONLY | SQLITE_OPEN_FULLMUTEX | SQLITE_OPEN_URI
+        if sqlite3_open_v2(uri, &handle, flags, nil) != SQLITE_OK {
+            let message = handle != nil ? String(cString: sqlite3_errmsg(handle)) : "Unknown error"
+            throw NSError(domain: "ReportDB", code: 1, userInfo: [NSLocalizedDescriptionKey: message])
+        }
+        sqlite3_exec(handle, "PRAGMA query_only = ON;", nil, nil, nil)
+    }
+
+    deinit {
+        close()
+    }
+
+    func close() {
+        if let h = handle {
+            sqlite3_close_v2(h)
+        }
+        handle = nil
+    }
+
+    func count(table: String) throws -> Int {
+        guard let db = handle else {
+            throw NSError(domain: "ReportDB", code: 2, userInfo: [NSLocalizedDescriptionKey: "Database not open"])
+        }
+        let query = "SELECT COUNT(*) FROM \(table);"
+        var stmt: OpaquePointer?
+        defer { sqlite3_finalize(stmt) }
+        if sqlite3_prepare_v2(db, query, -1, &stmt, nil) != SQLITE_OK {
+            let message = String(cString: sqlite3_errmsg(db))
+            throw NSError(domain: "ReportDB", code: 3, userInfo: [NSLocalizedDescriptionKey: message])
+        }
+        if sqlite3_step(stmt) != SQLITE_ROW {
+            let message = String(cString: sqlite3_errmsg(db))
+            throw NSError(domain: "ReportDB", code: 4, userInfo: [NSLocalizedDescriptionKey: message])
+        }
+        let count = sqlite3_column_int(stmt, 0)
+        return Int(count)
+    }
+}

--- a/DragonShield/Views/AssetMenuView.swift
+++ b/DragonShield/Views/AssetMenuView.swift
@@ -8,7 +8,7 @@ struct AssetMenuView: View {
     @State private var showingModifyAsset = false
     @State private var showingDeleteAsset = false
     @State private var selectedAsset: DragonAsset? = nil
-    @StateObject private var assetManager = AssetManager()
+    @EnvironmentObject var assetManager: AssetManager
     
     var body: some View {
         VStack {

--- a/DragonShield/Views/PortfolioView.swift
+++ b/DragonShield/Views/PortfolioView.swift
@@ -755,7 +755,8 @@ struct InstrumentParticle {
 // MARK: - Preview
 struct PortfolioView_Previews: PreviewProvider {
     static var previews: some View {
-        PortfolioView()
-            .environmentObject(AssetManager())
+        let dbManager = DatabaseManager()
+        return PortfolioView()
+            .environmentObject(AssetManager(dbManager: dbManager))
     }
 }

--- a/DragonShield/Views/SidebarView.swift
+++ b/DragonShield/Views/SidebarView.swift
@@ -95,12 +95,13 @@ struct SidebarView: View {
 
 struct SidebarView_Previews: PreviewProvider {
     static var previews: some View {
-        NavigationSplitView {
+        let dbManager = DatabaseManager()
+        return NavigationSplitView {
             SidebarView()
         } detail: {
             DashboardView()
         }
-        .environmentObject(DatabaseManager())
-        .environmentObject(AssetManager())
+        .environmentObject(dbManager)
+        .environmentObject(AssetManager(dbManager: dbManager))
     }
 }

--- a/DragonShieldTests/InstrumentReportServiceTests.swift
+++ b/DragonShieldTests/InstrumentReportServiceTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+import SQLite3
+@testable import DragonShield
+
+final class InstrumentReportServiceTests: XCTestCase {
+    func testGenerateReportCreatesCSVWithCounts() throws {
+        let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        let dbURL = tmpDir.appendingPathComponent("test.sqlite")
+        var db: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(dbURL.path, &db), SQLITE_OK)
+        sqlite3_exec(db, "CREATE TABLE Instruments(id INTEGER);", nil, nil, nil)
+        sqlite3_exec(db, "CREATE TABLE AssetSubClasses(id INTEGER);", nil, nil, nil)
+        sqlite3_exec(db, "CREATE TABLE PortfolioInstruments(id INTEGER);", nil, nil, nil)
+        sqlite3_exec(db, "INSERT INTO Instruments VALUES (1);", nil, nil, nil)
+        sqlite3_exec(db, "INSERT INTO AssetSubClasses VALUES (1);", nil, nil, nil)
+        sqlite3_exec(db, "INSERT INTO PortfolioInstruments VALUES (1);", nil, nil, nil)
+        sqlite3_close(db)
+
+        let destination = tmpDir.appendingPathComponent("report.csv")
+        let service = InstrumentReportService()
+        let summary = try service.generateReport(databasePath: dbURL.path, destinationURL: destination)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: destination.path))
+        let csv = try String(contentsOf: destination)
+        XCTAssertTrue(csv.contains("Instruments,1"))
+        XCTAssertEqual(summary.instrumentCount, 1)
+    }
+}


### PR DESCRIPTION
## Summary
- replace python-based report generator with Swift CSV export using read-only SQLite connection
- allow save panel to request security-scoped location and atomically write report
- add unit test verifying CSV contains instrument counts
- share DatabaseManager instance with AssetManager and open report database in immutable read-only mode

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild test -scheme DragonShield -project DragonShield.xcodeproj` *(fails: command not found: xcodebuild)*


------
https://chatgpt.com/codex/tasks/task_e_68a0a385d5888323a8a4bbd8712937cd