### PR TITLE
Include theme asset notes in valuation query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Polish Portfolio Theme maintenance layouts and add instrument notes field
 - Normalize empty instrument notes to nil in theme detail editor and add-instrument sheet
 - Fix Portfolio Theme allocation edits not persisting and log updates
+- Include theme asset notes in valuation query results
 - Introduce PortfolioThemeAsset table linking themes to instruments with target allocations
 - Add PortfolioTheme entity with CRUD UI and migration 010
 - Fix Portfolio Theme creation to persist database records and improve new theme editor layout

--- a/DragonShield/PortfolioValuationService.swift
+++ b/DragonShield/PortfolioValuationService.swift
@@ -1,0 +1,54 @@
+import Foundation
+import SQLite3
+
+struct PortfolioAssetValuation: Identifiable {
+    let instrumentId: Int
+    let instrumentName: String
+    let researchTargetPct: Double
+    let userTargetPct: Double
+    let currency: String
+    let currentValue: Double
+    let notes: String?
+
+    var id: Int { instrumentId }
+}
+
+final class PortfolioValuationService {
+    private let manager: DatabaseManager
+
+    init(manager: DatabaseManager) {
+        self.manager = manager
+    }
+
+    func fetchThemeAssetValuations(importSessionId: Int, themeId: Int) -> [PortfolioAssetValuation] {
+        var results: [PortfolioAssetValuation] = []
+        guard let db = manager.db else { return results }
+        let sql = """
+        SELECT a.instrument_id, i.instrument_name, a.research_target_pct, a.user_target_pct, i.currency, COALESCE(SUM(pr.quantity * pr.current_price),0), a.notes
+          FROM PortfolioThemeAsset a
+          JOIN Instruments i ON a.instrument_id = i.instrument_id
+          LEFT JOIN PositionReports pr ON pr.instrument_id = a.instrument_id AND pr.import_session_id = ?
+         WHERE a.theme_id = ?
+         GROUP BY a.instrument_id, i.instrument_name, a.research_target_pct, a.user_target_pct, i.currency, a.notes
+        """
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            sqlite3_finalize(stmt)
+            return results
+        }
+        defer { sqlite3_finalize(stmt) }
+        sqlite3_bind_int(stmt, 1, Int32(importSessionId))
+        sqlite3_bind_int(stmt, 2, Int32(themeId))
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            let instrId = Int(sqlite3_column_int(stmt, 0))
+            let name = String(cString: sqlite3_column_text(stmt, 1))
+            let research = sqlite3_column_double(stmt, 2)
+            let user = sqlite3_column_double(stmt, 3)
+            let currency = String(cString: sqlite3_column_text(stmt, 4))
+            let value = sqlite3_column_double(stmt, 5)
+            let notes = sqlite3_column_text(stmt, 6).map { String(cString: $0) }
+            results.append(PortfolioAssetValuation(instrumentId: instrId, instrumentName: name, researchTargetPct: research, userTargetPct: user, currency: currency, currentValue: value, notes: notes))
+        }
+        return results
+    }
+}

--- a/DragonShieldTests/PortfolioValuationServiceTests.swift
+++ b/DragonShieldTests/PortfolioValuationServiceTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+import SQLite3
+@testable import DragonShield
+
+final class PortfolioValuationServiceTests: XCTestCase {
+    private func setupDb(_ manager: DatabaseManager) {
+        var mem: OpaquePointer?
+        sqlite3_open(":memory:", &mem)
+        manager.db = mem
+        let sql = """
+        CREATE TABLE PortfolioThemeStatus (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            code TEXT NOT NULL UNIQUE,
+            name TEXT NOT NULL,
+            color_hex TEXT NOT NULL,
+            is_default INTEGER NOT NULL,
+            created_at TEXT DEFAULT '',
+            updated_at TEXT DEFAULT ''
+        );
+        INSERT INTO PortfolioThemeStatus (code,name,color_hex,is_default) VALUES ('ACTIVE','Active','#FFFFFF',1);
+        CREATE TABLE PortfolioTheme (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            code TEXT NOT NULL,
+            status_id INTEGER NOT NULL,
+            created_at TEXT DEFAULT '',
+            updated_at TEXT DEFAULT '',
+            archived_at TEXT,
+            soft_delete INTEGER DEFAULT 0
+        );
+        CREATE TABLE Instruments (
+            instrument_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            instrument_name TEXT NOT NULL,
+            sub_class_id INTEGER NOT NULL,
+            currency TEXT NOT NULL
+        );
+        CREATE TABLE PositionReports (
+            instrument_id INTEGER,
+            quantity REAL,
+            current_price REAL,
+            import_session_id INTEGER
+        );
+        """
+        sqlite3_exec(manager.db, sql, nil, nil, nil)
+        manager.ensurePortfolioThemeAssetTable()
+        _ = manager.createPortfolioTheme(name: "Growth", code: "GROWTH", statusId: 1)
+        sqlite3_exec(manager.db, "INSERT INTO Instruments (instrument_name, sub_class_id, currency) VALUES ('Apple',1,'USD');", nil, nil, nil)
+    }
+
+    func testFetchValuationsIncludesNotes() {
+        let manager = DatabaseManager()
+        setupDb(manager)
+        guard let theme = manager.fetchPortfolioThemes().first else { XCTFail(); return }
+        _ = manager.createThemeAsset(themeId: theme.id, instrumentId: 1, researchPct: 10.0, userPct: 15.0, notes: "Important")
+        sqlite3_exec(manager.db, "INSERT INTO PositionReports (instrument_id, quantity, current_price, import_session_id) VALUES (1,2,3,99);", nil, nil, nil)
+        let service = PortfolioValuationService(manager: manager)
+        let vals = service.fetchThemeAssetValuations(importSessionId: 99, themeId: theme.id)
+        XCTAssertEqual(vals.count, 1)
+        XCTAssertEqual(vals.first?.notes, "Important")
+        XCTAssertEqual(vals.first?.currentValue, 6.0)
+        sqlite3_close(manager.db)
+    }
+}


### PR DESCRIPTION
## Summary
- fetch theme asset notes in PortfolioValuationService SQL
- record addition in changelog
- add unit test for valuation notes

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -scheme DragonShield -project DragonShield.xcodeproj` *(fails: command not found)*
- `swiftformat .` *(fails: command not found)*
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5cd7bb8fc8323b51add1725802ba9