### PR TITLE
docs: use dbmate migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -467,6 +467,7 @@ All notable changes to this project will be documented in this file.
 - Show detailed Backup Summary and ensure restore logs publish on main thread
 - Keep original backup file by copying to a temporary location before atomic replace
 - Document python backup_restore script in README
+- Replace schema.sql references with dbmate migration instructions in README
 - Close SQLite connection before file moves and update dbVersion on main thread
 - Ensure published properties update on main thread and migrate onChange syntax
 - Distinct colors for each risk bucket segment and matching legend

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ DragonShield/
 ├── Views/                         # SwiftUI screens
 ├── Models/ & Services/            # Combine, data access
 ├── python_scripts/                # Parsers, analytics
-├── docs/                          # schema.sql, ADRs
+├── db/                            # database migrations (dbmate)
+├── docs/                          # documentation and ADRs
 ├── tests/                         # Unit & UI tests
 ├── README.md                      # This file
 └── LICENSE
@@ -96,9 +97,9 @@ DragonShield/
    ```
    All required packages are listed in `requirements.txt`.
 
-5. **Generate the local database**
+5. **Run database migrations**
    ```bash
-   python3 python_scripts/deploy_db.py
+   dbmate --migrations-dir DragonShield/db/migrations --url "sqlite:DragonShield/dragonshield.sqlite" up
    ```
 6. **Open the Xcode project**
    ```bash
@@ -116,18 +117,18 @@ DragonShield/
   - Primary database: `dragonshield.sqlite`
   - Test database: `dragonshield_test.sqlite`
   - Backup directory: `Dragonshield DB Backup` (full, reference and transaction backups)
-  - Generate the database with `python3 python_scripts/deploy_db.py`.
+  - Apply migrations with `dbmate --migrations-dir DragonShield/db/migrations --url "$DATABASE_URL" up`.
   - Full database backup/restore via `python3 python_scripts/backup_restore.py`
 - **Encryption**: SQLCipher (AES-256)
-- **Schema**: `docs/schema.sql`
+- **Migrations**: `DragonShield/db/migrations`
 - **Dev Key**: Temporary; do not use for production data
 
 ## Updating the Database
 
-Run the deploy script to rebuild the database from the schema and copy it to the container's Application Support folder. The script prints the schema version and final path:
+Run dbmate to apply migrations and copy the database to the container's Application Support folder. The command prints the applied versions and final path:
 
 ```bash
-python3 python_scripts/deploy_db.py
+dbmate --migrations-dir DragonShield/db/migrations --url "$DATABASE_URL" up
 ```
 
 ### ZKB CSV Import


### PR DESCRIPTION
## Summary
- document dbmate migrations in README
- note new dbmate usage in changelog

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68a21f9655f083238cb5cc518c4b3a41