### PR TITLE
docs: update Credit-Suisse mapping and schema version

### DIFF
--- a/Archive/tests/test_schema_version.py
+++ b/Archive/tests/test_schema_version.py
@@ -8,4 +8,4 @@ from deploy_db import parse_version
 
 def test_schema_version_updated():
     schema_path = Path(__file__).resolve().parents[1] / 'DragonShield' / 'database' / 'schema.sql'
-    assert parse_version(str(schema_path)) == '4.24'
+    assert parse_version(str(schema_path)) == '4.25'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file.
 - Fix backup script to verify and close database before deleting corrupt backup
 - Remove legacy Asset Allocation view and navigation link
 - Polish target edit panel layout with fixed width and regrouped inputs for clarity
-- Expand target edit panel to 800×600 and allow dragging to reposition
+- Expand target edit panel to 800x600 and allow dragging to reposition
 - Fix optional class ID handling in target sum validation warnings
 - Persist parent class targets and warn on total allocation without blocking saves
 - Introduce ClassTargets and SubClassTargets tables with migration logging
@@ -38,6 +38,7 @@ All notable changes to this project will be documented in this file.
 - Redesign Asset Allocation dashboard with modern cards
 - Added persistent edit buttons & dbl-click shortcut for target rows (PR #XXX)
 - Target editor pops up below row with white background and tolerance field (PR #XXX)
+- Correct Credit-Suisse parser mapping docs to reference Credit-Suisse only, update schema version to 4.25, and align field mappings
 - Document Target Allocation edit panel workflow
 - Implement side-panel editor for Asset Class targets
 - Activate pencil edit button in Allocation Targets table
@@ -69,9 +70,9 @@ All notable changes to this project will be documented in this file.
 - Maintain equal margin around Asset-Class table to prevent bleed
 - Auto-scale Asset Classes columns proportionally when the card is resized
 - Optimise Asset Class tile layout and cap deviation bars in Allocation dashboard
-- Add fixed Δ column and abbreviated numbers in Asset Classes table
-- Fix Δ column layout to stay visible within Asset Classes card
-- Shrink table padding and correct column widths to keep Δ column visible
+- Add fixed delta column and abbreviated numbers in Asset Classes table
+- Fix delta column layout to stay visible within Asset Classes card
+- Shrink table padding and correct column widths to keep delta column visible
 - Add sidebar link to the Kanban board
 - Reorganize sidebar navigation with expandable sections and remove old transaction links
 - Combine Currencies and FX Rates maintenance into one tabbed view
@@ -237,7 +238,7 @@ All notable changes to this project will be documented in this file.
 - Fix redeclaration of `counts` in BackupService
 - Fix compile error when restoring reference data due to undefined `counts`
 - Increase Data Import/Export canvas size and anchor Statement Loading Log at the page bottom
-- Double Data Import/Export canvas to 1600×1200 and keep log pinned to the bottom
+- Double Data Import/Export canvas to 1600x1200 and keep log pinned to the bottom
 - Backup reference data separately via new UI button and CLI flag
 - Enforce three-zone layout on Data Import/Export screen with persistent status line
 - Resolve variable scoping issue in BackupService restore function


### PR DESCRIPTION
## Summary
- reference Credit-Suisse only in statement mapping docs
- bump schema version references to 4.25 and align Valor/cash mappings
- update schema version test

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68a21f9bac388323b266e3929b60a52a