### PR TITLE
Fix total value not updating in Portfolio Themes list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Fix Portfolio Themes list not updating Total Value after valuations load
 - Add Total Value and Instruments columns with sortable headers to Portfolio Themes list
 - Fix theme total value spinner by loading valuations sequentially
 - Optimize portfolio theme fetch to count instruments without per-row queries

--- a/DragonShield/Models/PortfolioTheme.swift
+++ b/DragonShield/Models/PortfolioTheme.swift
@@ -7,40 +7,31 @@
 
 import Foundation
 
-// Add Hashable conformance
+// Hashable conformance is synthesized; equality must reflect valuation updates.
 struct PortfolioTheme: Identifiable, Hashable {
-    let id: Int
-    var name: String
-    let code: String
-    // This property does not exist in the database table or creation method,
-    // so it should be removed from the main struct if not used elsewhere.
-    // For now, we will assume it might be used in other contexts.
-    // var description: String? 
-    var statusId: Int
-    var createdAt: String
-    var updatedAt: String
-    var archivedAt: String?
-    var softDelete: Bool
-    var totalValueBase: Double? = nil
-    var instrumentCount: Int = 0
+  let id: Int
+  var name: String
+  let code: String
+  // This property does not exist in the database table or creation method,
+  // so it should be removed from the main struct if not used elsewhere.
+  // For now, we will assume it might be used in other contexts.
+  // var description: String?
+  var statusId: Int
+  var createdAt: String
+  var updatedAt: String
+  var archivedAt: String?
+  var softDelete: Bool
+  var totalValueBase: Double? = nil
+  var instrumentCount: Int = 0
 
-    // Required for Hashable
-    static func == (lhs: PortfolioTheme, rhs: PortfolioTheme) -> Bool {
-        lhs.id == rhs.id
-    }
+  static func isValidName(_ name: String) -> Bool {
+    let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+    return !trimmed.isEmpty && trimmed.count <= 64
+  }
 
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(id)
-    }
-
-    static func isValidName(_ name: String) -> Bool {
-        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
-        return !trimmed.isEmpty && trimmed.count <= 64
-    }
-
-    static func isValidCode(_ code: String) -> Bool {
-        let trimmed = code.trimmingCharacters(in: .whitespacesAndNewlines)
-        let pattern = "^[A-Z][A-Z0-9_]{1,30}$"
-        return trimmed.range(of: pattern, options: .regularExpression) != nil
-    }
+  static func isValidCode(_ code: String) -> Bool {
+    let trimmed = code.trimmingCharacters(in: .whitespacesAndNewlines)
+    let pattern = "^[A-Z][A-Z0-9_]{1,30}$"
+    return trimmed.range(of: pattern, options: .regularExpression) != nil
+  }
 }

--- a/DragonShield/Models/PortfolioTheme.swift
+++ b/DragonShield/Models/PortfolioTheme.swift
@@ -9,20 +9,20 @@ import Foundation
 
 // Hashable conformance is synthesized; equality must reflect valuation updates.
 struct PortfolioTheme: Identifiable, Hashable {
-  let id: Int
-  var name: String
-  let code: String
-  // This property does not exist in the database table or creation method,
-  // so it should be removed from the main struct if not used elsewhere.
-  // For now, we will assume it might be used in other contexts.
-  // var description: String?
-  var statusId: Int
-  var createdAt: String
-  var updatedAt: String
-  var archivedAt: String?
-  var softDelete: Bool
-  var totalValueBase: Double? = nil
-  var instrumentCount: Int = 0
+    let id: Int
+    var name: String
+    let code: String
+    // This property does not exist in the database table or creation method,
+    // so it should be removed from the main struct if not used elsewhere.
+    // For now, we will assume it might be used in other contexts.
+    // var description: String?
+    var statusId: Int
+    var createdAt: String
+    var updatedAt: String
+    var archivedAt: String?
+    var softDelete: Bool
+    var totalValueBase: Double? = nil
+    var instrumentCount: Int = 0
 
   static func isValidName(_ name: String) -> Bool {
     let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/DragonShieldTests/PortfolioThemeEqualityTests.swift
+++ b/DragonShieldTests/PortfolioThemeEqualityTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+
+@testable import DragonShield
+
+final class PortfolioThemeEqualityTests: XCTestCase {
+  func testTotalValueBaseAffectsEquality() {
+    var a = PortfolioTheme(
+      id: 1, name: "T", code: "T", statusId: 1, createdAt: "", updatedAt: "", archivedAt: nil,
+      softDelete: false)
+    var b = a
+    XCTAssertEqual(a, b)
+    a.totalValueBase = 100
+    XCTAssertNotEqual(a, b)
+  }
+}

--- a/DragonShieldTests/PortfolioThemeEqualityTests.swift
+++ b/DragonShieldTests/PortfolioThemeEqualityTests.swift
@@ -3,13 +3,13 @@ import XCTest
 @testable import DragonShield
 
 final class PortfolioThemeEqualityTests: XCTestCase {
-  func testTotalValueBaseAffectsEquality() {
-    var a = PortfolioTheme(
-      id: 1, name: "T", code: "T", statusId: 1, createdAt: "", updatedAt: "", archivedAt: nil,
-      softDelete: false)
-    var b = a
-    XCTAssertEqual(a, b)
-    a.totalValueBase = 100
-    XCTAssertNotEqual(a, b)
-  }
+    func testTotalValueBaseAffectsEquality() {
+        var a = PortfolioTheme(
+            id: 1, name: "T", code: "T", statusId: 1, createdAt: "2023-01-01T12:00:00Z", updatedAt: "2023-01-01T12:00:00Z", archivedAt: nil,
+            softDelete: false)
+        var b = a
+        XCTAssertEqual(a, b)
+        a.totalValueBase = 100
+        XCTAssertNotEqual(a, b)
+    }
 }


### PR DESCRIPTION
## Summary
- let PortfolioTheme use synthesized Equatable/Hashable so valuation updates refresh UI
- add regression test ensuring totalValueBase affects equality
- document fix in CHANGELOG

## Testing
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild -scheme DragonShield -project DragonShield.xcodeproj -quiet` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68a7488425288323a3ee0acbec6dff1f