### PR TITLE
Add portfolio valuation snapshot service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Normalize empty instrument notes to nil in theme detail editor and add-instrument sheet
 - Fix Portfolio Theme allocation edits not persisting and log updates
 - Fix instrument notes edits not saving in theme detail view
+- Present valuation status and notes in dedicated columns to avoid confusion
 - Introduce PortfolioThemeAsset table linking themes to instruments with target allocations
 - Add PortfolioTheme entity with CRUD UI and migration 010
 - Fix Portfolio Theme creation to persist database records and improve new theme editor layout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Add on-demand Portfolio Valuation service with refreshable theme snapshot
+- Include instrument notes in valuation snapshot output
 - Fix valuation to aggregate instrument holdings across the entire estate
 - Require archiving a theme before deletion with archive-and-delete alert flow
 - Polish Portfolio Theme maintenance layouts and add instrument notes field

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,13 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Add on-demand Portfolio Valuation service with refreshable theme snapshot
+- Fix valuation to aggregate instrument holdings across the entire estate
 - Require archiving a theme before deletion with archive-and-delete alert flow
 - Polish Portfolio Theme maintenance layouts and add instrument notes field
 - Normalize empty instrument notes to nil in theme detail editor and add-instrument sheet
 - Fix Portfolio Theme allocation edits not persisting and log updates
+- Fix instrument notes edits not saving in theme detail view
 - Introduce PortfolioThemeAsset table linking themes to instruments with target allocations
 - Add PortfolioTheme entity with CRUD UI and migration 010
 - Fix Portfolio Theme creation to persist database records and improve new theme editor layout

