### PR TITLE
feat: add portfolio theme status foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Consolidate UI concept notes into the main UI/UX design guide
 - Replace Database Management & Backups section with link to consolidated database documentation
 - Clarify PortfolioThemeStatus scope, color code validation, and default handling in portfolio module docs
+- Introduce PortfolioThemeStatus table with default statuses and basic management UI
 - Add search bar to Positions view to filter positions across all fields
 - Disable Generate Full Instrument Report button with hover notice in Database Management view
 - Expand Backup & Restore log by default in Database Management view

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Clarify PortfolioThemeStatus scope, color code validation, and default handling in portfolio module docs
 - Introduce PortfolioThemeStatus table with default statuses and basic management UI
 - Fix SQLITE_TRANSIENT compile error in PortfolioThemeStatus database helpers
+- Wrap PortfolioThemeStatus insert/update operations in transactions and log sqlite3_exec errors to preserve default integrity
 - Add search bar to Positions view to filter positions across all fields
 - Disable Generate Full Instrument Report button with hover notice in Database Management view
 - Expand Backup & Restore log by default in Database Management view

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - Introduce PortfolioThemeStatus table with default statuses and basic management UI
 - Fix SQLITE_TRANSIENT compile error in PortfolioThemeStatus database helpers
 - Wrap PortfolioThemeStatus insert/update operations in transactions and log sqlite3_exec errors to preserve default integrity
+- Harden PortfolioThemeStatus update transaction to rollback on commit failure
 - Add search bar to Positions view to filter positions across all fields
 - Disable Generate Full Instrument Report button with hover notice in Database Management view
 - Expand Backup & Restore log by default in Database Management view

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - Fix SQLITE_TRANSIENT compile error in PortfolioThemeStatus database helpers
 - Wrap PortfolioThemeStatus insert/update operations in transactions and log sqlite3_exec errors to preserve default integrity
 - Harden PortfolioThemeStatus update transaction to rollback on commit failure
+- Surface Theme Status save failures and handle default restoration errors
 - Add search bar to Positions view to filter positions across all fields
 - Disable Generate Full Instrument Report button with hover notice in Database Management view
 - Expand Backup & Restore log by default in Database Management view

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - Replace Database Management & Backups section with link to consolidated database documentation
 - Clarify PortfolioThemeStatus scope, color code validation, and default handling in portfolio module docs
 - Introduce PortfolioThemeStatus table with default statuses and basic management UI
+- Fix SQLITE_TRANSIENT compile error in PortfolioThemeStatus database helpers
 - Add search bar to Positions view to filter positions across all fields
 - Disable Generate Full Instrument Report button with hover notice in Database Management view
 - Expand Backup & Restore log by default in Database Management view

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - Wrap PortfolioThemeStatus insert/update operations in transactions and log sqlite3_exec errors to preserve default integrity
 - Harden PortfolioThemeStatus update transaction to rollback on commit failure
 - Surface Theme Status save failures and handle default restoration errors
+- Log default restoration as info to match OSLog levels
 - Add search bar to Positions view to filter positions across all fields
 - Disable Generate Full Instrument Report button with hover notice in Database Management view
 - Expand Backup & Restore log by default in Database Management view

