### PR TITLE
feat: show totals and instrument counts in portfolio themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Add Total Value and Instruments columns with sortable headers to Portfolio Themes list
+- Fix total value column stuck displaying spinner in Portfolio Themes list
 - Add on-demand Portfolio Valuation service with refreshable theme snapshot
 - Include instrument notes in valuation snapshot output
 - Fix valuation to aggregate instrument holdings across the entire estate

--- a/DragonShield/DatabaseManager+PortfolioThemes.swift
+++ b/DragonShield/DatabaseManager+PortfolioThemes.swift
@@ -76,7 +76,10 @@ extension DatabaseManager {
                 let updatedAt = String(cString: sqlite3_column_text(stmt, 5))
                 let archivedAt = sqlite3_column_text(stmt, 6).map { String(cString: $0) }
                 let softDelete = sqlite3_column_int(stmt, 7) == 1
-                themes.append(PortfolioTheme(id: id, name: name, code: code, statusId: statusId, createdAt: createdAt, updatedAt: updatedAt, archivedAt: archivedAt, softDelete: softDelete))
+                let count = singleIntQuery("SELECT COUNT(*) FROM PortfolioThemeAsset WHERE theme_id = ?") { bindStmt in
+                    sqlite3_bind_int(bindStmt, 1, Int32(id))
+                } ?? 0
+                themes.append(PortfolioTheme(id: id, name: name, code: code, statusId: statusId, createdAt: createdAt, updatedAt: updatedAt, archivedAt: archivedAt, softDelete: softDelete, totalValueBase: nil, instrumentCount: count))
             }
         } else {
             LoggingService.shared.log("Failed to prepare fetchPortfolioThemes: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
@@ -136,7 +139,10 @@ extension DatabaseManager {
                 let updatedAt = String(cString: sqlite3_column_text(stmt, 5))
                 let archivedAt = sqlite3_column_text(stmt, 6).map { String(cString: $0) }
                 let softDelete = sqlite3_column_int(stmt, 7) == 1
-                theme = PortfolioTheme(id: id, name: name, code: code, statusId: statusId, createdAt: createdAt, updatedAt: updatedAt, archivedAt: archivedAt, softDelete: softDelete)
+                let count = singleIntQuery("SELECT COUNT(*) FROM PortfolioThemeAsset WHERE theme_id = ?") { bindStmt in
+                    sqlite3_bind_int(bindStmt, 1, Int32(id))
+                } ?? 0
+                theme = PortfolioTheme(id: id, name: name, code: code, statusId: statusId, createdAt: createdAt, updatedAt: updatedAt, archivedAt: archivedAt, softDelete: softDelete, totalValueBase: nil, instrumentCount: count)
             }
         }
         sqlite3_finalize(stmt)

--- a/DragonShield/Models/PortfolioTheme.swift
+++ b/DragonShield/Models/PortfolioTheme.swift
@@ -1,6 +1,7 @@
 // DragonShield/Models/PortfolioTheme.swift
-// MARK: - Version 1.1
+// MARK: - Version 1.2
 // MARK: - History
+// - Added optional totalValueBase and instrumentCount for list overview metrics.
 // - Conformed to Hashable for SwiftUI List selection compatibility.
 // - Initial creation: Represents user-defined portfolio themes.
 
@@ -20,6 +21,8 @@ struct PortfolioTheme: Identifiable, Hashable {
     var updatedAt: String
     var archivedAt: String?
     var softDelete: Bool
+    var totalValueBase: Double? = nil
+    var instrumentCount: Int = 0
 
     // Required for Hashable
     static func == (lhs: PortfolioTheme, rhs: PortfolioTheme) -> Bool {

--- a/DragonShield/Views/PortfolioThemesListView.swift
+++ b/DragonShield/Views/PortfolioThemesListView.swift
@@ -1,6 +1,8 @@
 // DragonShield/Views/PortfolioThemesListView.swift
-// MARK: - Version 2.4
+// MARK: - Version 2.5
 // MARK: - History
+// - Added Total Value and Instruments columns with sortable headers and persisted sort order.
+// - Render archived themes in gray and load valuations asynchronously.
 // - Fixed compilation error by using the correct 'sortUsing' parameter for TableColumn.
 // - Implemented custom sorting logic to sort the 'Status' column alphabetically by name.
 
@@ -8,6 +10,9 @@ import SwiftUI
 
 struct PortfolioThemesListView: View {
     @EnvironmentObject var dbManager: DatabaseManager
+
+    private enum SortField: String { case name, code, status, updatedAt, totalValue, instruments }
+    private let sortDefaultsKey = "PortfolioThemesListView.sort"
     
     // Local state for the data
     @State private var themes: [PortfolioTheme] = []
@@ -72,7 +77,7 @@ struct PortfolioThemesListView: View {
             }
         }
         .navigationTitle("Portfolio Themes")
-        .onAppear(perform: loadData)
+        .onAppear { restoreSortOrder(); loadData() }
         .sheet(isPresented: $showingAddSheet, onDismiss: loadData) {
             AddPortfolioThemeView(isPresented: $showingAddSheet, onSave: {})
                 .environmentObject(dbManager)
@@ -98,20 +103,35 @@ struct PortfolioThemesListView: View {
 
     private var themesTable: some View {
         Table(themes, selection: $selectedThemeId, sortOrder: $sortOrder) {
-            TableColumn("Name", value: \.name)
-            TableColumn("Code", value: \.code)
-
-            TableColumn("Status", sortUsing: KeyPathComparator(\.statusId)) { theme in
-                Text(statusName(for: theme.statusId))
+            TableColumn(headerLabel("Name", field: .name), value: \.name) { theme in
+                Text(theme.name).foregroundStyle(isArchived(theme) ? .secondary : .primary)
             }
-
-            TableColumn("Last Updated", value: \.updatedAt)
-
+            TableColumn(headerLabel("Code", field: .code), value: \.code) { theme in
+                Text(theme.code).foregroundStyle(isArchived(theme) ? .secondary : .primary)
+            }
+            TableColumn(headerLabel("Status", field: .status), sortUsing: KeyPathComparator(\.statusId)) { theme in
+                Text(statusName(for: theme.statusId)).foregroundStyle(isArchived(theme) ? .secondary : .primary)
+            }
+            TableColumn(headerLabel("Last Updated", field: .updatedAt), value: \.updatedAt) { theme in
+                Text(theme.updatedAt).foregroundStyle(isArchived(theme) ? .secondary : .primary)
+            }
+            TableColumn(headerLabel("Total Value", field: .totalValue), sortUsing: KeyPathComparator(\.totalValueBase)) { theme in
+                totalValueCell(for: theme)
+            }
+            .width(min: 120)
+            TableColumn(headerLabel("Instruments", field: .instruments), value: \.instrumentCount) { theme in
+                Text("\(theme.instrumentCount)")
+                    .monospacedDigit()
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+                    .foregroundStyle(isArchived(theme) ? .secondary : .primary)
+            }
+            .width(min: 80)
             TableColumn("", content: { theme in
                 Button {
                     open(theme)
                 } label: {
                     Image(systemName: "chevron.right")
+                        .foregroundColor(isArchived(theme) ? .secondary : .primary)
                 }
                 .buttonStyle(.plain)
                 .help("Open Theme Details")
@@ -120,11 +140,9 @@ struct PortfolioThemesListView: View {
             .width(30)
         }
         .onChange(of: sortOrder) { newOrder in
-            // This custom logic sorts the table correctly when any header is clicked
             guard let comparator = newOrder.first else { return }
-
+            persistSortOrder()
             if comparator.keyPath == \.statusId {
-                // If the "Status" column is clicked, sort by the status name string
                 themes.sort { lhs, rhs in
                     let nameLHS = statusName(for: lhs.statusId)
                     let nameRHS = statusName(for: rhs.statusId)
@@ -134,8 +152,27 @@ struct PortfolioThemesListView: View {
                         return nameLHS.localizedStandardCompare(nameRHS) == .orderedDescending
                     }
                 }
+            } else if comparator.keyPath == \.totalValueBase {
+                themes.sort { lhs, rhs in
+                    let l = lhs.totalValueBase
+                    let r = rhs.totalValueBase
+                    if comparator.order == .forward {
+                        switch (l, r) {
+                        case let (l?, r?): return l < r
+                        case (nil, _?): return true
+                        case (_?, nil): return false
+                        default: return false
+                        }
+                    } else {
+                        switch (l, r) {
+                        case let (l?, r?): return l > r
+                        case (nil, _?): return false
+                        case (_?, nil): return true
+                        default: return false
+                        }
+                    }
+                }
             } else {
-                // For all other columns, use the default sorting
                 themes.sort(using: newOrder)
             }
         }
@@ -150,10 +187,94 @@ struct PortfolioThemesListView: View {
         self.themes = dbManager.fetchPortfolioThemes(includeArchived: true, includeSoftDeleted: false, search: nil)
         // Ensure data is sorted when first loaded
         self.themes.sort(using: self.sortOrder)
+        loadValuations()
     }
 
     private func statusName(for id: Int) -> String {
         return statuses.first { $0.id == id }?.name ?? "N/A"
+    }
+
+    private func isArchived(_ theme: PortfolioTheme) -> Bool {
+        statuses.first { $0.id == theme.statusId }?.code == PortfolioThemeStatus.archivedCode
+    }
+
+    private func headerLabel(_ title: String, field: SortField) -> Text {
+        if let comp = sortOrder.first, sortField(for: comp) == field {
+            let asc = comp.order == .forward
+            return Text("\(title) \(asc ? "▲" : "▼")").foregroundColor(.accentColor)
+        } else {
+            return Text("\(title) ↕").foregroundColor(.secondary)
+        }
+    }
+
+    private func sortField(for comparator: KeyPathComparator<PortfolioTheme>) -> SortField? {
+        switch comparator.keyPath {
+        case \.name: return .name
+        case \.code: return .code
+        case \.statusId: return .status
+        case \.updatedAt: return .updatedAt
+        case \.totalValueBase: return .totalValue
+        case \.instrumentCount: return .instruments
+        default: return nil
+        }
+    }
+
+    private func persistSortOrder() {
+        guard let comp = sortOrder.first, let field = sortField(for: comp) else { return }
+        let asc = comp.order == .forward ? "asc" : "desc"
+        UserDefaults.standard.set("\(field.rawValue)|\(asc)", forKey: sortDefaultsKey)
+    }
+
+    private func restoreSortOrder() {
+        guard let saved = UserDefaults.standard.string(forKey: sortDefaultsKey) else {
+            sortOrder = [KeyPathComparator(\.updatedAt, order: .reverse)]
+            return
+        }
+        let parts = saved.split(separator: "|")
+        guard parts.count == 2, let field = SortField(rawValue: String(parts[0])) else {
+            sortOrder = [KeyPathComparator(\.updatedAt, order: .reverse)]
+            return
+        }
+        let asc = parts[1] == "asc"
+        switch field {
+        case .name: sortOrder = [KeyPathComparator(\.name, order: asc ? .forward : .reverse)]
+        case .code: sortOrder = [KeyPathComparator(\.code, order: asc ? .forward : .reverse)]
+        case .status: sortOrder = [KeyPathComparator(\.statusId, order: asc ? .forward : .reverse)]
+        case .updatedAt: sortOrder = [KeyPathComparator(\.updatedAt, order: asc ? .forward : .reverse)]
+        case .totalValue: sortOrder = [KeyPathComparator(\.totalValueBase, order: asc ? .forward : .reverse)]
+        case .instruments: sortOrder = [KeyPathComparator(\.instrumentCount, order: asc ? .forward : .reverse)]
+        }
+    }
+
+    private func loadValuations() {
+        let service = PortfolioValuationService(dbManager: dbManager)
+        for theme in themes {
+            Task.detached { [theme] in
+                let value = service.snapshot(themeId: theme.id).totalValueBase
+                await MainActor.run {
+                    if let idx = self.themes.firstIndex(where: { $0.id == theme.id }) {
+                        self.themes[idx].totalValueBase = value
+                        self.themes.sort(using: self.sortOrder)
+                    }
+                }
+            }
+        }
+    }
+
+    private func totalValueCell(for theme: PortfolioTheme) -> some View {
+        Group {
+            if let value = theme.totalValueBase {
+                Text(value, format: .currency(code: dbManager.baseCurrency).precision(.fractionLength(2)))
+                    .monospacedDigit()
+            } else {
+                HStack(spacing: 4) {
+                    Text("—")
+                    ProgressView().controlSize(.small)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .trailing)
+        .foregroundStyle(isArchived(theme) ? .secondary : .primary)
     }
     
     func handleDelete(_ theme: PortfolioTheme) {

--- a/DragonShieldTests/PortfolioThemeInstrumentCountTests.swift
+++ b/DragonShieldTests/PortfolioThemeInstrumentCountTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+import SQLite3
+@testable import DragonShield
+
+final class PortfolioThemeInstrumentCountTests: XCTestCase {
+    private func setup(_ manager: DatabaseManager) {
+        var mem: OpaquePointer?
+        sqlite3_open(":memory:", &mem)
+        manager.db = mem
+        let sql = """
+        CREATE TABLE PortfolioThemeStatus (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            code TEXT NOT NULL,
+            name TEXT NOT NULL,
+            color_hex TEXT NOT NULL,
+            is_default INTEGER NOT NULL
+        );
+        INSERT INTO PortfolioThemeStatus (code,name,color_hex,is_default) VALUES ('ACTIVE','Active','#FFFFFF',1);
+        CREATE TABLE PortfolioTheme (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            code TEXT NOT NULL,
+            status_id INTEGER NOT NULL,
+            created_at TEXT DEFAULT '',
+            updated_at TEXT DEFAULT '',
+            archived_at TEXT,
+            soft_delete INTEGER DEFAULT 0
+        );
+        CREATE TABLE Instruments (
+            instrument_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            instrument_name TEXT NOT NULL,
+            sub_class_id INTEGER NOT NULL,
+            currency TEXT NOT NULL
+        );
+        """
+        sqlite3_exec(manager.db, sql, nil, nil, nil)
+        manager.ensurePortfolioThemeAssetTable()
+    }
+
+    func testFetchThemesReturnsInstrumentCount() {
+        let manager = DatabaseManager()
+        setup(manager)
+        _ = manager.createPortfolioTheme(name: "Growth", code: "GROWTH", statusId: 1)
+        sqlite3_exec(manager.db, "INSERT INTO Instruments (instrument_name, sub_class_id, currency) VALUES ('Apple',1,'USD');", nil, nil, nil)
+        sqlite3_exec(manager.db, "INSERT INTO Instruments (instrument_name, sub_class_id, currency) VALUES ('Tesla',1,'USD');", nil, nil, nil)
+        guard let theme = manager.fetchPortfolioThemes().first else { XCTFail(); return }
+        _ = manager.createThemeAsset(themeId: theme.id, instrumentId: 1, researchPct: 50.0)
+        _ = manager.createThemeAsset(themeId: theme.id, instrumentId: 2, researchPct: 50.0)
+        let fetched = manager.fetchPortfolioThemes()
+        XCTAssertEqual(fetched.first?.instrumentCount, 2)
+        sqlite3_close(manager.db)
+    }
+}


### PR DESCRIPTION
## Summary
- add Total Value and Instruments columns to Portfolio Themes overview
- persist sort preferences with header indicators and archived row styling
- fetch instrument counts and async valuations; include unit test
- fix total value column stuck displaying spinner in Portfolio Themes list

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild test -project DragonShield.xcodeproj -scheme DragonShield -destination 'platform=macOS'` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e914e4c48323919908b37c4977f8