### PR TITLE
feat(theme): enable navigation to detail view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,12 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Introduce PortfolioThemeAsset table linking themes to instruments with target allocations
 - Add PortfolioTheme entity with CRUD UI and migration 010
 - Fix Portfolio Theme creation to persist database records and improve new theme editor layout
 - Show Portfolio Themes navigation unconditionally in sidebar
+- Navigate from Portfolio Themes list to detail view with keyboard, icon, or context menu; archived themes open read-only and link remains feature-flagged
+- Open Theme details with double-click or Return using supported SwiftUI APIs
 - Disable Performance and Rebalancing links in sidebar
 - Ensure new theme popup accepts a theme code and disable Save until required fields are valid
 - Introduce HealthCheckRegistry for startup diagnostics with per-check configuration

--- a/DragonShield/DatabaseManager+PortfolioThemeAssets.swift
+++ b/DragonShield/DatabaseManager+PortfolioThemeAssets.swift
@@ -1,0 +1,196 @@
+import Foundation
+import SQLite3
+
+extension DatabaseManager {
+    func ensurePortfolioThemeAssetTable() {
+        let sql = """
+        CREATE TABLE IF NOT EXISTS PortfolioThemeAsset (
+            theme_id INTEGER NOT NULL REFERENCES PortfolioTheme(id) ON DELETE RESTRICT,
+            instrument_id INTEGER NOT NULL REFERENCES Instruments(instrument_id) ON DELETE RESTRICT,
+            research_target_pct REAL NOT NULL DEFAULT 0.0 CHECK (research_target_pct >= 0.0 AND research_target_pct <= 100.0),
+            user_target_pct REAL NOT NULL DEFAULT 0.0 CHECK (user_target_pct >= 0.0 AND user_target_pct <= 100.0),
+            notes TEXT NULL,
+            created_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
+            updated_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
+            PRIMARY KEY (theme_id, instrument_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_theme_asset_instrument ON PortfolioThemeAsset(instrument_id);
+        """
+        if sqlite3_exec(db, sql, nil, nil, nil) != SQLITE_OK {
+            LoggingService.shared.log("ensurePortfolioThemeAssetTable failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+    }
+
+    private func themeEditable(themeId: Int) -> Bool {
+        let sql = "SELECT archived_at, soft_delete FROM PortfolioTheme WHERE id = ?"
+        var stmt: OpaquePointer?
+        var ok = false
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            sqlite3_bind_int(stmt, 1, Int32(themeId))
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                let archived = sqlite3_column_text(stmt, 0)
+                let softDelete = sqlite3_column_int(stmt, 1) == 1
+                ok = archived == nil && !softDelete
+            }
+        }
+        sqlite3_finalize(stmt)
+        return ok
+    }
+
+    private func instrumentExists(_ instrumentId: Int) -> Bool {
+        let sql = "SELECT 1 FROM Instruments WHERE instrument_id = ? LIMIT 1"
+        var stmt: OpaquePointer?
+        var exists = false
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            sqlite3_bind_int(stmt, 1, Int32(instrumentId))
+            exists = sqlite3_step(stmt) == SQLITE_ROW
+        }
+        sqlite3_finalize(stmt)
+        return exists
+    }
+
+    func createThemeAsset(themeId: Int, instrumentId: Int, researchPct: Double, userPct: Double? = nil, notes: String? = nil) -> PortfolioThemeAsset? {
+        guard PortfolioThemeAsset.isValidPercentage(researchPct),
+              PortfolioThemeAsset.isValidPercentage(userPct ?? researchPct) else {
+            LoggingService.shared.log("Invalid percentage bounds", type: .info, logger: .database)
+            return nil
+        }
+        guard themeEditable(themeId: themeId) else {
+            LoggingService.shared.log("Theme \(themeId) not editable", type: .info, logger: .database)
+            return nil
+        }
+        guard instrumentExists(instrumentId) else {
+            LoggingService.shared.log("Instrument \(instrumentId) missing", type: .info, logger: .database)
+            return nil
+        }
+        let uPct = userPct ?? researchPct
+        let sql = """
+            INSERT INTO PortfolioThemeAsset (theme_id, instrument_id, research_target_pct, user_target_pct, notes)
+            VALUES (?,?,?,?,?)
+        """
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            LoggingService.shared.log("prepare createThemeAsset failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            return nil
+        }
+        sqlite3_bind_int(stmt, 1, Int32(themeId))
+        sqlite3_bind_int(stmt, 2, Int32(instrumentId))
+        sqlite3_bind_double(stmt, 3, researchPct)
+        sqlite3_bind_double(stmt, 4, uPct)
+        if let notes = notes {
+            let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+            sqlite3_bind_text(stmt, 5, notes, -1, SQLITE_TRANSIENT)
+        } else {
+            sqlite3_bind_null(stmt, 5)
+        }
+        if sqlite3_step(stmt) != SQLITE_DONE {
+            LoggingService.shared.log("createThemeAsset failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            sqlite3_finalize(stmt)
+            return nil
+        }
+        sqlite3_finalize(stmt)
+        return getThemeAsset(themeId: themeId, instrumentId: instrumentId)
+    }
+
+    func getThemeAsset(themeId: Int, instrumentId: Int) -> PortfolioThemeAsset? {
+        let sql = """
+            SELECT theme_id, instrument_id, research_target_pct, user_target_pct, notes, created_at, updated_at
+            FROM PortfolioThemeAsset WHERE theme_id = ? AND instrument_id = ?
+        """
+        var stmt: OpaquePointer?
+        var asset: PortfolioThemeAsset?
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            sqlite3_bind_int(stmt, 1, Int32(themeId))
+            sqlite3_bind_int(stmt, 2, Int32(instrumentId))
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                let themeId = Int(sqlite3_column_int(stmt, 0))
+                let instrId = Int(sqlite3_column_int(stmt, 1))
+                let research = sqlite3_column_double(stmt, 2)
+                let user = sqlite3_column_double(stmt, 3)
+                let notes = sqlite3_column_text(stmt, 4).map { String(cString: $0) }
+                let createdAt = String(cString: sqlite3_column_text(stmt, 5))
+                let updatedAt = String(cString: sqlite3_column_text(stmt, 6))
+                asset = PortfolioThemeAsset(themeId: themeId, instrumentId: instrId, researchTargetPct: research, userTargetPct: user, notes: notes, createdAt: createdAt, updatedAt: updatedAt)
+            }
+        }
+        sqlite3_finalize(stmt)
+        return asset
+    }
+
+    func listThemeAssets(themeId: Int) -> [PortfolioThemeAsset] {
+        var assets: [PortfolioThemeAsset] = []
+        let sql = """
+            SELECT theme_id, instrument_id, research_target_pct, user_target_pct, notes, created_at, updated_at
+            FROM PortfolioThemeAsset WHERE theme_id = ? ORDER BY instrument_id
+        """
+        var stmt: OpaquePointer?
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            sqlite3_bind_int(stmt, 1, Int32(themeId))
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                let themeId = Int(sqlite3_column_int(stmt, 0))
+                let instrId = Int(sqlite3_column_int(stmt, 1))
+                let research = sqlite3_column_double(stmt, 2)
+                let user = sqlite3_column_double(stmt, 3)
+                let notes = sqlite3_column_text(stmt, 4).map { String(cString: $0) }
+                let createdAt = String(cString: sqlite3_column_text(stmt, 5))
+                let updatedAt = String(cString: sqlite3_column_text(stmt, 6))
+                assets.append(PortfolioThemeAsset(themeId: themeId, instrumentId: instrId, researchTargetPct: research, userTargetPct: user, notes: notes, createdAt: createdAt, updatedAt: updatedAt))
+            }
+        }
+        sqlite3_finalize(stmt)
+        return assets
+    }
+
+    func updateThemeAsset(themeId: Int, instrumentId: Int, researchPct: Double?, userPct: Double?, notes: String?) -> PortfolioThemeAsset? {
+        guard themeEditable(themeId: themeId) else {
+            LoggingService.shared.log("Theme \(themeId) not editable", type: .info, logger: .database)
+            return nil
+        }
+        if let r = researchPct, !PortfolioThemeAsset.isValidPercentage(r) { return nil }
+        if let u = userPct, !PortfolioThemeAsset.isValidPercentage(u) { return nil }
+        let sql = """
+            UPDATE PortfolioThemeAsset
+            SET research_target_pct = COALESCE(?, research_target_pct),
+                user_target_pct = COALESCE(?, user_target_pct),
+                notes = ?,
+                updated_at = STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')
+            WHERE theme_id = ? AND instrument_id = ?
+        """
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            return nil
+        }
+        if let r = researchPct { sqlite3_bind_double(stmt, 1, r) } else { sqlite3_bind_null(stmt, 1) }
+        if let u = userPct { sqlite3_bind_double(stmt, 2, u) } else { sqlite3_bind_null(stmt, 2) }
+        if let notes = notes {
+            let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+            sqlite3_bind_text(stmt, 3, notes, -1, SQLITE_TRANSIENT)
+        } else {
+            sqlite3_bind_null(stmt, 3)
+        }
+        sqlite3_bind_int(stmt, 4, Int32(themeId))
+        sqlite3_bind_int(stmt, 5, Int32(instrumentId))
+        guard sqlite3_step(stmt) == SQLITE_DONE else {
+            LoggingService.shared.log("updateThemeAsset failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            sqlite3_finalize(stmt)
+            return nil
+        }
+        sqlite3_finalize(stmt)
+        return getThemeAsset(themeId: themeId, instrumentId: instrumentId)
+    }
+
+    func removeThemeAsset(themeId: Int, instrumentId: Int) -> Bool {
+        guard themeEditable(themeId: themeId) else {
+            LoggingService.shared.log("Theme \(themeId) not editable", type: .info, logger: .database)
+            return false
+        }
+        let sql = "DELETE FROM PortfolioThemeAsset WHERE theme_id = ? AND instrument_id = ?"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return false }
+        sqlite3_bind_int(stmt, 1, Int32(themeId))
+        sqlite3_bind_int(stmt, 2, Int32(instrumentId))
+        let ok = sqlite3_step(stmt) == SQLITE_DONE
+        sqlite3_finalize(stmt)
+        return ok
+    }
+}