--- a/DragonShield/PortfolioValuationService.swift
+++ b/DragonShield/PortfolioValuationService.swift
@@ -131,12 +131,8 @@ final class PortfolioValuationService {
                 result = sqlite3_column_double(stmt, 0)
                 if let cString = sqlite3_column_text(stmt, 1) {
                     let date = Self.dateFormatter.date(from: String(cString: cString))
-                    if let d = date {
-                        if let existing = fxAsOf {
-                            if d > existing { fxAsOf = d }
-                        } else {
-                            fxAsOf = d
-                        }
+                    if let d = date, d > (fxAsOf ?? .distantPast) {
+                        fxAsOf = d
                     }
                 }
             }

--- a/DragonShield/PortfolioValuationService.swift
+++ b/DragonShield/PortfolioValuationService.swift
@@ -1,0 +1,147 @@
+import Foundation
+import SQLite3
+
+struct ValuationRow: Identifiable {
+    let instrumentId: Int
+    let instrumentName: String
+    let researchTargetPct: Double
+    let userTargetPct: Double
+    let currentValueBase: Double
+    let actualPct: Double
+    let notes: String?
+    let flag: String?
+    var id: Int { instrumentId }
+}
+
+struct ValuationSnapshot {
+    let positionsAsOf: Date?
+    let fxAsOf: Date?
+    let totalValueBase: Double
+    let rows: [ValuationRow]
+    let excludedFxCount: Int
+    let missingCurrencies: [String]
+}
+
+final class PortfolioValuationService {
+    private let dbManager: DatabaseManager
+    private static let dateFormatter = ISO8601DateFormatter()
+
+    init(dbManager: DatabaseManager) {
+        self.dbManager = dbManager
+    }
+
+    func snapshot(themeId: Int) -> ValuationSnapshot {
+        let start = Date()
+        guard let db = dbManager.db else {
+            return ValuationSnapshot(positionsAsOf: nil, fxAsOf: nil, totalValueBase: 0, rows: [], excludedFxCount: 0, missingCurrencies: [])
+        }
+        guard !dbManager.baseCurrency.isEmpty else {
+            LoggingService.shared.log("Base currency not configured.", type: .error, logger: .database)
+            return ValuationSnapshot(positionsAsOf: nil, fxAsOf: nil, totalValueBase: 0, rows: [], excludedFxCount: 0, missingCurrencies: [])
+        }
+
+        let theme = dbManager.getPortfolioTheme(id: themeId)
+
+        var positionsAsOf: Date?
+        var stmt: OpaquePointer?
+        let asOfSql = "SELECT MAX(report_date) FROM PositionReports"
+        if sqlite3_prepare_v2(db, asOfSql, -1, &stmt, nil) == SQLITE_OK {
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                if let cString = sqlite3_column_text(stmt, 0) {
+                    positionsAsOf = Self.dateFormatter.date(from: String(cString: cString))
+                }
+            }
+        }
+        sqlite3_finalize(stmt)
+
+        var rows: [ValuationRow] = []
+        var total: Double = 0
+        var fxAsOf: Date? = nil
+        var excludedFx = 0
+        var missing: Set<String> = []
+
+        let sql = """
+        SELECT a.instrument_id, i.instrument_name, a.research_target_pct, a.user_target_pct, i.currency, COALESCE(SUM(pr.quantity * pr.current_price),0)
+          FROM PortfolioThemeAsset a
+          JOIN Instruments i ON a.instrument_id = i.instrument_id
+          LEFT JOIN PositionReports pr ON pr.instrument_id = a.instrument_id
+         WHERE a.theme_id = ?
+         GROUP BY a.instrument_id, i.instrument_name, a.research_target_pct, a.user_target_pct, i.currency
+        """
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            sqlite3_bind_int(stmt, 1, Int32(themeId))
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                let instrId = Int(sqlite3_column_int(stmt, 0))
+                let name = String(cString: sqlite3_column_text(stmt, 1))
+                let research = sqlite3_column_double(stmt, 2)
+                let user = sqlite3_column_double(stmt, 3)
+                let currency = String(cString: sqlite3_column_text(stmt, 4))
+                let nativeValue = sqlite3_column_double(stmt, 5)
+                var flag: String? = nil
+                var valueBase: Double = 0
+                var note: String? = nil
+                if nativeValue == 0 {
+                    flag = "No position"
+                } else if currency == dbManager.baseCurrency {
+                    valueBase = nativeValue
+                } else if let rate = fetchRate(for: currency, asOf: positionsAsOf, fxAsOf: &fxAsOf) {
+                    valueBase = nativeValue * rate
+                } else {
+                    flag = "FX missing — excluded"
+                    excludedFx += 1
+                    missing.insert(currency)
+                }
+                rows.append(ValuationRow(instrumentId: instrId, instrumentName: name, researchTargetPct: research, userTargetPct: user, currentValueBase: valueBase, actualPct: 0, notes: note, flag: flag))
+                if flag == nil { total += valueBase }
+            }
+        }
+        sqlite3_finalize(stmt)
+
+        var valuedCount = 0
+        rows = rows.map { row in
+            var pct: Double = 0
+            if total > 0 && row.flag == nil {
+                pct = row.currentValueBase / total * 100
+                valuedCount += 1
+            }
+            return ValuationRow(instrumentId: row.instrumentId, instrumentName: row.instrumentName, researchTargetPct: row.researchTargetPct, userTargetPct: row.userTargetPct, currentValueBase: row.currentValueBase, actualPct: pct, notes: row.notes, flag: row.flag)
+        }
+
+        let duration = Int(Date().timeIntervalSince(start) * 1000)
+        if let t = theme {
+            let posStr = positionsAsOf.map { Self.dateFormatter.string(from: $0) } ?? ""
+            let fxStr = fxAsOf.map { Self.dateFormatter.string(from: $0) } ?? ""
+            LoggingService.shared.log("valuation themeId=\(t.id) themeCode=\(t.code) positions_asof=\(posStr) fx_asof=\(fxStr) instrumentsN=\(rows.count) valuedN=\(valuedCount) excludedFxN=\(excludedFx) totalBase=\(String(format: "%.2f", total)) duration_ms=\(duration)", logger: .database)
+        }
+
+        return ValuationSnapshot(positionsAsOf: positionsAsOf, fxAsOf: fxAsOf, totalValueBase: total, rows: rows, excludedFxCount: excludedFx, missingCurrencies: Array(missing))
+    }
+
+    private func fetchRate(for currency: String, asOf: Date?, fxAsOf: inout Date?) -> Double? {
+        guard let db = dbManager.db else { return nil }
+        let dateStr = asOf.map { Self.dateFormatter.string(from: $0) } ?? Self.dateFormatter.string(from: Date())
+        let sql = "SELECT rate_to_chf, rate_date FROM ExchangeRates WHERE currency_code = ? AND rate_date <= ? ORDER BY rate_date DESC LIMIT 1"
+        var stmt: OpaquePointer?
+        var result: Double?
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            sqlite3_bind_text(stmt, 1, currency, -1, nil)
+            sqlite3_bind_text(stmt, 2, dateStr, -1, nil)
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                result = sqlite3_column_double(stmt, 0)
+                if let cString = sqlite3_column_text(stmt, 1) {
+                    let date = Self.dateFormatter.date(from: String(cString: cString))
+                    if let d = date {
+                        if let existing = fxAsOf {
+                            if d > existing { fxAsOf = d }
+                        } else {
+                            fxAsOf = d
+                        }
+                    }
+                }
+            }
+        }
+        sqlite3_finalize(stmt)
+        return result
+    }
+}
+

--- a/DragonShield/PortfolioValuationService.swift
+++ b/DragonShield/PortfolioValuationService.swift
@@ -95,6 +95,7 @@ final class PortfolioValuationService {
                 if flag == nil { total += valueBase }
             }
         }