--- a/DragonShield/DatabaseManager+PortfolioThemeStatus.swift
+++ b/DragonShield/DatabaseManager+PortfolioThemeStatus.swift
@@ -160,7 +160,7 @@ extension DatabaseManager {
         if count == 0 {
             let rc = sqlite3_exec(db, "UPDATE PortfolioThemeStatus SET is_default = 1 WHERE code = 'DRAFT'", nil, nil, nil)
             if rc == SQLITE_OK {
-                LoggingService.shared.log("Default theme status was missing and restored to Draft", type: .warning, logger: .database)
+                LoggingService.shared.log("Default theme status was missing and restored to Draft", type: .info, logger: .database)
             } else {
                 LoggingService.shared.log("Failed to restore default theme status: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
             }

--- a/DragonShield/DatabaseManager+PortfolioThemeStatus.swift
+++ b/DragonShield/DatabaseManager+PortfolioThemeStatus.swift
@@ -158,8 +158,12 @@ extension DatabaseManager {
         }
         sqlite3_finalize(stmt)
         if count == 0 {
-            sqlite3_exec(db, "UPDATE PortfolioThemeStatus SET is_default = 1 WHERE code = 'DRAFT'", nil, nil, nil)
-            LoggingService.shared.log("Default theme status was missing and restored to Draft", type: .error, logger: .database)
+            let rc = sqlite3_exec(db, "UPDATE PortfolioThemeStatus SET is_default = 1 WHERE code = 'DRAFT'", nil, nil, nil)
+            if rc == SQLITE_OK {
+                LoggingService.shared.log("Default theme status was missing and restored to Draft", type: .warning, logger: .database)
+            } else {
+                LoggingService.shared.log("Failed to restore default theme status: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            }
         }
     }
 }

--- a/DragonShield/DatabaseManager+PortfolioThemeStatus.swift
+++ b/DragonShield/DatabaseManager+PortfolioThemeStatus.swift
@@ -1,0 +1,109 @@
+// DragonShield/DatabaseManager+PortfolioThemeStatus.swift
+// MARK: - Version 1.0
+// MARK: - History
+// - Initial creation: CRUD helpers for PortfolioThemeStatus with default enforcement.
+
+import SQLite3
+import Foundation
+
+extension DatabaseManager {
+    func fetchPortfolioThemeStatuses() -> [PortfolioThemeStatus] {
+        var items: [PortfolioThemeStatus] = []
+        let sql = "SELECT id, code, name, color_hex, is_default FROM PortfolioThemeStatus ORDER BY id"
+        var stmt: OpaquePointer?
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                let id = Int(sqlite3_column_int(stmt, 0))
+                let code = String(cString: sqlite3_column_text(stmt, 1))
+                let name = String(cString: sqlite3_column_text(stmt, 2))
+                let color = String(cString: sqlite3_column_text(stmt, 3))
+                let isDefault = sqlite3_column_int(stmt, 4) == 1
+                items.append(PortfolioThemeStatus(id: id, code: code, name: name, colorHex: color, isDefault: isDefault))
+            }
+        } else {
+            LoggingService.shared.log("Failed to prepare fetchPortfolioThemeStatuses: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+        sqlite3_finalize(stmt)
+        return items
+    }
+
+    func insertPortfolioThemeStatus(code: String, name: String, colorHex: String, isDefault: Bool) -> Bool {
+        if isDefault {
+            sqlite3_exec(db, "UPDATE PortfolioThemeStatus SET is_default = 0 WHERE is_default = 1", nil, nil, nil)
+        }
+        let sql = "INSERT INTO PortfolioThemeStatus (code, name, color_hex, is_default) VALUES (?,?,?,?)"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            LoggingService.shared.log("prepare insertPortfolioThemeStatus failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            return false
+        }
+        sqlite3_bind_text(stmt, 1, code, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 2, name, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 3, colorHex, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_int(stmt, 4, isDefault ? 1 : 0)
+        defer { sqlite3_finalize(stmt) }
+        if sqlite3_step(stmt) == SQLITE_DONE {
+            LoggingService.shared.log("Inserted theme status \(code)", type: .info, logger: .database)
+            return true
+        } else {
+            LoggingService.shared.log("Insert theme status failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            return false
+        }
+    }
+
+    func updatePortfolioThemeStatus(id: Int, name: String, colorHex: String, isDefault: Bool) -> Bool {
+        if isDefault {
+            sqlite3_exec(db, "UPDATE PortfolioThemeStatus SET is_default = 0 WHERE is_default = 1", nil, nil, nil)
+        }
+        let sql = "UPDATE PortfolioThemeStatus SET name = ?, color_hex = ?, is_default = ? WHERE id = ?"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            LoggingService.shared.log("prepare updatePortfolioThemeStatus failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            return false
+        }
+        sqlite3_bind_text(stmt, 1, name, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 2, colorHex, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_int(stmt, 3, isDefault ? 1 : 0)
+        sqlite3_bind_int(stmt, 4, Int32(id))
+        defer { sqlite3_finalize(stmt) }
+        if sqlite3_step(stmt) == SQLITE_DONE {
+            LoggingService.shared.log("Updated theme status id=\(id)", type: .info, logger: .database)
+            return true
+        } else {
+            LoggingService.shared.log("Update theme status failed id=\(id): \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            return false
+        }
+    }
+
+    func setDefaultThemeStatus(id: Int) {
+        let sql = "UPDATE PortfolioThemeStatus SET is_default = CASE WHEN id = ? THEN 1 ELSE 0 END"
+        var stmt: OpaquePointer?
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            sqlite3_bind_int(stmt, 1, Int32(id))
+            if sqlite3_step(stmt) == SQLITE_DONE {
+                LoggingService.shared.log("Set default theme status id=\(id)", type: .info, logger: .database)
+            } else {
+                LoggingService.shared.log("Failed to set default theme status: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            }
+        } else {
+            LoggingService.shared.log("prepare setDefaultThemeStatus failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+        sqlite3_finalize(stmt)
+    }
+
+    func ensurePortfolioThemeStatusDefault() {
+        let sql = "SELECT COUNT(*) FROM PortfolioThemeStatus WHERE is_default = 1"
+        var stmt: OpaquePointer?
+        var count = 0
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                count = Int(sqlite3_column_int(stmt, 0))
+            }
+        }
+        sqlite3_finalize(stmt)
+        if count == 0 {
+            sqlite3_exec(db, "UPDATE PortfolioThemeStatus SET is_default = 1 WHERE code = 'DRAFT'", nil, nil, nil)
+            LoggingService.shared.log("Default theme status was missing and restored to Draft", type: .error, logger: .database)
+        }
+    }
+}

--- a/DragonShield/DatabaseManager+PortfolioThemeStatus.swift
+++ b/DragonShield/DatabaseManager+PortfolioThemeStatus.swift
@@ -37,11 +37,12 @@ extension DatabaseManager {
             LoggingService.shared.log("prepare insertPortfolioThemeStatus failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
             return false
         }
+        defer { sqlite3_finalize(stmt) }
+        let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
         sqlite3_bind_text(stmt, 1, code, -1, SQLITE_TRANSIENT)
         sqlite3_bind_text(stmt, 2, name, -1, SQLITE_TRANSIENT)
         sqlite3_bind_text(stmt, 3, colorHex, -1, SQLITE_TRANSIENT)
         sqlite3_bind_int(stmt, 4, isDefault ? 1 : 0)
-        defer { sqlite3_finalize(stmt) }
         if sqlite3_step(stmt) == SQLITE_DONE {
             LoggingService.shared.log("Inserted theme status \(code)", type: .info, logger: .database)
             return true
@@ -61,11 +62,12 @@ extension DatabaseManager {
             LoggingService.shared.log("prepare updatePortfolioThemeStatus failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
             return false
         }
+        defer { sqlite3_finalize(stmt) }
+        let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
         sqlite3_bind_text(stmt, 1, name, -1, SQLITE_TRANSIENT)
         sqlite3_bind_text(stmt, 2, colorHex, -1, SQLITE_TRANSIENT)
         sqlite3_bind_int(stmt, 3, isDefault ? 1 : 0)
         sqlite3_bind_int(stmt, 4, Int32(id))
-        defer { sqlite3_finalize(stmt) }
         if sqlite3_step(stmt) == SQLITE_DONE {
             LoggingService.shared.log("Updated theme status id=\(id)", type: .info, logger: .database)
             return true

--- a/DragonShield/DatabaseManager.swift
+++ b/DragonShield/DatabaseManager.swift
@@ -88,6 +88,7 @@ class DatabaseManager: ObservableObject {
         }
         
         openDatabase()
+        ensurePortfolioThemeStatusDefault()
         let version = loadConfiguration()
         self.dbVersion = version
         DispatchQueue.main.async { self.dbVersion = version }

--- a/DragonShield/Models/PortfolioThemeStatus.swift
+++ b/DragonShield/Models/PortfolioThemeStatus.swift
@@ -1,0 +1,28 @@
+// DragonShield/Models/PortfolioThemeStatus.swift
+// MARK: - Version 1.0
+// MARK: - History
+// - Initial creation: Represents status codes for portfolio themes.
+
+import Foundation
+
+struct PortfolioThemeStatus: Identifiable {
+    let id: Int
+    let code: String
+    var name: String
+    var colorHex: String
+    var isDefault: Bool
+
+    static func isValidCode(_ code: String) -> Bool {
+        let pattern = "^[A-Z][A-Z0-9_]{1,30}$"
+        return code.range(of: pattern, options: .regularExpression) != nil
+    }
+
+    static func isValidName(_ name: String) -> Bool {
+        return !name.isEmpty && name.count <= 64
+    }
+
+    static func isValidColor(_ hex: String) -> Bool {
+        let pattern = "^#[0-9A-Fa-f]{6}$"
+        return hex.range(of: pattern, options: .regularExpression) != nil
+    }
+}

--- a/DragonShield/Views/SettingsView.swift
+++ b/DragonShield/Views/SettingsView.swift
@@ -22,6 +22,9 @@ struct SettingsView: View {
     @AppStorage("runStartupHealthChecks")
     private var runStartupHealthChecks: Bool = true
 
+    @AppStorage(UserDefaultsKeys.portfolioThemesEnabled)
+    private var portfolioThemesEnabled: Bool = false
+
     private var okCount: Int {
         runner.reports.filter { if case .ok = $0.result { return true } else { return false } }.count
     }
@@ -119,6 +122,12 @@ struct SettingsView: View {
                     Text("\(okCount) ok / \(warningCount) warning / \(errorCount) error")
                 }
                 NavigationLink("Detailed Report", destination: HealthCheckResultsView())
+            }
+
+            if portfolioThemesEnabled {
+                Section(header: Text("Portfolio Management")) {
+                    NavigationLink("Theme Statuses", destination: ThemeStatusSettingsView().environmentObject(dbManager))
+                }
             }
 
             #if DEBUG

--- a/DragonShield/Views/ThemeStatusSettingsView.swift
+++ b/DragonShield/Views/ThemeStatusSettingsView.swift
@@ -1,0 +1,108 @@
+// DragonShield/Views/ThemeStatusSettingsView.swift
+// MARK: - Version 1.0
+// MARK: - History
+// - Initial creation: Manage PortfolioThemeStatus entries.
+
+import SwiftUI
+
+struct ThemeStatusSettingsView: View {
+    @EnvironmentObject var dbManager: DatabaseManager
+    @State private var statuses: [PortfolioThemeStatus] = []
+    @State private var editing: PortfolioThemeStatus?
+    @State private var isNew: Bool = false
+
+    var body: some View {
+        VStack {
+            List {
+                ForEach(statuses) { status in
+                    HStack {
+                        Text(status.code).frame(width: 80, alignment: .leading)
+                        Text(status.name).frame(width: 120, alignment: .leading)
+                        Text(status.colorHex).frame(width: 80, alignment: .leading)
+                        Spacer()
+                        Button(action: { dbManager.setDefaultThemeStatus(id: status.id); load() }) {
+                            Image(systemName: status.isDefault ? "largecircle.fill.circle" : "circle")
+                        }.buttonStyle(.plain)
+                        Button("Edit") {
+                            editing = status
+                            isNew = false
+                        }
+                    }
+                }
+            }
+            HStack {
+                Button("+ Add Status") {
+                    editing = PortfolioThemeStatus(id: 0, code: "", name: "", colorHex: "#000000", isDefault: false)
+                    isNew = true
+                }
+                Spacer()
+            }.padding()
+        }
+        .navigationTitle("Theme Statuses")
+        .onAppear(perform: load)
+        .sheet(item: $editing, onDismiss: load) { status in
+            ThemeStatusEditView(status: status, isNew: isNew) { updated in
+                if isNew {
+                    _ = dbManager.insertPortfolioThemeStatus(code: updated.code, name: updated.name, colorHex: updated.colorHex, isDefault: updated.isDefault)
+                } else {
+                    _ = dbManager.updatePortfolioThemeStatus(id: updated.id, name: updated.name, colorHex: updated.colorHex, isDefault: updated.isDefault)
+                }
+            }
+        }
+    }
+
+    private func load() {
+        statuses = dbManager.fetchPortfolioThemeStatuses()
+    }
+}
+
+struct ThemeStatusEditView: View {
+    @State var status: PortfolioThemeStatus
+    let isNew: Bool
+    var onSave: (PortfolioThemeStatus) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var code: String = ""
+    @State private var name: String = ""
+    @State private var color: String = ""
+    @State private var isDefault: Bool = false
+
+    var body: some View {
+        Form {
+            if isNew {
+                TextField("Code", text: $code)
+            } else {
+                Text("Code: \(status.code)")
+            }
+            TextField("Name", text: $name)
+            TextField("Color", text: $color)
+            Toggle("Default", isOn: $isDefault)
+            HStack {
+                Spacer()
+                Button("Save") {
+                    var updated = status
+                    updated.name = name
+                    updated.colorHex = color
+                    updated.isDefault = isDefault
+                    if isNew { updated = PortfolioThemeStatus(id: status.id, code: code.uppercased(), name: name, colorHex: color, isDefault: isDefault) }
+                    onSave(updated)
+                    dismiss()
+                }
+                .disabled(!valid)
+                Button("Cancel") { dismiss() }
+            }
+        }
+        .onAppear {
+            code = status.code
+            name = status.name
+            color = status.colorHex
+            isDefault = status.isDefault
+        }
+        .frame(minWidth: 300, minHeight: 200)
+    }
+
+    private var valid: Bool {
+        let codeOk = isNew ? PortfolioThemeStatus.isValidCode(code) : true
+        return codeOk && PortfolioThemeStatus.isValidName(name) && PortfolioThemeStatus.isValidColor(color)
+    }
+}

--- a/DragonShield/db/migrations/009_portfolio_theme_status.sql
+++ b/DragonShield/db/migrations/009_portfolio_theme_status.sql
@@ -1,0 +1,30 @@
+-- migrate:up
+-- Purpose: Introduce PortfolioThemeStatus table with default statuses.
+-- Assumptions: No existing PortfolioThemeStatus table; uses SQLite.
+-- Idempotency: Uses IF NOT EXISTS and INSERT OR IGNORE.
+
+CREATE TABLE IF NOT EXISTS PortfolioThemeStatus (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    code TEXT NOT NULL UNIQUE CHECK (code GLOB '[A-Z][A-Z0-9_]*'),
+    name TEXT NOT NULL UNIQUE,
+    color_hex TEXT NOT NULL CHECK (color_hex GLOB '#[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]'),
+    is_default BOOLEAN NOT NULL DEFAULT 0,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_portfolio_theme_status_default
+ON PortfolioThemeStatus(is_default) WHERE is_default = 1;
+
+INSERT OR IGNORE INTO PortfolioThemeStatus (code, name, color_hex, is_default) VALUES
+ ('DRAFT','Draft','#9AA0A6',1),
+ ('ACTIVE','Active','#34A853',0),
+ ('ARCHIVED','Archived','#B0BEC5',0);
+
+UPDATE PortfolioThemeStatus
+SET is_default = 1
+WHERE code = 'DRAFT'
+  AND NOT EXISTS (SELECT 1 FROM PortfolioThemeStatus WHERE is_default = 1);
+
+-- migrate:down
+DROP TABLE IF EXISTS PortfolioThemeStatus;

--- a/DragonShield/helpers/UserDefaultsKeys.swift
+++ b/DragonShield/helpers/UserDefaultsKeys.swift
@@ -21,4 +21,5 @@ struct UserDefaultsKeys {
     static let positionsFontSize = "positionsFontSize"
     /// Persist selected segment in Currencies & FX maintenance view.
     static let currenciesFxSegment = "currenciesFxSegment"
+    static let portfolioThemesEnabled = "portfolioThemesEnabled"
 }

--- a/DragonShieldTests/PortfolioThemeStatusTests.swift
+++ b/DragonShieldTests/PortfolioThemeStatusTests.swift
@@ -7,4 +7,15 @@ final class PortfolioThemeStatusTests: XCTestCase {
         XCTAssertFalse(PortfolioThemeStatus.isValidColor("#1234"))
         XCTAssertFalse(PortfolioThemeStatus.isValidColor("blue"))
     }
+
+    func testCodeValidation() {
+        XCTAssertTrue(PortfolioThemeStatus.isValidCode("VALID1"))
+        XCTAssertFalse(PortfolioThemeStatus.isValidCode("invalid"))
+    }
+
+    func testNameValidation() {
+        XCTAssertTrue(PortfolioThemeStatus.isValidName("Valid Name"))
+        XCTAssertFalse(PortfolioThemeStatus.isValidName(""))
+        XCTAssertFalse(PortfolioThemeStatus.isValidName(String(repeating: "a", count: 65)))
+    }
 }

--- a/DragonShieldTests/PortfolioThemeStatusTests.swift
+++ b/DragonShieldTests/PortfolioThemeStatusTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import DragonShield
+
+final class PortfolioThemeStatusTests: XCTestCase {
+    func testColorValidation() {
+        XCTAssertTrue(PortfolioThemeStatus.isValidColor("#A1B2C3"))
+        XCTAssertFalse(PortfolioThemeStatus.isValidColor("#1234"))
+        XCTAssertFalse(PortfolioThemeStatus.isValidColor("blue"))
+    }
+}


### PR DESCRIPTION
## Summary
- add PortfolioThemeStatus table and seed default statuses
- manage theme status settings under feature flag
- validate color hex format

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `dbmate --migrations-dir "/workspace/DragonShield/DragonShield/db/migrations" --url "$DATABASE_URL" status` *(fails: command not found: dbmate)*
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a36e8d32888323b8ceeff35b6e85f9