### PR TITLE
docs: consolidate UI concept notes into guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Consolidate UI concept notes into the main UI/UX design guide
 - Disable Generate Full Instrument Report button with hover notice in Database Management view
 - Expand Backup & Restore log by default in Database Management view
 - Add button to validate Instruments in Database Management view

--- a/DragonShield/docs/UI-Concept.md
+++ b/DragonShield/docs/UI-Concept.md
@@ -1,8 +1,0 @@
-# UI Concept
-
-## Editing
-
-- Asset Class Allocation rows now include a persistent pencil button within the Target column.
-- Double-clicking a row or pressing **Enter** / **Space** when focused opens the Target-Editor directly below the row.
-- The active row highlights with a soft blue background while editing.
-- The editor now includes a field for tolerance percentage.

--- a/DragonShield/docs/UX_UI_concept/dragon_shield_ui_guide.md
+++ b/DragonShield/docs/UX_UI_concept/dragon_shield_ui_guide.md
@@ -97,6 +97,11 @@ Dragon Shield follows a **ZEN-minimalist** approach combined with Apple-native U
 - Strategy note field: Freeform markdown-style block
 - Price chart: Time-based with date ticks and hover tooltips
 - Key metrics: Position size, gain/loss, performance
+- Asset Class Allocation editing:
+  - Persistent pencil button in Target column for each row
+  - Double-click or Enter/Space when focused opens the Target-Editor beneath the row
+  - Active row highlights with a soft blue background during editing
+  - Target-Editor includes a tolerance percentage field
 
 ### 3. Transaction Log
 - Filters: Date / Asset / Type

--- a/DragonShield/docs/manifest.json
+++ b/DragonShield/docs/manifest.json
@@ -1,0 +1,12 @@
+{
+  "docs": [
+    {
+      "path": "UX_UI_concept/dragon_shield_ui_guide.md",
+      "sha": "c6cf9fc2053d2e97c29679ccfafa2f54496ba088"
+    },
+    {
+      "path": "logging_concept_dragonshield.md",
+      "sha": "afa4057bd725e4e8927eed15bc1cf485902ce5e0"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 Dragon Shield is a native macOS application for private investors to track, analyze and document all assets entirely offline. Every byte of financial data remains on your Mac, encrypted in a local database—no cloud, no telemetry.
 
 The app follows Apple's best-in-class UX conventions while embracing ZEN-minimalism for clarity and focus.
+For detailed interface guidelines, see the [Dragon Shield UI/UX Design Guide](DragonShield/docs/UX_UI_concept/dragon_shield_ui_guide.md).
 
 ## ✨ Key Features (End-Goal Vision)
 


### PR DESCRIPTION
## Summary
- merge UI-Concept into main UI/UX guide
- link README to consolidated guide
- track docs in manifest

## Testing
- `make setup` (fails: No rule to make target 'setup')
- `make fmt && make lint` (fails: No rule to make target 'fmt')
- `make migrate` (fails: No rule to make target 'migrate')
- `make build` (fails: No rule to make target 'build')
- `make test` (fails: No rule to make target 'test`)

------
https://chatgpt.com/codex/tasks/task_e_68a21f9c83908323b6a649ae25c3e16d