+        
         sqlite3_finalize(stmt)
 
         var valuedCount = 0

--- a/DragonShield/Views/PortfolioThemeDetailView.swift
+++ b/DragonShield/Views/PortfolioThemeDetailView.swift
@@ -193,6 +193,7 @@ private var valuationSection: some View {
                     Text("User %").frame(width: 72, alignment: .trailing)
                     Text("Current Value").frame(width: 120, alignment: .trailing)
                     Text("Actual %").frame(width: 72, alignment: .trailing)
+                    Text("Status").frame(width: 120, alignment: .leading)
                     Text("Notes").frame(minWidth: 100, alignment: .leading)
                 }
                 ForEach(snap.rows) { row in
@@ -202,7 +203,8 @@ private var valuationSection: some View {
                         Text(row.userTargetPct, format: .number.precision(.fractionLength(1))).frame(width: 72, alignment: .trailing)
                         Text(row.currentValueBase, format: .currency(code: dbManager.baseCurrency).precision(.fractionLength(2))).frame(width: 120, alignment: .trailing)
                         Text(row.actualPct, format: .number.precision(.fractionLength(1))).frame(width: 72, alignment: .trailing)
-                        Text(row.flag ?? "").frame(minWidth: 100, alignment: .leading)
+                        Text(row.flag ?? "").frame(width: 120, alignment: .leading)
+                        Text(row.notes ?? "").frame(minWidth: 100, alignment: .leading)
                     }
                 }
                 HStack {
@@ -211,6 +213,7 @@ private var valuationSection: some View {
                     Spacer().frame(width: 72)
                     Text(snap.totalValueBase, format: .currency(code: dbManager.baseCurrency).precision(.fractionLength(2))).frame(width: 120, alignment: .trailing)
                     Text(100, format: .number.precision(.fractionLength(1))).frame(width: 72, alignment: .trailing)
+                    Spacer().frame(width: 120)
                     Spacer().frame(minWidth: 100)
                 }
             }

--- a/DragonShieldTests/PortfolioThemeAssetTests.swift
+++ b/DragonShieldTests/PortfolioThemeAssetTests.swift
@@ -73,6 +73,16 @@ final class PortfolioThemeAssetTests: XCTestCase {
         sqlite3_close(manager.db)
     }
 
