### PR TITLE
fix: generate instrument report via read-only export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Ensure backup routines include TargetChangeLog and full reference data
 - Fix backup script to verify and close database before deleting corrupt backup
 - Remove legacy Asset Allocation view and navigation link
+- Generate full instrument report via read-only SQLite and atomic CSV export without DetachedSignatures warnings
 - Polish target edit panel layout with fixed width and regrouped inputs for clarity
 - Expand target edit panel to 800×600 and allow dragging to reposition
 - Fix optional class ID handling in target sum validation warnings

--- a/DragonShield/ReportDB.swift
+++ b/DragonShield/ReportDB.swift
@@ -1,0 +1,56 @@
+import Foundation
+import SQLite3
+import OSLog
+
+final class ReportDB {
+    private static let configureLog: Void = {
+        sqlite3_config(SQLITE_CONFIG_LOG, { _, errorCode, messagePointer in
+            guard let messagePointer = messagePointer else { return }
+            let message = String(cString: messagePointer)
+            if message.contains("/private/var/db/DetachedSignatures") { return }
+            LoggingService.shared.log("sqlite: \(message) (\(errorCode))", logger: .database)
+        }, nil)
+    }()
+
+    private var handle: OpaquePointer?
+
+    init(path: String) throws {
+        _ = ReportDB.configureLog
+        let flags = SQLITE_OPEN_READONLY | SQLITE_OPEN_FULLMUTEX | SQLITE_OPEN_PRIVATECACHE
+        if sqlite3_open_v2(path, &handle, flags, nil) != SQLITE_OK {
+            let message = handle != nil ? String(cString: sqlite3_errmsg(handle)) : "Unknown error"
+            throw NSError(domain: "ReportDB", code: 1, userInfo: [NSLocalizedDescriptionKey: message])
+        }
+        sqlite3_db_config(handle, SQLITE_DBCONFIG_ENABLE_LOAD_EXTENSION, 0, nil)
+    }
+
+    deinit {
+        close()
+    }
+
+    func close() {
+        if let h = handle {
+            sqlite3_close_v2(h)
+        }
+        handle = nil
+    }
+
+    func count(table: String) throws -> Int {
+        guard let db = handle else {
+            throw NSError(domain: "ReportDB", code: 2, userInfo: [NSLocalizedDescriptionKey: "Database not open"])
+        }
+        let query = "SELECT COUNT(*) FROM \(table);"
+        var stmt: OpaquePointer?
+        defer { sqlite3_finalize(stmt) }
+        if sqlite3_prepare_v2(db, query, -1, &stmt, nil) != SQLITE_OK {
+            let message = String(cString: sqlite3_errmsg(db))
+            throw NSError(domain: "ReportDB", code: 3, userInfo: [NSLocalizedDescriptionKey: message])
+        }
+        if sqlite3_step(stmt) != SQLITE_ROW {
+            let message = String(cString: sqlite3_errmsg(db))
+            throw NSError(domain: "ReportDB", code: 4, userInfo: [NSLocalizedDescriptionKey: message])
+        }
+        let count = sqlite3_column_int(stmt, 0)
+        return Int(count)
+    }
+}

--- a/DragonShieldTests/InstrumentReportServiceTests.swift
+++ b/DragonShieldTests/InstrumentReportServiceTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+import SQLite3
+@testable import DragonShield
+
+final class InstrumentReportServiceTests: XCTestCase {
+    func testGenerateReportCreatesCSVWithCounts() throws {
+        let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        let dbURL = tmpDir.appendingPathComponent("test.sqlite")
+        var db: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(dbURL.path, &db), SQLITE_OK)
+        sqlite3_exec(db, "CREATE TABLE Instruments(id INTEGER);", nil, nil, nil)
+        sqlite3_exec(db, "CREATE TABLE AssetSubClasses(id INTEGER);", nil, nil, nil)
+        sqlite3_exec(db, "CREATE TABLE PortfolioInstruments(id INTEGER);", nil, nil, nil)
+        sqlite3_exec(db, "INSERT INTO Instruments VALUES (1);", nil, nil, nil)
+        sqlite3_exec(db, "INSERT INTO AssetSubClasses VALUES (1);", nil, nil, nil)
+        sqlite3_exec(db, "INSERT INTO PortfolioInstruments VALUES (1);", nil, nil, nil)
+        sqlite3_close(db)
+
+        let destination = tmpDir.appendingPathComponent("report.csv")
+        let service = InstrumentReportService()
+        let summary = try service.generateReport(databasePath: dbURL.path, destinationURL: destination)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: destination.path))
+        let csv = try String(contentsOf: destination)
+        XCTAssertTrue(csv.contains("Instruments,1"))
+        XCTAssertEqual(summary.instrumentCount, 1)
+    }
+}


### PR DESCRIPTION
## Summary
- replace python-based report generator with Swift CSV export using read-only SQLite connection
- allow save panel to request security-scoped location and atomically write report
- disable SQLite extension loading and silence DetachedSignatures warning during export

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild test -scheme DragonShield -project DragonShield.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a385d5888323a8a4bbd8712937cd