### PR TITLE
Fix theme creation persistence and dialog layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Persist newly created Portfolio Themes and refine theme editor layout
+- Add PortfolioTheme entity with CRUD UI and migration 010
+- Show Portfolio Themes navigation unconditionally in sidebar
+- Disable Performance and Rebalancing links in sidebar
 - Introduce HealthCheckRegistry for startup diagnostics with per-check configuration
 - Expose health check summary and toggle in Settings with link to detailed report
 - Show executed health checks with detailed results in dedicated window and verify database file presence

--- a/DragonShield/DatabaseManager+PortfolioThemes.swift
+++ b/DragonShield/DatabaseManager+PortfolioThemes.swift
@@ -1,0 +1,227 @@
+// DragonShield/DatabaseManager+PortfolioThemes.swift
+// MARK: - Version 1.0
+// MARK: - History
+// - Initial creation: CRUD helpers for PortfolioTheme.
+
+import SQLite3
+import Foundation
+
+extension DatabaseManager {
+    private func defaultThemeStatusId() -> Int? {
+        let sql = "SELECT id FROM PortfolioThemeStatus WHERE is_default = 1 LIMIT 1"
+        var stmt: OpaquePointer?
+        var result: Int?
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                result = Int(sqlite3_column_int(stmt, 0))
+            }
+        }
+        sqlite3_finalize(stmt)
+        return result
+    }
+
+    private func archivedThemeStatusId() -> Int? {
+        let sql = "SELECT id FROM PortfolioThemeStatus WHERE code = 'ARCHIVED' LIMIT 1"
+        var stmt: OpaquePointer?
+        var result: Int?
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                result = Int(sqlite3_column_int(stmt, 0))
+            }
+        }
+        sqlite3_finalize(stmt)
+        return result
+    }
+
+    func fetchPortfolioThemes(includeArchived: Bool = true, includeSoftDeleted: Bool = false, search: String? = nil) -> [PortfolioTheme] {
+        var themes: [PortfolioTheme] = []
+        var sql = "SELECT id,name,code,status_id,created_at,updated_at,archived_at,soft_delete FROM PortfolioTheme WHERE 1=1"
+        if !includeArchived { sql += " AND archived_at IS NULL" }
+        if !includeSoftDeleted { sql += " AND soft_delete = 0" }
+        if let s = search, !s.isEmpty {
+            sql += " AND (name LIKE ? OR code LIKE ?)"
+        }
+        sql += " ORDER BY updated_at DESC"
+        var stmt: OpaquePointer?
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            if let s = search, !s.isEmpty {
+                let like = "%" + s + "%"
+                let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+                sqlite3_bind_text(stmt, 1, like, -1, SQLITE_TRANSIENT)
+                sqlite3_bind_text(stmt, 2, like, -1, SQLITE_TRANSIENT)
+            }
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                let id = Int(sqlite3_column_int(stmt, 0))
+                let name = String(cString: sqlite3_column_text(stmt, 1))
+                let code = String(cString: sqlite3_column_text(stmt, 2))
+                let statusId = Int(sqlite3_column_int(stmt, 3))
+                let createdAt = String(cString: sqlite3_column_text(stmt, 4))
+                let updatedAt = String(cString: sqlite3_column_text(stmt, 5))
+                let archivedAt = sqlite3_column_text(stmt, 6).map { String(cString: $0) }
+                let softDelete = sqlite3_column_int(stmt, 7) == 1
+                themes.append(PortfolioTheme(id: id, name: name, code: code, statusId: statusId, createdAt: createdAt, updatedAt: updatedAt, archivedAt: archivedAt, softDelete: softDelete))
+            }
+        } else {
+            LoggingService.shared.log("Failed to prepare fetchPortfolioThemes: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+        sqlite3_finalize(stmt)
+        return themes
+    }
+
+    func createPortfolioTheme(name: String, code: String, statusId: Int? = nil) -> PortfolioTheme? {
+        guard PortfolioTheme.isValidName(name) else {
+            LoggingService.shared.log("Invalid theme name", type: .info, logger: .database)
+            return nil
+        }
+        guard PortfolioTheme.isValidCode(code) else {
+            LoggingService.shared.log("Invalid theme code", type: .info, logger: .database)
+            return nil
+        }
+        let status = statusId ?? defaultThemeStatusId()
+        guard let status = status else {
+            LoggingService.shared.log("No default Theme Status found", type: .error, logger: .database)
+            return nil
+        }
+        guard sqlite3_exec(db, "BEGIN IMMEDIATE", nil, nil, nil) == SQLITE_OK else {
+            LoggingService.shared.log("BEGIN createPortfolioTheme failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            return nil
+        }
+        let sql = "INSERT INTO PortfolioTheme (name, code, status_id) VALUES (?,?,?)"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            LoggingService.shared.log("prepare createPortfolioTheme failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            _ = sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
+            return nil
+        }
+        let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        sqlite3_bind_text(stmt, 1, name, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 2, code, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_int(stmt, 3, Int32(status))
+        if sqlite3_step(stmt) != SQLITE_DONE {
+            LoggingService.shared.log("createPortfolioTheme failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            sqlite3_finalize(stmt)
+            _ = sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
+            return nil
+        }
+        sqlite3_finalize(stmt)
+        guard sqlite3_exec(db, "COMMIT", nil, nil, nil) == SQLITE_OK else {
+            LoggingService.shared.log("COMMIT createPortfolioTheme failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            _ = sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
+            return nil
+        }
+        let id = Int(sqlite3_last_insert_rowid(db))
+        LoggingService.shared.log("Created theme id=\(id)", type: .info, logger: .database)
+        return getPortfolioTheme(id: id)
+    }
+
+    func getPortfolioTheme(id: Int) -> PortfolioTheme? {
+        let sql = "SELECT id,name,code,status_id,created_at,updated_at,archived_at,soft_delete FROM PortfolioTheme WHERE id = ?"
+        var stmt: OpaquePointer?
+        var theme: PortfolioTheme?
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            sqlite3_bind_int(stmt, 1, Int32(id))
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                let id = Int(sqlite3_column_int(stmt, 0))
+                let name = String(cString: sqlite3_column_text(stmt, 1))
+                let code = String(cString: sqlite3_column_text(stmt, 2))
+                let statusId = Int(sqlite3_column_int(stmt, 3))
+                let createdAt = String(cString: sqlite3_column_text(stmt, 4))
+                let updatedAt = String(cString: sqlite3_column_text(stmt, 5))
+                let archivedAt = sqlite3_column_text(stmt, 6).map { String(cString: $0) }
+                let softDelete = sqlite3_column_int(stmt, 7) == 1
+                theme = PortfolioTheme(id: id, name: name, code: code, statusId: statusId, createdAt: createdAt, updatedAt: updatedAt, archivedAt: archivedAt, softDelete: softDelete)
+            }
+        }
+        sqlite3_finalize(stmt)
+        return theme
+    }
+
+    func updatePortfolioTheme(id: Int, name: String, statusId: Int, archivedAt: String?) -> Bool {
+        let sql = "UPDATE PortfolioTheme SET name = ?, status_id = ?, archived_at = ?, updated_at = STRFTIME('%Y-%m-%dT%H:%M:%fZ','now') WHERE id = ?"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            LoggingService.shared.log("prepare updatePortfolioTheme failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            return false
+        }
+        let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        sqlite3_bind_text(stmt, 1, name, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_int(stmt, 2, Int32(statusId))
+        if let archivedAt = archivedAt {
+            sqlite3_bind_text(stmt, 3, archivedAt, -1, SQLITE_TRANSIENT)
+        } else {
+            sqlite3_bind_null(stmt, 3)
+        }
+        sqlite3_bind_int(stmt, 4, Int32(id))
+        let rc = sqlite3_step(stmt)
+        sqlite3_finalize(stmt)
+        if rc == SQLITE_DONE {
+            LoggingService.shared.log("Updated theme id=\(id)", type: .info, logger: .database)
+            return true
+        } else {
+            LoggingService.shared.log("updatePortfolioTheme failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            return false
+        }
+    }
+
+    func archivePortfolioTheme(id: Int) -> Bool {
+        guard let archivedId = archivedThemeStatusId() else { return false }
+        let sql = "UPDATE PortfolioTheme SET status_id = ?, archived_at = STRFTIME('%Y-%m-%dT%H:%M:%fZ','now'), updated_at = STRFTIME('%Y-%m-%dT%H:%M:%fZ','now') WHERE id = ?"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return false }
+        sqlite3_bind_int(stmt, 1, Int32(archivedId))
+        sqlite3_bind_int(stmt, 2, Int32(id))
+        let rc = sqlite3_step(stmt)
+        sqlite3_finalize(stmt)
+        if rc == SQLITE_DONE {
+            LoggingService.shared.log("Archived theme id=\(id)", type: .info, logger: .database)
+            return true
+        }
+        LoggingService.shared.log("archivePortfolioTheme failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        return false
+    }
+
+    func unarchivePortfolioTheme(id: Int, statusId: Int) -> Bool {
+        let sql = "UPDATE PortfolioTheme SET status_id = ?, archived_at = NULL, updated_at = STRFTIME('%Y-%m-%dT%H:%M:%fZ','now') WHERE id = ?"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return false }
+        sqlite3_bind_int(stmt, 1, Int32(statusId))
+        sqlite3_bind_int(stmt, 2, Int32(id))
+        let rc = sqlite3_step(stmt)
+        sqlite3_finalize(stmt)
+        if rc == SQLITE_DONE {
+            LoggingService.shared.log("Unarchived theme id=\(id)", type: .info, logger: .database)
+            return true
+        }
+        LoggingService.shared.log("unarchivePortfolioTheme failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        return false
+    }
+
+    func softDeletePortfolioTheme(id: Int) -> Bool {
+        let checkSql = "SELECT archived_at FROM PortfolioTheme WHERE id = ?"
+        var checkStmt: OpaquePointer?
+        var archived: Bool = false
+        if sqlite3_prepare_v2(db, checkSql, -1, &checkStmt, nil) == SQLITE_OK {
+            sqlite3_bind_int(checkStmt, 1, Int32(id))
+            if sqlite3_step(checkStmt) == SQLITE_ROW {
+                archived = sqlite3_column_text(checkStmt, 0) != nil
+            }
+        }
+        sqlite3_finalize(checkStmt)
+        if !archived {
+            LoggingService.shared.log("Soft delete requires the theme to be Archived first.", type: .info, logger: .database)
+            return false
+        }
+        let sql = "UPDATE PortfolioTheme SET soft_delete = 1, updated_at = STRFTIME('%Y-%m-%dT%H:%M:%fZ','now') WHERE id = ?"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return false }
+        sqlite3_bind_int(stmt, 1, Int32(id))
+        let rc = sqlite3_step(stmt)
+        sqlite3_finalize(stmt)
+        if rc == SQLITE_DONE {
+            LoggingService.shared.log("Soft deleted theme id=\(id)", type: .info, logger: .database)
+            return true
+        }
+        LoggingService.shared.log("softDeletePortfolioTheme failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        return false
+    }
+}

--- a/DragonShield/Models/PortfolioTheme.swift
+++ b/DragonShield/Models/PortfolioTheme.swift
@@ -1,0 +1,26 @@
+// DragonShield/Models/PortfolioTheme.swift
+// MARK: - Version 1.0
+// MARK: - History
+// - Initial creation: Represents user-defined portfolio themes.
+
+import Foundation
+
+struct PortfolioTheme: Identifiable {
+    let id: Int
+    var name: String
+    let code: String
+    var statusId: Int
+    var createdAt: String
+    var updatedAt: String
+    var archivedAt: String?
+    var softDelete: Bool
+
+    static func isValidName(_ name: String) -> Bool {
+        return !name.isEmpty && name.count <= 64
+    }
+
+    static func isValidCode(_ code: String) -> Bool {
+        let pattern = "^[A-Z][A-Z0-9_]{1,30}$"
+        return code.range(of: pattern, options: .regularExpression) != nil
+    }
+}

--- a/DragonShield/Views/PortfolioThemeDetailView.swift
+++ b/DragonShield/Views/PortfolioThemeDetailView.swift
@@ -1,0 +1,94 @@
+// DragonShield/Views/PortfolioThemeDetailView.swift
+// MARK: - Version 1.0
+// MARK: - History
+// - Initial creation: Edit view for PortfolioTheme.
+
+import SwiftUI
+
+struct PortfolioThemeDetailView: View {
+    @EnvironmentObject var dbManager: DatabaseManager
+    @State var theme: PortfolioTheme
+    let isNew: Bool
+    var onSave: (PortfolioTheme) -> Void
+    var onArchive: () -> Void
+    var onUnarchive: (Int) -> Void
+    var onSoftDelete: () -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var name: String = ""
+    @State private var code: String = ""
+    @State private var statusId: Int = 0
+    @State private var statuses: [PortfolioThemeStatus] = []
+
+    var body: some View {
+        Form {
+            Section {
+                TextField("Name", text: $name)
+                    .textFieldStyle(.roundedBorder)
+                if isNew {
+                    TextField("Code", text: $code)
+                        .textFieldStyle(.roundedBorder)
+                        .textInputAutocapitalization(.characters)
+                } else {
+                    Text("Code: \(theme.code)")
+                }
+                Picker("Status", selection: $statusId) {
+                    ForEach(statuses) { status in
+                        Text(status.name).tag(status.id)
+                    }
+                }
+                Text("Archived at: \(theme.archivedAt ?? "—")")
+            }
+            if !isNew {
+                Section("Danger Zone") {
+                    if theme.archivedAt == nil {
+                        Button("Archive Theme") {
+                            onArchive()
+                            dismiss()
+                        }
+                    } else {
+                        Button("Unarchive") {
+                            let defaultStatus = statuses.first { $0.isDefault }?.id ?? statusId
+                            onUnarchive(defaultStatus)
+                            dismiss()
+                        }
+                        Button("Soft Delete") {
+                            onSoftDelete()
+                            dismiss()
+                        }
+                    }
+                }
+            }
+            Section {
+                HStack {
+                    Spacer()
+                    Button("Save") {
+                        var updated = theme
+                        if isNew {
+                            updated = PortfolioTheme(id: 0, name: name, code: code.uppercased(), statusId: statusId, createdAt: "", updatedAt: "", archivedAt: nil, softDelete: false)
+                        } else {
+                            updated.name = name
+                            updated.statusId = statusId
+                        }
+                        onSave(updated)
+                        dismiss()
+                    }.disabled(!valid)
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+        .frame(minWidth: 480, minHeight: 360)
+        .onAppear {
+            statuses = dbManager.fetchPortfolioThemeStatuses()
+            name = theme.name
+            code = theme.code
+            statusId = theme.statusId
+        }
+    }
+
+    private var valid: Bool {
+        let nameOk = PortfolioTheme.isValidName(name)
+        let codeOk = isNew ? PortfolioTheme.isValidCode(code.uppercased()) : true
+        return nameOk && codeOk
+    }
+}

--- a/DragonShield/Views/PortfolioThemesListView.swift
+++ b/DragonShield/Views/PortfolioThemesListView.swift
@@ -1,0 +1,115 @@
+// DragonShield/Views/PortfolioThemesListView.swift
+// MARK: - Version 1.0
+// MARK: - History
+// - Initial creation: List and manage PortfolioTheme records.
+
+import SwiftUI
+
+struct PortfolioThemesListView: View {
+    @EnvironmentObject var dbManager: DatabaseManager
+    @State private var themes: [PortfolioTheme] = []
+    @State private var editing: PortfolioTheme?
+    @State private var isNew: Bool = false
+    @State private var showErrorAlert = false
+    @State private var errorMessage = ""
+
+    var body: some View {
+        VStack {
+            List {
+                ForEach(themes) { theme in
+                    HStack {
+                        Text(theme.name).frame(width: 160, alignment: .leading)
+                        Text(theme.code).frame(width: 120, alignment: .leading)
+                        Text(statusName(theme.statusId)).frame(width: 80, alignment: .leading)
+                        Text(theme.updatedAt).frame(width: 180, alignment: .leading)
+                        Spacer()
+                        Button("Open") { editing = theme; isNew = false }
+                        if theme.archivedAt == nil {
+                            Button("Archive") {
+                                if !dbManager.archivePortfolioTheme(id: theme.id) {
+                                    errorMessage = "Failed to archive theme"
+                                    showErrorAlert = true
+                                }
+                                load()
+                            }
+                        } else {
+                            Button("Unarchive") {
+                                let defaultStatus = dbManager.fetchPortfolioThemeStatuses().first { $0.isDefault }?.id ?? theme.statusId
+                                if !dbManager.unarchivePortfolioTheme(id: theme.id, statusId: defaultStatus) {
+                                    errorMessage = "Failed to unarchive theme"
+                                    showErrorAlert = true
+                                }
+                                load()
+                            }
+                        }
+                    }
+                }
+            }
+            HStack {
+                Button("+ New Theme") {
+                    let defaultStatus = dbManager.fetchPortfolioThemeStatuses().first { $0.isDefault }?.id ?? 0
+                    editing = PortfolioTheme(id: 0, name: "", code: "", statusId: defaultStatus, createdAt: "", updatedAt: "", archivedAt: nil, softDelete: false)
+                    isNew = true
+                }
+                Spacer()
+            }.padding()
+        }
+        .navigationTitle("Portfolio Themes")
+        .onAppear(perform: load)
+        .sheet(item: $editing, onDismiss: load) { theme in
+            PortfolioThemeDetailView(theme: theme, isNew: isNew) { updated in
+                var ok = true
+                if isNew {
+                    ok = dbManager.createPortfolioTheme(name: updated.name, code: updated.code, statusId: updated.statusId) != nil
+                } else {
+                    ok = dbManager.updatePortfolioTheme(id: updated.id, name: updated.name, statusId: updated.statusId, archivedAt: updated.archivedAt)
+                }
+                if ok {
+                    load()
+                } else {
+                    errorMessage = isNew ? "Failed to create theme" : "Failed to update theme"
+                    showErrorAlert = true
+                }
+                editing = nil
+                isNew = false
+            } onArchive: {
+                if !dbManager.archivePortfolioTheme(id: theme.id) {
+                    errorMessage = "Failed to archive theme"
+                    showErrorAlert = true
+                }
+                load()
+                editing = nil
+                isNew = false
+            } onUnarchive: { statusId in
+                if !dbManager.unarchivePortfolioTheme(id: theme.id, statusId: statusId) {
+                    errorMessage = "Failed to unarchive theme"
+                    showErrorAlert = true
+                }
+                load()
+                editing = nil
+                isNew = false
+            } onSoftDelete: {
+                if !dbManager.softDeletePortfolioTheme(id: theme.id) {
+                    errorMessage = "Failed to soft delete theme"
+                    showErrorAlert = true
+                }
+                load()
+                editing = nil
+                isNew = false
+            }
+        }
+        .alert("Database Error", isPresented: $showErrorAlert) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(errorMessage)
+        }
+    }
+
+    private func load() {
+        themes = dbManager.fetchPortfolioThemes(includeArchived: true, includeSoftDeleted: false, search: nil)
+    }
+
+    private func statusName(_ id: Int) -> String {
+        dbManager.fetchPortfolioThemeStatuses().first { $0.id == id }?.name ?? "-"
+    }
+}

--- a/DragonShield/Views/SidebarView.swift
+++ b/DragonShield/Views/SidebarView.swift
@@ -32,7 +32,9 @@ struct SidebarView: View {
 
                 NavigationLink(destination: PerformanceView()) {
                     Label("Performance", systemImage: "chart.bar.fill")
+                        .foregroundColor(.gray)
                 }
+                .disabled(true)
             }
 
             DisclosureGroup("Management", isExpanded: $showManagement) {
@@ -42,10 +44,16 @@ struct SidebarView: View {
 
                 NavigationLink(destination: RebalancingView()) {
                     Label("Rebalancing", systemImage: "arrow.left.arrow.right")
+                        .foregroundColor(.gray)
                 }
+                .disabled(true)
 
                 NavigationLink(destination: ToDoKanbanView()) {
                     Label("To-Do Board", systemImage: "checklist")
+                }
+
+                NavigationLink(destination: PortfolioThemesListView().environmentObject(dbManager)) {
+                    Label("Portfolio Themes", systemImage: "list.bullet")
                 }
             }
 

--- a/DragonShield/db/migrations/010_portfolio_theme.sql
+++ b/DragonShield/db/migrations/010_portfolio_theme.sql
@@ -1,0 +1,26 @@
+-- migrate:up
+-- Purpose: Introduce PortfolioTheme table to store user-defined portfolio themes.
+-- Assumptions: PortfolioThemeStatus table exists with default rows; SQLite database.
+-- Idempotency: Uses IF NOT EXISTS and partial unique indexes.
+
+CREATE TABLE IF NOT EXISTS PortfolioTheme (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL CHECK (LENGTH(name) BETWEEN 1 AND 64),
+    code TEXT NOT NULL CHECK (code GLOB '[A-Z][A-Z0-9_]*' AND LENGTH(code) BETWEEN 2 AND 31),
+    status_id INTEGER NOT NULL REFERENCES PortfolioThemeStatus(id),
+    created_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
+    updated_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
+    archived_at TEXT NULL,
+    soft_delete INTEGER NOT NULL DEFAULT 0 CHECK (soft_delete IN (0,1))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_portfolio_theme_name_unique
+ON PortfolioTheme(LOWER(name))
+WHERE soft_delete = 0;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_portfolio_theme_code_unique
+ON PortfolioTheme(LOWER(code))
+WHERE soft_delete = 0;
+
+-- migrate:down
+DROP TABLE IF EXISTS PortfolioTheme;

--- a/DragonShieldTests/PortfolioThemeTests.swift
+++ b/DragonShieldTests/PortfolioThemeTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import DragonShield
+
+final class PortfolioThemeTests: XCTestCase {
+    func testCodeValidation() {
+        XCTAssertTrue(PortfolioTheme.isValidCode("THEME_1"))
+        XCTAssertFalse(PortfolioTheme.isValidCode("theme"))
+    }
+
+    func testNameValidation() {
+        XCTAssertTrue(PortfolioTheme.isValidName("Core Growth"))
+        XCTAssertFalse(PortfolioTheme.isValidName(""))
+    }
+}


### PR DESCRIPTION
## Summary
- ensure Portfolio Theme creations persist and surface DB failures
- polish theme editor sheet layout for readability

## Testing
- `make setup` (fails: No rule to make target 'setup')
- `make fmt && make lint` (fails: No rule to make target 'fmt')
- `make migrate` (fails: No rule to make target 'migrate')
- `make build` (fails: No rule to make target 'build')
- `make test` (fails: No rule to make target 'test')
- `swift test` (fails: Could not find Package.swift)


------
https://chatgpt.com/codex/tasks/task_e_68a40100491483239dcd53130900aa77