### PR TITLE
Show backup restore log details by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Expand Backup & Restore log by default in Database Management view
 - Add button to validate Instruments in Database Management view
 - Temporarily disable Reference and Transaction data backup and restore buttons
 - Sync validation status of class and subclass targets from findings and purge zero-target data

--- a/DragonShield/Views/DatabaseManagementView.swift
+++ b/DragonShield/Views/DatabaseManagementView.swift
@@ -11,7 +11,7 @@ struct DatabaseManagementView: View {
     @State private var restoreURL: URL?
     @State private var showRestoreConfirm = false
     @State private var errorMessage: String?
-    @State private var showLogDetails = false
+    @State private var showLogDetails = true
     @State private var showReferenceInfo = false
     @State private var reportProcessing = false
     @State private var validationProcessing = false


### PR DESCRIPTION
## Summary
- expand Backup & Restore log details by default in Database Management view

## Testing
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift)
- `xcodebuild` *(fails: command not found)
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a20c75d2e88323a1fdb3989158acbb