### PR TITLE
Disable broken instrument report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Disable Generate Full Instrument Report button with hover notice in Database Management view
 - Expand Backup & Restore log by default in Database Management view
 - Add button to validate Instruments in Database Management view
 - Temporarily disable Reference and Transaction data backup and restore buttons

--- a/DragonShield/Views/DatabaseManagementView.swift
+++ b/DragonShield/Views/DatabaseManagementView.swift
@@ -13,12 +13,9 @@ struct DatabaseManagementView: View {
     @State private var errorMessage: String?
     @State private var showLogDetails = true
     @State private var showReferenceInfo = false
-    @State private var reportProcessing = false
     @State private var validationProcessing = false
     @State private var showRestoreComparison = false
     @State private var restoreDeltas: [RestoreDelta] = []
-
-    private let reportService = InstrumentReportService()
 
     // MARK: - Info Card
     private func infoRow(_ label: String, value: String, mono: Bool = false) -> some View {
@@ -133,11 +130,11 @@ struct DatabaseManagementView: View {
                 Text("Reports")
                     .font(.system(size: 14, weight: .medium))
                 HStack(spacing: 12) {
-                    Button(action: generateInstrumentReport) {
-                        if reportProcessing { ProgressView() } else { Text("Generate Full Instrument Report") }
-                    }
-                    .buttonStyle(PrimaryButtonStyle())
-                    .disabled(reportProcessing)
+                    Button("Generate Full Instrument Report") {}
+                        .buttonStyle(PrimaryButtonStyle())
+                        .disabled(true)
+                        .opacity(0.5)
+                        .help("Script needs to be fixed")
                 }
             }
 
@@ -352,34 +349,6 @@ struct DatabaseManagementView: View {
         }
     }
 
-    private func generateInstrumentReport() {
-        let panel = NSSavePanel()
-        panel.canCreateDirectories = true
-        if #available(macOS 12.0, *) {
-            if let xlsxType = UTType(filenameExtension: "xlsx") { panel.allowedContentTypes = [xlsxType] }
-        } else {
-            panel.allowedFileTypes = ["xlsx"]
-        }
-        panel.nameFieldStringValue = "instrument_report.xlsx"
-        guard panel.runModal() == .OK, let url = panel.url else { return }
-        reportProcessing = true
-        appendReportLog("Generating full instrument report…")
-        DispatchQueue.global().async {
-            do {
-                try reportService.generateReport(outputPath: url.path)
-                DispatchQueue.main.async {
-                    reportProcessing = false
-                    appendReportLog("Report saved to \(url.path)")
-                }
-            } catch {
-                DispatchQueue.main.async {
-                    reportProcessing = false
-                    appendReportLog("Error: \(error.localizedDescription)")
-                }
-            }
-        }
-    }
-
     private func confirmSwitchMode() {
         let newMode = dbManager.dbMode == .production ? "TEST" : "PRODUCTION"
         let alert = NSAlert()
@@ -399,13 +368,6 @@ struct DatabaseManagementView: View {
 
     private var fileSizeString: String {
         ByteCountFormatter.string(fromByteCount: dbManager.dbFileSize, countStyle: .file)
-    }
-
-    private func appendReportLog(_ message: String) {
-        backupService.logMessages.insert(message, at: 0)
-        if backupService.logMessages.count > 10 {
-            backupService.logMessages = Array(backupService.logMessages.prefix(10))
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- disable Generate Full Instrument Report button with tooltip explaining script fix needed
- remove unused report generation logic

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68a21c2fe9ec83238028c86f5817156c