+    func testUpdateNotesPersists() {
+        let manager = DatabaseManager()
+        setupDb(manager)
+        guard let theme = manager.fetchPortfolioThemes().first else { XCTFail(); return }
+        _ = manager.createThemeAsset(themeId: theme.id, instrumentId: 1, researchPct: 10.0, userPct: 10.0, notes: "Old")
+        let updated = manager.updateThemeAsset(themeId: theme.id, instrumentId: 1, researchPct: 10.0, userPct: 10.0, notes: "New note")
+        XCTAssertEqual(updated?.notes, "New note")
+        sqlite3_close(manager.db)
+    }
+
     func testNotesPreservedWhenNil() {
         let manager = DatabaseManager()
         setupDb(manager)

--- a/DragonShieldTests/PortfolioValuationServiceTests.swift
+++ b/DragonShieldTests/PortfolioValuationServiceTests.swift
@@ -16,7 +16,7 @@ final class PortfolioValuationServiceTests: XCTestCase {
         INSERT INTO PortfolioTheme VALUES (1,'Core','CORE',1,NULL,0);
         CREATE TABLE PortfolioThemeAsset (theme_id INTEGER, instrument_id INTEGER, research_target_pct REAL, user_target_pct REAL, notes TEXT, PRIMARY KEY(theme_id,instrument_id));
         INSERT INTO PortfolioThemeAsset VALUES (1,1,25,25,NULL);
-        INSERT INTO PortfolioThemeAsset VALUES (1,2,25,20,NULL);
+        INSERT INTO PortfolioThemeAsset VALUES (1,2,25,20,'Tech');
         INSERT INTO PortfolioThemeAsset VALUES (1,3,30,35,NULL);
         INSERT INTO PortfolioThemeAsset VALUES (1,4,20,20,NULL);
         CREATE TABLE Instruments (instrument_id INTEGER PRIMARY KEY, instrument_name TEXT, currency TEXT);
@@ -45,6 +45,7 @@ final class PortfolioValuationServiceTests: XCTestCase {
         let rows = Dictionary(uniqueKeysWithValues: snap.rows.map { ($0.instrumentId, $0) })
         XCTAssertEqual(rows[1]?.currentValueBase, 1500, accuracy: 0.01)
         XCTAssertEqual(rows[2]?.currentValueBase, 450, accuracy: 0.01)
+        XCTAssertEqual(rows[2]?.notes, "Tech")
         XCTAssertEqual(rows[3]?.flag, "FX missing — excluded")
         XCTAssertEqual(rows[4]?.flag, "No position")
         sqlite3_close(manager.db)

--- a/DragonShieldTests/PortfolioValuationServiceTests.swift
+++ b/DragonShieldTests/PortfolioValuationServiceTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+import SQLite3
+@testable import DragonShield
+
+final class PortfolioValuationServiceTests: XCTestCase {
+    private func setupManager() -> DatabaseManager {
+        let manager = DatabaseManager()
+        var db: OpaquePointer?
+        sqlite3_open(":memory:", &db)
+        manager.db = db
+        manager.baseCurrency = "CHF"
+        let sql = """
+        CREATE TABLE PortfolioThemeStatus (id INTEGER PRIMARY KEY, code TEXT, name TEXT, color_hex TEXT, is_default INTEGER);
+        INSERT INTO PortfolioThemeStatus VALUES (1,'ACTIVE','Active','#fff',1);
+        CREATE TABLE PortfolioTheme (id INTEGER PRIMARY KEY, name TEXT, code TEXT, status_id INTEGER, archived_at TEXT, soft_delete INTEGER DEFAULT 0);
+        INSERT INTO PortfolioTheme VALUES (1,'Core','CORE',1,NULL,0);
+        CREATE TABLE PortfolioThemeAsset (theme_id INTEGER, instrument_id INTEGER, research_target_pct REAL, user_target_pct REAL, notes TEXT, PRIMARY KEY(theme_id,instrument_id));
+        INSERT INTO PortfolioThemeAsset VALUES (1,1,25,25,NULL);
+        INSERT INTO PortfolioThemeAsset VALUES (1,2,25,20,NULL);
+        INSERT INTO PortfolioThemeAsset VALUES (1,3,30,35,NULL);
+        INSERT INTO PortfolioThemeAsset VALUES (1,4,20,20,NULL);
+        CREATE TABLE Instruments (instrument_id INTEGER PRIMARY KEY, instrument_name TEXT, currency TEXT);
+        INSERT INTO Instruments VALUES (1,'AAPL','CHF');
+        INSERT INTO Instruments VALUES (2,'MSFT','USD');
+        INSERT INTO Instruments VALUES (3,'VOO','EUR');
+        INSERT INTO Instruments VALUES (4,'CASH','CHF');
+        CREATE TABLE PositionReports (position_id INTEGER PRIMARY KEY AUTOINCREMENT, import_session_id INTEGER, instrument_id INTEGER, quantity REAL, current_price REAL, report_date TEXT);
+        INSERT INTO PositionReports (import_session_id,instrument_id,quantity,current_price,report_date) VALUES (10,1,10,100,'2025-08-20T14:05:00Z');
+        INSERT INTO PositionReports (import_session_id,instrument_id,quantity,current_price,report_date) VALUES (10,1,5,100,'2025-08-20T14:05:00Z');
+        INSERT INTO PositionReports (import_session_id,instrument_id,quantity,current_price,report_date) VALUES (10,2,50,10,'2025-08-20T14:05:00Z');
+        INSERT INTO PositionReports (import_session_id,instrument_id,quantity,current_price,report_date) VALUES (10,3,7,100,'2025-08-20T14:05:00Z');
+        CREATE TABLE ExchangeRates (currency_code TEXT, rate_date TEXT, rate_to_chf REAL);
+        INSERT INTO ExchangeRates VALUES ('USD','2025-08-20T14:00:00Z',0.9);
+        """
+        sqlite3_exec(db, sql, nil, nil, nil)
+        return manager
+    }
+
+    func testSnapshotAggregatesAndFlags() {
+        let manager = setupManager()
+        let service = PortfolioValuationService(dbManager: manager)
+        let snap = service.snapshot(themeId: 1)
+        XCTAssertEqual(snap.totalValueBase, 1950, accuracy: 0.01)
+        XCTAssertEqual(snap.excludedFxCount, 1)
+        let rows = Dictionary(uniqueKeysWithValues: snap.rows.map { ($0.instrumentId, $0) })
+        XCTAssertEqual(rows[1]?.currentValueBase, 1500, accuracy: 0.01)
+        XCTAssertEqual(rows[2]?.currentValueBase, 450, accuracy: 0.01)
+        XCTAssertEqual(rows[3]?.flag, "FX missing — excluded")
+        XCTAssertEqual(rows[4]?.flag, "No position")
+        sqlite3_close(manager.db)
+    }
+}


### PR DESCRIPTION
## Summary
- compute theme valuation snapshot from latest positions with FX conversion
- display refreshable valuation in theme detail view
- cover valuation aggregation and edge cases with tests
- fix valuation to aggregate instrument holdings across entire estate
- fix instrument notes edits not saving in theme detail view

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68a5aa6f7650832392836c08a87f3edb