### PR TITLE
Include notes in portfolio valuation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Fetch PortfolioThemeAsset notes in PortfolioValuationService so valuations surface comments
 - Require archiving a theme before deletion with archive-and-delete alert flow
 - Polish Portfolio Theme maintenance layouts and add instrument notes field
 - Normalize empty instrument notes to nil in theme detail editor and add-instrument sheet

--- a/DragonShield/PortfolioValuationService.swift
+++ b/DragonShield/PortfolioValuationService.swift
@@ -1,0 +1,71 @@
+// DragonShield/PortfolioValuationService.swift
+// MARK: - Version 1.0
+// MARK: - History
+// - 1.0: Fetch theme asset valuations with notes.
+
+import Foundation
+import SQLite3
+
+/// Provides valuation data for portfolio themes.
+final class PortfolioValuationService {
+    private let db: OpaquePointer?
+
+    /// Create a service using an existing SQLite connection.
+    init(db: OpaquePointer?) {
+        self.db = db
+    }
+
+    /// Represents valuation details for a theme asset.
+    struct ThemeAssetValuation: Equatable {
+        let instrumentId: Int
+        let instrumentName: String
+        let researchTargetPct: Double
+        let userTargetPct: Double
+        let currency: String
+        let value: Double
+        let notes: String?
+    }
+
+    /// Fetch valuations for all assets within a theme for a given import session.
+    func fetchValuations(importSessionId: Int, themeId: Int) -> [ThemeAssetValuation] {
+        guard let db = db else { return [] }
+        let sql = """
+        SELECT a.instrument_id, i.instrument_name, a.research_target_pct, a.user_target_pct, i.currency, COALESCE(SUM(pr.quantity * pr.current_price),0), a.notes
+          FROM PortfolioThemeAsset a
+          JOIN Instruments i ON a.instrument_id = i.instrument_id
+          LEFT JOIN PositionReports pr ON pr.instrument_id = a.instrument_id AND pr.import_session_id = ?
+         WHERE a.theme_id = ?
+         GROUP BY a.instrument_id, i.instrument_name, a.research_target_pct, a.user_target_pct, i.currency, a.notes
+        """
+        var stmt: OpaquePointer?
+        var results: [ThemeAssetValuation] = []
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            sqlite3_bind_int(stmt, 1, Int32(importSessionId))
+            sqlite3_bind_int(stmt, 2, Int32(themeId))
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                let instrId = Int(sqlite3_column_int(stmt, 0))
+                let name = String(cString: sqlite3_column_text(stmt, 1))
+                let research = sqlite3_column_double(stmt, 2)
+                let user = sqlite3_column_double(stmt, 3)
+                let currency = String(cString: sqlite3_column_text(stmt, 4))
+                let value = sqlite3_column_double(stmt, 5)
+                let notes = sqlite3_column_text(stmt, 6).map { String(cString: $0) }
+                let valuation = ThemeAssetValuation(
+                    instrumentId: instrId,
+                    instrumentName: name,
+                    researchTargetPct: research,
+                    userTargetPct: user,
+                    currency: currency,
+                    value: value,
+                    notes: notes
+                )
+                results.append(valuation)
+            }
+        } else {
+            LoggingService.shared.log("Failed to prepare fetchValuations: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+        sqlite3_finalize(stmt)
+        return results
+    }
+}
+

--- a/DragonShieldTests/PortfolioValuationServiceTests.swift
+++ b/DragonShieldTests/PortfolioValuationServiceTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+import SQLite3
+@testable import DragonShield
+
+final class PortfolioValuationServiceTests: XCTestCase {
+    private func setupDb(_ manager: DatabaseManager) {
+        var mem: OpaquePointer?
+        sqlite3_open(":memory:", &mem)
+        manager.db = mem
+        let sql = """
+        CREATE TABLE PortfolioThemeStatus (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            code TEXT NOT NULL UNIQUE,
+            name TEXT NOT NULL,
+            color_hex TEXT NOT NULL,
+            is_default INTEGER NOT NULL,
+            created_at TEXT DEFAULT '',
+            updated_at TEXT DEFAULT ''
+        );
+        INSERT INTO PortfolioThemeStatus (code,name,color_hex,is_default) VALUES ('ACTIVE','Active','#FFFFFF',1);
+        CREATE TABLE PortfolioTheme (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            code TEXT NOT NULL,
+            status_id INTEGER NOT NULL,
+            created_at TEXT DEFAULT '',
+            updated_at TEXT DEFAULT '',
+            archived_at TEXT,
+            soft_delete INTEGER DEFAULT 0
+        );
+        CREATE TABLE Instruments (
+            instrument_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            instrument_name TEXT NOT NULL,
+            sub_class_id INTEGER NOT NULL,
+            currency TEXT NOT NULL
+        );
+        CREATE TABLE PositionReports (
+            report_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            instrument_id INTEGER NOT NULL,
+            import_session_id INTEGER NOT NULL,
+            quantity REAL NOT NULL,
+            current_price REAL NOT NULL
+        );
+        """
+        sqlite3_exec(manager.db, sql, nil, nil, nil)
+        manager.ensurePortfolioThemeAssetTable()
+        _ = manager.createPortfolioTheme(name: "Growth", code: "GROWTH", statusId: 1)
+        sqlite3_exec(manager.db, "INSERT INTO Instruments (instrument_name, sub_class_id, currency) VALUES ('Apple',1,'USD');", nil, nil, nil)
+    }
+
+    func testValuationIncludesNotes() {
+        let manager = DatabaseManager()
+        setupDb(manager)
+        guard let theme = manager.fetchPortfolioThemes().first else { XCTFail(); return }
+        _ = manager.createThemeAsset(themeId: theme.id, instrumentId: 1, researchPct: 50.0, userPct: 50.0, notes: "Important")
+        sqlite3_exec(manager.db, "INSERT INTO PositionReports (instrument_id, import_session_id, quantity, current_price) VALUES (1,1,2,100);", nil, nil, nil)
+        let service = PortfolioValuationService(db: manager.db)
+        let valuations = service.fetchValuations(importSessionId: 1, themeId: theme.id)
+        XCTAssertEqual(valuations.count, 1)
+        let valuation = valuations[0]
+        XCTAssertEqual(valuation.notes, "Important")
+        XCTAssertEqual(valuation.value, 200.0, accuracy: 0.001)
+        sqlite3_close(manager.db)
+    }
+}
+


### PR DESCRIPTION
## Summary
- surface PortfolioThemeAsset notes in valuation results by selecting and grouping on notes
- cover valuation service with test ensuring notes and values are returned
- document portfolio valuation note fix

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a5cd7bb8fc8323b51add1725802ba9