--- a/DragonShield/DatabaseManager+PortfolioThemes.swift
+++ b/DragonShield/DatabaseManager+PortfolioThemes.swift
@@ -122,7 +122,7 @@ extension DatabaseManager {
     }
 
     func getPortfolioTheme(id: Int) -> PortfolioTheme? {
-        let sql = "SELECT id,name,code,status_id,created_at,updated_at,archived_at,soft_delete FROM PortfolioTheme WHERE id = ?"
+        let sql = "SELECT id,name,code,status_id,created_at,updated_at,archived_at,soft_delete FROM PortfolioTheme WHERE id = ? AND soft_delete = 0"
         var stmt: OpaquePointer?
         var theme: PortfolioTheme?
         if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {

--- a/DragonShield/DatabaseManager.swift
+++ b/DragonShield/DatabaseManager.swift
@@ -90,6 +90,7 @@ class DatabaseManager: ObservableObject {
         openDatabase()
         ensurePortfolioThemeStatusDefault()
         ensurePortfolioThemeTable()
+        ensurePortfolioThemeAssetTable()
         let version = loadConfiguration()
         self.dbVersion = version
         DispatchQueue.main.async { self.dbVersion = version }

--- a/DragonShield/Models/PortfolioThemeAsset.swift
+++ b/DragonShield/Models/PortfolioThemeAsset.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+// Represents a link between a portfolio theme and an instrument with target allocations.
+struct PortfolioThemeAsset: Identifiable, Hashable {
+    let themeId: Int
+    let instrumentId: Int
+    var researchTargetPct: Double
+    var userTargetPct: Double
+    var notes: String?
+    var createdAt: String
+    var updatedAt: String
+
+    var id: Int { instrumentId }
+
+    static func isValidPercentage(_ value: Double) -> Bool {
+        value >= 0.0 && value <= 100.0
+    }
+}

--- a/DragonShield/Views/PortfolioThemeDetailView.swift
+++ b/DragonShield/Views/PortfolioThemeDetailView.swift
@@ -1,95 +1,210 @@
 // DragonShield/Views/PortfolioThemeDetailView.swift
-// MARK: - Version 1.0
+// MARK: - Version 1.2
 // MARK: - History
-// - Initial creation: Edit view for PortfolioTheme.
+// - 1.1 -> 1.2: Allow navigation via themeId, fetch fresh data, handle archived/read-only and soft-deleted themes.
 
 import SwiftUI
 
 struct PortfolioThemeDetailView: View {
     @EnvironmentObject var dbManager: DatabaseManager
-    @State var theme: PortfolioTheme
-    let isNew: Bool
-    var onSave: (PortfolioTheme) -> Void
-    var onArchive: () -> Void
-    var onUnarchive: (Int) -> Void
-    var onSoftDelete: () -> Void
+    let themeId: Int
+    let origin: String
+    var onSave: (PortfolioTheme) -> Void = { _ in }
+    var onArchive: () -> Void = {}
+    var onUnarchive: (Int) -> Void = { _ in }
+    var onSoftDelete: () -> Void = {}
     @Environment(\.dismiss) private var dismiss
 
+    @State private var theme: PortfolioTheme?
     @State private var name: String = ""
     @State private var code: String = ""
     @State private var statusId: Int = 0
     @State private var statuses: [PortfolioThemeStatus] = []
 
+    @State private var assets: [PortfolioThemeAsset] = []
+    @State private var allInstruments: [(id: Int, name: String)] = []
+    @State private var showAdd = false
+    @State private var addInstrumentId: Int = 0
+    @State private var addResearchPct: Double = 0
+    @State private var addUserPct: Double = 0
+    @State private var showMissingAlert = false
+
     var body: some View {
         VStack(alignment: .leading) {
-            Form {
-                Section {
-                    TextField("Name", text: $name).textFieldStyle(.roundedBorder)
-                    if isNew {
-                        TextField("Code", text: $code)
-                            .textFieldStyle(.roundedBorder)
-                            .onChange(of: code) { code = code.uppercased() }
-                    } else {
-                        Text("Code: \(theme.code)")
+            if let theme = theme {
+                Form {
+                    Section {
+                        TextField("Name", text: $name).textFieldStyle(.roundedBorder)
+                        Text("Code: \(code)")
+                        Picker("Status", selection: $statusId) {
+                            ForEach(statuses) { status in
+                                Text(status.name).tag(status.id)
+                            }
+                        }
+                        Text("Archived at: \(theme.archivedAt ?? "—")")
                     }
-                    Picker("Status", selection: $statusId) {
-                        ForEach(statuses) { status in
-                            Text(status.name).tag(status.id)
+                    if isReadOnly {
+                        Section {
+                            Text("Archived themes are read-only.")
+                                .foregroundColor(.secondary)
                         }
                     }
-                    Text("Archived at: \(theme.archivedAt ?? "—")")
-                }
-                if !isNew {
+                    compositionSection
                     Section("Danger Zone") {
                         if theme.archivedAt == nil {
-                            Button("Archive Theme") {
-                                onArchive()
-                                dismiss()
-                            }
+                            Button("Archive Theme") { onArchive(); dismiss() }
                         } else {
                             Button("Unarchive") {
                                 let defaultStatus = statuses.first { $0.isDefault }?.id ?? statusId
                                 onUnarchive(defaultStatus)
                                 dismiss()
                             }
-                            Button("Soft Delete") {
-                                onSoftDelete()
-                                dismiss()
-                            }
+                            Button("Soft Delete") { onSoftDelete(); dismiss() }
                         }
                     }
                 }
-            }
-            HStack {
-                Spacer()
-                Button("Save") {
-                    let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
-                    var updated = theme
-                    if isNew {
-                        updated = PortfolioTheme(id: 0, name: trimmedName, code: code.uppercased(), statusId: statusId, createdAt: "", updatedAt: "", archivedAt: nil, softDelete: false)
-                    } else {
-                        updated.name = trimmedName
-                        updated.statusId = statusId
+                HStack {
+                    Spacer()
+                    Button("Save") {
+                        saveTheme()
                     }
-                    onSave(updated)
-                    dismiss()
-                }.disabled(!valid)
-                Button("Cancel") { dismiss() }
+                    .disabled(!valid || isReadOnly)
+                    Button("Cancel") { dismiss() }
+                }
+                .padding([.top, .leading, .trailing])
+            } else {
+                Text("This theme is no longer available.")
             }
-            .padding([.top, .leading, .trailing])
         }
-        .frame(minWidth: 500, minHeight: 320)
-        .onAppear {
-            statuses = dbManager.fetchPortfolioThemeStatuses()
-            name = theme.name
-            code = theme.code
-            statusId = theme.statusId
+        .frame(minWidth: 620, minHeight: 420)
+        .onAppear(perform: loadTheme)
+        .sheet(isPresented: $showAdd) { addSheet }
+        .alert("This theme is no longer available.", isPresented: $showMissingAlert) {
+            Button("OK") { dismiss() }
         }
     }
 
     private var valid: Bool {
-        let nameOk = PortfolioTheme.isValidName(name)
-        let codeOk = isNew ? PortfolioTheme.isValidCode(code.uppercased()) : true
-        return nameOk && codeOk
+        PortfolioTheme.isValidName(name)
+    }
+
+    private var isReadOnly: Bool { theme?.archivedAt != nil }
+
+    private var researchTotal: Double { assets.reduce(0) { $0 + $1.researchTargetPct } }
+    private var userTotal: Double { assets.reduce(0) { $0 + $1.userTargetPct } }
+
+    @ViewBuilder
+    private var compositionSection: some View {
+        Section("Composition") {
+            if assets.isEmpty {
+                Text("No instruments attached")
+            } else {
+                ForEach($assets) { $asset in
+                    HStack {
+                        Text(instrumentName(asset.instrumentId))
+                        TextField("Research %", value: $asset.researchTargetPct, format: .number)
+                            .frame(width: 80)
+                            .disabled(isReadOnly)
+                            .onSubmit { save(asset) }
+                        TextField("User %", value: $asset.userTargetPct, format: .number)
+                            .frame(width: 80)
+                            .disabled(isReadOnly)
+                            .onSubmit { save(asset) }
+                        if !isReadOnly {
+                            Button("Remove") { remove(asset) }
+                        }
+                    }
+                }
+                HStack {
+                    Text(String(format: "Research sum %.1f%%", researchTotal))
+                    Text(String(format: "| User sum %.1f%%", userTotal))
+                        .foregroundColor(abs(userTotal - 100.0) > 0.1 ? .orange : .primary)
+                }
+            }
+            if !isReadOnly {
+                Button("+ Add Instrument") { showAdd = true }
+            }
+        }
+    }
+
+    private var addSheet: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Picker("Instrument", selection: $addInstrumentId) {
+                ForEach(availableInstruments, id: \.id) { item in
+                    Text(item.name).tag(item.id)
+                }
+            }
+            TextField("Research %", value: $addResearchPct, format: .number)
+            TextField("User %", value: $addUserPct, format: .number)
+            HStack {
+                Button("Add") {
+                    let userPct = addUserPct == addResearchPct ? nil : addUserPct
+                    _ = dbManager.createThemeAsset(themeId: themeId, instrumentId: addInstrumentId, researchPct: addResearchPct, userPct: userPct)
+                    showAdd = false
+                    addResearchPct = 0; addUserPct = 0
+                    loadAssets()
+                }
+                Button("Cancel") { showAdd = false }
+            }
+        }
+        .padding()
+        .frame(minWidth: 300)
+    }
+
+    private var availableInstruments: [(id: Int, name: String)] {
+        allInstruments.filter { inst in !assets.contains { $0.instrumentId == inst.id } }
+    }
+
+    private func loadTheme() {
+        guard let fetched = dbManager.getPortfolioTheme(id: themeId) else {
+            LoggingService.shared.log("open theme detail themeId=\(themeId) origin=\(origin) result=not_found", logger: .ui)
+            showMissingAlert = true
+            return
+        }
+        if fetched.softDelete {
+            LoggingService.shared.log("open theme detail themeId=\(themeId) origin=\(origin) result=soft_deleted", logger: .ui)
+            showMissingAlert = true
+            return
+        }
+        theme = fetched
+        statuses = dbManager.fetchPortfolioThemeStatuses()
+        name = fetched.name
+        code = fetched.code
+        statusId = fetched.statusId
+        loadAssets()
+        LoggingService.shared.log("open theme detail themeId=\(fetched.id) code=\(fetched.code) origin=\(origin) result=opened", logger: .ui)
+        if fetched.archivedAt != nil {
+            LoggingService.shared.log("theme \(fetched.id) state=archived_readonly", logger: .ui)
+        }
+    }
+
+    private func loadAssets() {
+        assets = dbManager.listThemeAssets(themeId: themeId)
+        allInstruments = dbManager.fetchAssets().map { ($0.id, $0.name) }
+        if let first = availableInstruments.first { addInstrumentId = first.id }
+    }
+
+    private func instrumentName(_ id: Int) -> String {
+        allInstruments.first { $0.id == id }?.name ?? "#\(id)"
+    }
+
+    private func saveTheme() {
+        guard var current = theme else { return }
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        current.name = trimmed
+        current.statusId = statusId
+        _ = dbManager.updatePortfolioTheme(id: current.id, name: current.name, statusId: current.statusId, archivedAt: current.archivedAt)
+        onSave(current)
+        dismiss()
+    }
+
+    private func save(_ asset: PortfolioThemeAsset) {
+        _ = dbManager.updateThemeAsset(themeId: themeId, instrumentId: asset.instrumentId, researchPct: asset.researchTargetPct, userPct: asset.userTargetPct, notes: asset.notes)
+        loadAssets()
+    }
+
+    private func remove(_ asset: PortfolioThemeAsset) {
+        _ = dbManager.removeThemeAsset(themeId: themeId, instrumentId: asset.instrumentId)
+        loadAssets()
     }
 }

--- a/DragonShield/Views/PortfolioThemesListView.swift
+++ b/DragonShield/Views/PortfolioThemesListView.swift
@@ -17,18 +17,20 @@ struct PortfolioThemesListView: View {
     @State private var selectedThemeId: PortfolioTheme.ID?
     @State private var themeToEdit: PortfolioTheme?
     @State private var showingAddSheet = false
+    @State private var navigateThemeId: Int?
 
     // State to manage the table's sort order
     @State private var sortOrder = [KeyPathComparator<PortfolioTheme>]()
 
     var body: some View {
-        VStack {
-            themesTable // The Table view, now correctly defined
-            
-            HStack {
-                Button(action: { showingAddSheet = true }) {
-                    Label("Add Theme", systemImage: "plus")
-                }
+        NavigationStack {
+            VStack {
+                themesTable // The Table view, now correctly defined
+
+                HStack {
+                    Button(action: { showingAddSheet = true }) {
+                        Label("Add Theme", systemImage: "plus")
+                    }
 
                 Button(action: {
                     if let selectedId = selectedThemeId {
@@ -47,8 +49,15 @@ struct PortfolioThemesListView: View {
                     Label("Delete Theme", systemImage: "trash")
                 }
                 .disabled(selectedThemeId == nil)
+                }
+                .padding()
             }
-            .padding()
+            .navigationDestination(isPresented: Binding(get: { navigateThemeId != nil }, set: { if !$0 { navigateThemeId = nil } })) {
+                if let id = navigateThemeId {
+                    PortfolioThemeDetailView(themeId: id, origin: "themesList")
+                        .environmentObject(dbManager)
+                }
+            }
         }
         .navigationTitle("Portfolio Themes")
         .onAppear(perform: loadData)
@@ -68,14 +77,24 @@ struct PortfolioThemesListView: View {
         Table(themes, selection: $selectedThemeId, sortOrder: $sortOrder) {
             TableColumn("Name", value: \.name)
             TableColumn("Code", value: \.code)
-            
-            // CORRECTED: Use `sortUsing` to make a custom column sortable.
-            // This makes the header clickable and associates it with the `statusId` keypath.
+
             TableColumn("Status", sortUsing: KeyPathComparator(\.statusId)) { theme in
                 Text(statusName(for: theme.statusId))
             }
-            
+
             TableColumn("Last Updated", value: \.updatedAt)
+
+            TableColumn("", content: { theme in
+                Button {
+                    open(theme)
+                } label: {
+                    Image(systemName: "chevron.right")
+                }
+                .buttonStyle(.plain)
+                .help("Open Theme Details")
+                .accessibilityLabel("Open details for \(theme.name)")
+            })
+            .width(30)
         }
         .onChange(of: sortOrder) { newOrder in
             // This custom logic sorts the table correctly when any header is clicked
@@ -97,6 +116,18 @@ struct PortfolioThemesListView: View {
                 themes.sort(using: newOrder)
             }
         }
+        .onTapGesture(count: 2, perform: openSelected)
+        .overlay(
+            Button(action: openSelected) {
+                EmptyView()
+            }
+            .keyboardShortcut(.return, modifiers: [])
+            .frame(width: 0, height: 0)
+            .opacity(0)
+        )
+        .contextMenu(forSelectionType: PortfolioTheme.ID.self) { _ in
+            Button("Open Theme Details") { openSelected() }.disabled(selectedThemeId == nil)
+        }
     }
     
     private func loadData() {
@@ -117,5 +148,15 @@ struct PortfolioThemesListView: View {
         } else {
             print("Error: Failed to delete theme with ID \(theme.id)")
         }
+    }
+
+    private func openSelected() {
+        if let selectedId = selectedThemeId, let theme = themes.first(where: { $0.id == selectedId }) {
+            open(theme)
+        }
+    }
+
+    private func open(_ theme: PortfolioTheme) {
+        navigateThemeId = theme.id
     }
 }

--- a/DragonShield/Views/SidebarView.swift
+++ b/DragonShield/Views/SidebarView.swift
@@ -13,6 +13,7 @@ import AppKit
 struct SidebarView: View {
     @EnvironmentObject var dbManager: DatabaseManager
     @EnvironmentObject var healthRunner: HealthCheckRunner
+    @AppStorage(UserDefaultsKeys.portfolioThemesEnabled) private var portfolioThemesEnabled: Bool = false
 
     @State private var showOverview = true
     @State private var showManagement = true
@@ -52,8 +53,10 @@ struct SidebarView: View {
                     Label("To-Do Board", systemImage: "checklist")
                 }
 
-                NavigationLink(destination: PortfolioThemesListView().environmentObject(dbManager)) {
-                    Label("Portfolio Themes", systemImage: "list.bullet")
+                if portfolioThemesEnabled {
+                    NavigationLink(destination: PortfolioThemesListView().environmentObject(dbManager)) {
+                        Label("Portfolio Themes", systemImage: "list.bullet")
+                    }
                 }
             }
 

--- a/DragonShield/db/migrations/011_portfolio_theme_asset.sql
+++ b/DragonShield/db/migrations/011_portfolio_theme_asset.sql
@@ -1,0 +1,20 @@
+-- migrate:up
+-- Purpose: Introduce PortfolioThemeAsset table linking themes to instruments with target percentages.
+-- Assumptions: PortfolioTheme and Instruments tables exist; SQLite database with dbmate migrations.
+-- Idempotency: Uses IF NOT EXISTS and CHECK constraints.
+
+CREATE TABLE IF NOT EXISTS PortfolioThemeAsset (
+    theme_id INTEGER NOT NULL REFERENCES PortfolioTheme(id) ON DELETE RESTRICT,
+    instrument_id INTEGER NOT NULL REFERENCES Instruments(instrument_id) ON DELETE RESTRICT,
+    research_target_pct REAL NOT NULL DEFAULT 0.0 CHECK(research_target_pct >= 0.0 AND research_target_pct <= 100.0),
+    user_target_pct REAL NOT NULL DEFAULT 0.0 CHECK(user_target_pct >= 0.0 AND user_target_pct <= 100.0),
+    notes TEXT NULL,
+    created_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
+    updated_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
+    PRIMARY KEY (theme_id, instrument_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_portfolio_theme_asset_instrument ON PortfolioThemeAsset(instrument_id);
+
+-- migrate:down
+DROP TABLE IF EXISTS PortfolioThemeAsset;

--- a/DragonShieldTests/PortfolioThemeAssetTests.swift
+++ b/DragonShieldTests/PortfolioThemeAssetTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+import SQLite3
+@testable import DragonShield
+
+final class PortfolioThemeAssetTests: XCTestCase {
+    private func setupDb(_ manager: DatabaseManager) {
+        var mem: OpaquePointer?
+        sqlite3_open(":memory:", &mem)
+        manager.db = mem
+        let sql = """
+        CREATE TABLE PortfolioThemeStatus (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            code TEXT NOT NULL UNIQUE,
+            name TEXT NOT NULL,
+            color_hex TEXT NOT NULL,
+            is_default INTEGER NOT NULL,
+            created_at TEXT DEFAULT '',
+            updated_at TEXT DEFAULT ''
+        );
+        INSERT INTO PortfolioThemeStatus (code,name,color_hex,is_default) VALUES ('ACTIVE','Active','#FFFFFF',1);
+        CREATE TABLE PortfolioTheme (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            code TEXT NOT NULL,
+            status_id INTEGER NOT NULL,
+            created_at TEXT DEFAULT '',
+            updated_at TEXT DEFAULT '',
+            archived_at TEXT,
+            soft_delete INTEGER DEFAULT 0
+        );
+        CREATE TABLE Instruments (
+            instrument_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            instrument_name TEXT NOT NULL,
+            sub_class_id INTEGER NOT NULL,
+            currency TEXT NOT NULL
+        );
+        """
+        sqlite3_exec(manager.db, sql, nil, nil, nil)
+        manager.ensurePortfolioThemeAssetTable()
+        _ = manager.createPortfolioTheme(name: "Growth", code: "GROWTH", statusId: 1)
+        sqlite3_exec(manager.db, "INSERT INTO Instruments (instrument_name, sub_class_id, currency) VALUES ('Apple',1,'USD');", nil, nil, nil)
+    }
+
+    func testCreateDefaultsUserPct() {
+        let manager = DatabaseManager()
+        setupDb(manager)
+        guard let theme = manager.fetchPortfolioThemes().first else { XCTFail(); return }
+        let asset = manager.createThemeAsset(themeId: theme.id, instrumentId: 1, researchPct: 25.0)
+        XCTAssertNotNil(asset)
+        XCTAssertEqual(asset?.userTargetPct, 25.0)
+        sqlite3_close(manager.db)
+    }
+
+    func testDuplicateInstrumentRejected() {
+        let manager = DatabaseManager()
+        setupDb(manager)
+        guard let theme = manager.fetchPortfolioThemes().first else { XCTFail(); return }
+        let first = manager.createThemeAsset(themeId: theme.id, instrumentId: 1, researchPct: 10.0)
+        XCTAssertNotNil(first)
+        let second = manager.createThemeAsset(themeId: theme.id, instrumentId: 1, researchPct: 5.0)
+        XCTAssertNil(second)
+        sqlite3_close(manager.db)
+    }
+
+    func testUpdateTargets() {
+        let manager = DatabaseManager()
+        setupDb(manager)
+        guard let theme = manager.fetchPortfolioThemes().first else { XCTFail(); return }
+        _ = manager.createThemeAsset(themeId: theme.id, instrumentId: 1, researchPct: 10.0, userPct: 10.0)
+        let updated = manager.updateThemeAsset(themeId: theme.id, instrumentId: 1, researchPct: 20.0, userPct: 30.0, notes: nil)
+        XCTAssertEqual(updated?.researchTargetPct, 20.0)
+        XCTAssertEqual(updated?.userTargetPct, 30.0)
+        sqlite3_close(manager.db)
+    }
+}

--- a/DragonShieldTests/PortfolioThemeNavigationTests.swift
+++ b/DragonShieldTests/PortfolioThemeNavigationTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+import SQLite3
+@testable import DragonShield
+
+final class PortfolioThemeNavigationTests: XCTestCase {
+    func testSoftDeletedThemeNotFetchable() {
+        let manager = DatabaseManager()
+        var mem: OpaquePointer?
+        sqlite3_open(":memory:", &mem)
+        manager.db = mem
+        let sql = """
+        CREATE TABLE PortfolioThemeStatus (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            code TEXT NOT NULL UNIQUE,
+            name TEXT NOT NULL,
+            color_hex TEXT NOT NULL,
+            is_default INTEGER NOT NULL,
+            created_at TEXT DEFAULT '',
+            updated_at TEXT DEFAULT ''
+        );
+        INSERT INTO PortfolioThemeStatus (code,name,color_hex,is_default) VALUES
+            ('ACTIVE','Active','#FFFFFF',1),
+            ('ARCH','Archived','#CCCCCC',0);
+        """
+        sqlite3_exec(manager.db, sql, nil, nil, nil)
+        manager.ensurePortfolioThemeTable()
+        guard let theme = manager.createPortfolioTheme(name: "Growth", code: "GROWTH", statusId: 1) else { XCTFail(); return }
+        XCTAssertTrue(manager.archivePortfolioTheme(id: theme.id))
+        XCTAssertTrue(manager.softDeletePortfolioTheme(id: theme.id))
+        XCTAssertNil(manager.getPortfolioTheme(id: theme.id))
+        sqlite3_close(mem)
+    }
+}


### PR DESCRIPTION
## Summary
- gate themes navigation behind feature flag and expose link only when enabled
- allow opening PortfolioThemeDetailView from themes list via keyboard, context menu, or details icon
- detail view fetches theme by id, logs navigation result, and respects read-only state for archived themes
- open theme details with double-click or Return using supported SwiftUI APIs

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a49f6f82908323a81c19fe5cd46ecc