### PR TITLE
feat: add totals and instrument count to themes list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Fix Portfolio Theme allocation edits not persisting and log updates
 - Fix instrument notes edits not saving in theme detail view
 - Present valuation status and notes in dedicated columns to avoid confusion
+- Show total value and instrument count columns with sortable headers in Portfolio Themes list
 - Introduce PortfolioThemeAsset table linking themes to instruments with target allocations
 - Add PortfolioTheme entity with CRUD UI and migration 010
 - Fix Portfolio Theme creation to persist database records and improve new theme editor layout

--- a/DragonShield/DatabaseManager+PortfolioThemeAssets.swift
+++ b/DragonShield/DatabaseManager+PortfolioThemeAssets.swift
@@ -198,4 +198,18 @@ extension DatabaseManager {
         sqlite3_finalize(stmt)
         return ok
     }
+
+    func countThemeAssets(themeId: Int) -> Int {
+        let sql = "SELECT COUNT(*) FROM PortfolioThemeAsset WHERE theme_id = ?"
+        var stmt: OpaquePointer?
+        var result = 0
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            sqlite3_bind_int(stmt, 1, Int32(themeId))
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                result = Int(sqlite3_column_int(stmt, 0))
+            }
+        }
+        sqlite3_finalize(stmt)
+        return result
+    }
 }

--- a/DragonShieldTests/PortfolioThemeAssetCountTests.swift
+++ b/DragonShieldTests/PortfolioThemeAssetCountTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+import SQLite3
+@testable import DragonShield
+
+final class PortfolioThemeAssetCountTests: XCTestCase {
+    private func setupDb(_ manager: DatabaseManager) {
+        var mem: OpaquePointer?
+        sqlite3_open(":memory:", &mem)
+        manager.db = mem
+        let sql = """
+        CREATE TABLE PortfolioThemeStatus (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            code TEXT NOT NULL UNIQUE,
+            name TEXT NOT NULL,
+            color_hex TEXT NOT NULL,
+            is_default INTEGER NOT NULL,
+            created_at TEXT DEFAULT '',
+            updated_at TEXT DEFAULT ''
+        );
+        INSERT INTO PortfolioThemeStatus (code,name,color_hex,is_default) VALUES ('ACTIVE','Active','#FFFFFF',1);
+        CREATE TABLE PortfolioTheme (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            code TEXT NOT NULL,
+            status_id INTEGER NOT NULL,
+            created_at TEXT DEFAULT '',
+            updated_at TEXT DEFAULT '',
+            archived_at TEXT,
+            soft_delete INTEGER DEFAULT 0
+        );
+        CREATE TABLE Instruments (
+            instrument_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            instrument_name TEXT NOT NULL,
+            sub_class_id INTEGER NOT NULL,
+            currency TEXT NOT NULL
+        );
+        INSERT INTO Instruments (instrument_name, sub_class_id, currency) VALUES ('A',1,'CHF');
+        INSERT INTO Instruments (instrument_name, sub_class_id, currency) VALUES ('B',1,'CHF');
+        """
+        sqlite3_exec(manager.db, sql, nil, nil, nil)
+        manager.ensurePortfolioThemeAssetTable()
+        _ = manager.createPortfolioTheme(name: "Growth", code: "GROWTH", statusId: 1)
+    }
+
+    func testCountThemeAssets() {
+        let manager = DatabaseManager()
+        setupDb(manager)
+        guard let theme = manager.fetchPortfolioThemes().first else { XCTFail(); return }
+        _ = manager.createThemeAsset(themeId: theme.id, instrumentId: 1, researchPct: 10.0)
+        _ = manager.createThemeAsset(themeId: theme.id, instrumentId: 2, researchPct: 15.0)
+        let count = manager.countThemeAssets(themeId: theme.id)
+        XCTAssertEqual(count, 2)
+        sqlite3_close(manager.db)
+    }
+}


### PR DESCRIPTION
## Summary
- show total value and instrument count columns in Portfolio Themes list with archived styling
- persist sort order and support sorting by totals and instruments
- expose helper to count theme assets and test it

## Testing
- `make setup` *(failed: No rule to make target 'setup')*
- `make fmt` *(failed: No rule to make target 'fmt')*
- `make lint` *(failed: No rule to make target 'lint')*
- `make migrate` *(failed: No rule to make target 'migrate')*
- `make build` *(failed: No rule to make target 'build')*
- `make test` *(failed: No rule to make target 'test')*
- `swift test` *(failed: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e914e4c48323919908b37c4977f8