### PR TITLE
Fix sequential theme asset update test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Ensure sequential theme asset updates persist and close test DB handles
 - Polish Portfolio Theme maintenance layouts and add instrument notes field
 - Normalize empty instrument notes to nil in theme detail editor and add-instrument sheet
 - Fix Portfolio Theme allocation edits not persisting and log updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Apply SQLite PRAGMAs in test DB setup to mirror production behavior
 - Ensure sequential theme asset updates persist and close test DB handles
 - Polish Portfolio Theme maintenance layouts and add instrument notes field
 - Normalize empty instrument notes to nil in theme detail editor and add-instrument sheet

--- a/DragonShieldTests/PortfolioThemeAssetSequentialUpdateTests.swift
+++ b/DragonShieldTests/PortfolioThemeAssetSequentialUpdateTests.swift
@@ -14,6 +14,12 @@ final class PortfolioThemeAssetSequentialUpdateTests: XCTestCase {
         sqlite3_open(":memory:", &mem)
         manager.db = mem
 
+        sqlite3_exec(manager.db, "PRAGMA foreign_keys = ON;", nil, nil, nil)
+        sqlite3_exec(manager.db, "PRAGMA journal_mode = WAL;", nil, nil, nil)
+        sqlite3_exec(manager.db, "PRAGMA synchronous = NORMAL;", nil, nil, nil)
+        sqlite3_exec(manager.db, "PRAGMA busy_timeout = 5000;", nil, nil, nil)
+        sqlite3_exec(manager.db, "PRAGMA wal_autocheckpoint = 1000;", nil, nil, nil)
+
         let sql = """
         CREATE TABLE PortfolioThemeStatus (
             id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
## Summary
- refactor PortfolioThemeAssetSequentialUpdateTests to use setUp/tearDown for in-memory DB
- verify final update persists after sequential updates

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -project DragonShield.xcodeproj -scheme DragonShield -destination 'platform=macOS' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a58efd37408323a02effc6e598bdca