### PR TITLE
Include theme asset notes in valuation query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Include theme asset notes in valuation query
 - Require archiving a theme before deletion with archive-and-delete alert flow
 - Polish Portfolio Theme maintenance layouts and add instrument notes field
 - Normalize empty instrument notes to nil in theme detail editor and add-instrument sheet

--- a/DragonShield/PortfolioValuationService.swift
+++ b/DragonShield/PortfolioValuationService.swift
@@ -1,0 +1,71 @@
+import Foundation
+import SQLite3
+
+struct PortfolioAssetValuation {
+    let instrumentId: Int
+    let instrumentName: String
+    let researchTargetPct: Double
+    let userTargetPct: Double
+    let currency: String
+    let currentValue: Double
+    let notes: String?
+}
+
+final class PortfolioValuationService {
+    private let db: OpaquePointer?
+
+    init(db: OpaquePointer?) {
+        self.db = db
+    }
+
+    func fetchThemeValuations(themeId: Int, importSessionId: Int) -> [PortfolioAssetValuation] {
+        var results: [PortfolioAssetValuation] = []
+        let sql = """
+        SELECT a.instrument_id,
+               i.instrument_name,
+               a.research_target_pct,
+               a.user_target_pct,
+               i.currency,
+               COALESCE(SUM(pr.quantity * pr.current_price),0),
+               a.notes
+          FROM PortfolioThemeAsset a
+          JOIN Instruments i ON a.instrument_id = i.instrument_id
+          LEFT JOIN PositionReports pr ON pr.instrument_id = a.instrument_id AND pr.import_session_id = ?
+         WHERE a.theme_id = ?
+         GROUP BY a.instrument_id, i.instrument_name, a.research_target_pct, a.user_target_pct, i.currency, a.notes;
+        """
+        var stmt: OpaquePointer?
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            sqlite3_bind_int(stmt, 1, Int32(importSessionId))
+            sqlite3_bind_int(stmt, 2, Int32(themeId))
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                let instrumentId = Int(sqlite3_column_int(stmt, 0))
+                let name = String(cString: sqlite3_column_text(stmt, 1))
+                let research = sqlite3_column_double(stmt, 2)
+                let user = sqlite3_column_double(stmt, 3)
+                let currency = String(cString: sqlite3_column_text(stmt, 4))
+                let value = sqlite3_column_double(stmt, 5)
+                let notes: String?
+                if sqlite3_column_type(stmt, 6) == SQLITE_NULL {
+                    notes = nil
+                } else {
+                    notes = String(cString: sqlite3_column_text(stmt, 6))
+                }
+                results.append(PortfolioAssetValuation(
+                    instrumentId: instrumentId,
+                    instrumentName: name,
+                    researchTargetPct: research,
+                    userTargetPct: user,
+                    currency: currency,
+                    currentValue: value,
+                    notes: notes
+                ))
+            }
+        } else {
+            LoggingService.shared.log("fetchThemeValuations prepare failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+        sqlite3_finalize(stmt)
+        return results
+    }
+}
+

--- a/DragonShieldTests/PortfolioValuationServiceTests.swift
+++ b/DragonShieldTests/PortfolioValuationServiceTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+import SQLite3
+@testable import DragonShield
+
+final class PortfolioValuationServiceTests: XCTestCase {
+    private func setupDb(_ manager: DatabaseManager) -> (themeId: Int, sessionId: Int) {
+        var mem: OpaquePointer?
+        sqlite3_open(":memory:", &mem)
+        manager.db = mem
+        let sql = """
+        CREATE TABLE PortfolioThemeStatus (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            code TEXT NOT NULL UNIQUE,
+            name TEXT NOT NULL,
+            color_hex TEXT NOT NULL,
+            is_default INTEGER NOT NULL,
+            created_at TEXT DEFAULT '',
+            updated_at TEXT DEFAULT ''
+        );
+        INSERT INTO PortfolioThemeStatus (code,name,color_hex,is_default) VALUES ('ACTIVE','Active','#FFFFFF',1);
+        CREATE TABLE PortfolioTheme (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            code TEXT NOT NULL,
+            status_id INTEGER NOT NULL,
+            created_at TEXT DEFAULT '',
+            updated_at TEXT DEFAULT '',
+            archived_at TEXT,
+            soft_delete INTEGER DEFAULT 0
+        );
+        CREATE TABLE Instruments (
+            instrument_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            instrument_name TEXT NOT NULL,
+            sub_class_id INTEGER NOT NULL,
+            currency TEXT NOT NULL
+        );
+        CREATE TABLE PositionReports (
+            position_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            import_session_id INTEGER,
+            instrument_id INTEGER,
+            quantity REAL,
+            current_price REAL
+        );
+        """
+        sqlite3_exec(manager.db, sql, nil, nil, nil)
+        manager.ensurePortfolioThemeAssetTable()
+        _ = manager.createPortfolioTheme(name: "Growth", code: "GROW", statusId: 1)
+        sqlite3_exec(manager.db, "INSERT INTO Instruments (instrument_name, sub_class_id, currency) VALUES ('Apple',1,'USD');", nil, nil, nil)
+        sqlite3_exec(manager.db, "INSERT INTO PositionReports (import_session_id, instrument_id, quantity, current_price) VALUES (1,1,10,5);", nil, nil, nil)
+        _ = manager.createThemeAsset(themeId: 1, instrumentId: 1, researchPct: 50.0, userPct: 60.0, notes: "Note A")
+        return (themeId: 1, sessionId: 1)
+    }
+
+    func testValuationIncludesNotes() {
+        let manager = DatabaseManager()
+        let setup = setupDb(manager)
+        let service = PortfolioValuationService(db: manager.db)
+        let items = service.fetchThemeValuations(themeId: setup.themeId, importSessionId: setup.sessionId)
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items.first?.notes, "Note A")
+        sqlite3_close(manager.db)
+    }
+}


### PR DESCRIPTION
## Summary
- add PortfolioValuationService with SQL returning notes for each theme asset
- cover valuation notes with a unit test
- document valuation query improvement in changelog

## Testing
- `make setup` (fails: No rule to make target 'setup')
- `make fmt` (fails: No rule to make target 'fmt')
- `make lint` (fails: No rule to make target 'lint')
- `make migrate` (fails: No rule to make target 'migrate')
- `make build` (fails: No rule to make target 'build')
- `make test` (fails: No rule to make target 'test')

------
https://chatgpt.com/codex/tasks/task_e_68a5cd7bb8fc8323b51add1725802ba9