### PR TITLE
Improve theme valuation FX handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Ensure Portfolio Theme valuation shows all instruments, resolves FX via identity and inversion, and keeps table visible for zero totals
 - Fix Portfolio Themes list not updating Total Value after valuations load
 - Add Total Value and Instruments columns with sortable headers to Portfolio Themes list
 - Fix theme total value spinner by loading valuations sequentially

--- a/DragonShield/PortfolioValuationService.swift
+++ b/DragonShield/PortfolioValuationService.swift
@@ -9,7 +9,7 @@ struct ValuationRow: Identifiable {
     let currentValueBase: Double
     let actualPct: Double
     let notes: String?
-    let flag: String?
+    let status: String
     var id: Int { instrumentId }
 }
 
@@ -58,6 +58,8 @@ final class PortfolioValuationService {
         var total: Double = 0
         var fxAsOf: Date? = nil
         var excludedFx = 0
+        var noPos = 0
+        var included = 0
         var missing: Set<String> = []
 
         let sql = """
@@ -78,67 +80,101 @@ final class PortfolioValuationService {
                 let currency = String(cString: sqlite3_column_text(stmt, 4))
                 let nativeValue = sqlite3_column_double(stmt, 5)
                 let note = sqlite3_column_text(stmt, 6).map { String(cString: $0) }
-                var flag: String? = nil
+                var status = "OK"
                 var valueBase: Double = 0
                 if nativeValue == 0 {
-                    flag = "No position"
-                } else if currency == dbManager.baseCurrency {
-                    valueBase = nativeValue
-                } else if let rate = fetchRate(for: currency, asOf: positionsAsOf, fxAsOf: &fxAsOf) {
+                    status = "No position"
+                    noPos += 1
+                } else if let rate = fetchRate(from: currency, to: dbManager.baseCurrency, asOf: positionsAsOf, fxAsOf: &fxAsOf) {
                     valueBase = nativeValue * rate
+                    included += 1
                 } else {
-                    flag = "FX missing — excluded"
+                    status = "FX missing — excluded"
                     excludedFx += 1
                     missing.insert(currency)
                 }
-                rows.append(ValuationRow(instrumentId: instrId, instrumentName: name, researchTargetPct: research, userTargetPct: user, currentValueBase: valueBase, actualPct: 0, notes: note, flag: flag))
-                if flag == nil { total += valueBase }
+                rows.append(ValuationRow(instrumentId: instrId, instrumentName: name, researchTargetPct: research, userTargetPct: user, currentValueBase: valueBase, actualPct: 0, notes: note, status: status))
+                if status == "OK" { total += valueBase }
             }
         }
-        
         sqlite3_finalize(stmt)
 
-        var valuedCount = 0
         rows = rows.map { row in
             var pct: Double = 0
-            if total > 0 && row.flag == nil {
+            if total > 0 && row.status == "OK" {
                 pct = row.currentValueBase / total * 100
-                valuedCount += 1
             }
-            return ValuationRow(instrumentId: row.instrumentId, instrumentName: row.instrumentName, researchTargetPct: row.researchTargetPct, userTargetPct: row.userTargetPct, currentValueBase: row.currentValueBase, actualPct: pct, notes: row.notes, flag: row.flag)
+            return ValuationRow(instrumentId: row.instrumentId, instrumentName: row.instrumentName, researchTargetPct: row.researchTargetPct, userTargetPct: row.userTargetPct, currentValueBase: row.currentValueBase, actualPct: pct, notes: row.notes, status: row.status)
         }
 
         let duration = Int(Date().timeIntervalSince(start) * 1000)
         if let t = theme {
-            let posStr = positionsAsOf.map { Self.dateFormatter.string(from: $0) } ?? ""
-            let fxStr = fxAsOf.map { Self.dateFormatter.string(from: $0) } ?? ""
-            LoggingService.shared.log("valuation themeId=\(t.id) themeCode=\(t.code) positions_asof=\(posStr) fx_asof=\(fxStr) instrumentsN=\(rows.count) valuedN=\(valuedCount) excludedFxN=\(excludedFx) totalBase=\(String(format: "%.2f", total)) duration_ms=\(duration)", logger: .database)
+            let event: [String: Any] = [
+                "themeId": t.id,
+                "positions_asof": positionsAsOf.map { Self.dateFormatter.string(from: $0) } ?? NSNull(),
+                "fx_asof": fxAsOf.map { Self.dateFormatter.string(from: $0) } ?? NSNull(),
+                "rows_total": rows.count,
+                "rows_no_position": noPos,
+                "rows_fx_missing": excludedFx,
+                "rows_included": included,
+                "total_base": total,
+                "duration_ms": duration
+            ]
+            if let data = try? JSONSerialization.data(withJSONObject: event),
+               let json = String(data: data, encoding: .utf8) {
+                LoggingService.shared.log(json, logger: .database)
+            }
         }
 
         return ValuationSnapshot(positionsAsOf: positionsAsOf, fxAsOf: fxAsOf, totalValueBase: total, rows: rows, excludedFxCount: excludedFx, missingCurrencies: Array(missing))
     }
 
-    private func fetchRate(for currency: String, asOf: Date?, fxAsOf: inout Date?) -> Double? {
+    private func fetchRate(from valueCcy: String, to baseCcy: String, asOf: Date?, fxAsOf: inout Date?) -> Double? {
+        if valueCcy == baseCcy { return 1.0 }
         guard let db = dbManager.db else { return nil }
         let dateStr = asOf.map { Self.dateFormatter.string(from: $0) } ?? Self.dateFormatter.string(from: Date())
         let sql = "SELECT rate_to_chf, rate_date FROM ExchangeRates WHERE currency_code = ? AND rate_date <= ? ORDER BY rate_date DESC LIMIT 1"
-        var stmt: OpaquePointer?
-        var result: Double?
-        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
-            sqlite3_bind_text(stmt, 1, currency, -1, nil)
-            sqlite3_bind_text(stmt, 2, dateStr, -1, nil)
-            if sqlite3_step(stmt) == SQLITE_ROW {
-                result = sqlite3_column_double(stmt, 0)
-                if let cString = sqlite3_column_text(stmt, 1) {
-                    let date = Self.dateFormatter.date(from: String(cString: cString))
-                    if let d = date, d > (fxAsOf ?? .distantPast) {
-                        fxAsOf = d
+
+        func query(_ ccy: String) -> (Double, Date)? {
+            var stmt: OpaquePointer?
+            defer { sqlite3_finalize(stmt) }
+            if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+                sqlite3_bind_text(stmt, 1, ccy, -1, nil)
+                sqlite3_bind_text(stmt, 2, dateStr, -1, nil)
+                if sqlite3_step(stmt) == SQLITE_ROW {
+                    let rate = sqlite3_column_double(stmt, 0)
+                    let date: Date
+                    if let cString = sqlite3_column_text(stmt, 1),
+                       let d = Self.dateFormatter.date(from: String(cString: cString)) {
+                        date = d
+                    } else {
+                        date = asOf ?? Date()
                     }
+                    return (rate, date)
                 }
             }
+            return nil
         }
-        sqlite3_finalize(stmt)
-        return result
+
+        guard let valueInfo = query(valueCcy) else { return nil }
+        let baseInfo: (Double, Date)
+        if baseCcy == "CHF" {
+            baseInfo = (1.0, valueInfo.1)
+        } else if let info = query(baseCcy) {
+            baseInfo = info
+        } else {
+            return nil
+        }
+
+        let usedDate = max(valueInfo.1, baseInfo.1)
+        if usedDate > (fxAsOf ?? .distantPast) { fxAsOf = usedDate }
+
+        if baseCcy == "CHF" {
+            return valueInfo.0
+        } else if valueCcy == "CHF" {
+            return 1.0 / baseInfo.0
+        } else {
+            return valueInfo.0 / baseInfo.0
+        }
     }
 }
-

--- a/DragonShield/Views/PortfolioThemeDetailView.swift
+++ b/DragonShield/Views/PortfolioThemeDetailView.swift
@@ -176,6 +176,7 @@ private var valuationSection: some View {
         if let snap = valuation {
             let pos = snap.positionsAsOf.map { DateFormatter.iso8601DateTime.string(from: $0) } ?? "—"
             let fx = snap.fxAsOf.map { DateFormatter.iso8601DateTime.string(from: $0) } ?? "—"
+            let totalPct = snap.rows.filter { $0.status == "OK" }.reduce(0) { $0 + $1.actualPct }
             Text("As of: Positions \(pos)  |  FX \(fx)")
             Text("Total Value (\(dbManager.baseCurrency)): \(snap.totalValueBase, format: .currency(code: dbManager.baseCurrency))")
             if snap.excludedFxCount > 0 {
@@ -186,36 +187,35 @@ private var valuationSection: some View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(8)
                     .background(Color.gray.opacity(0.1))
-            } else {
+            }
+            HStack {
+                Text("Instrument").frame(maxWidth: .infinity, alignment: .leading)
+                Text("Research %").frame(width: 72, alignment: .trailing)
+                Text("User %").frame(width: 72, alignment: .trailing)
+                Text("Current Value").frame(width: 120, alignment: .trailing)
+                Text("Actual %").frame(width: 72, alignment: .trailing)
+                Text("Status").frame(width: 120, alignment: .leading)
+                Text("Notes").frame(minWidth: 100, alignment: .leading)
+            }
+            ForEach(snap.rows) { row in
                 HStack {
-                    Text("Instrument").frame(maxWidth: .infinity, alignment: .leading)
-                    Text("Research %").frame(width: 72, alignment: .trailing)
-                    Text("User %").frame(width: 72, alignment: .trailing)
-                    Text("Current Value").frame(width: 120, alignment: .trailing)
-                    Text("Actual %").frame(width: 72, alignment: .trailing)
-                    Text("Status").frame(width: 120, alignment: .leading)
-                    Text("Notes").frame(minWidth: 100, alignment: .leading)
+                    Text(row.instrumentName).frame(maxWidth: .infinity, alignment: .leading)
+                    Text(row.researchTargetPct, format: .number.precision(.fractionLength(1))).frame(width: 72, alignment: .trailing)
+                    Text(row.userTargetPct, format: .number.precision(.fractionLength(1))).frame(width: 72, alignment: .trailing)
+                    Text(row.currentValueBase, format: .currency(code: dbManager.baseCurrency).precision(.fractionLength(2))).frame(width: 120, alignment: .trailing)
+                    Text(row.actualPct, format: .number.precision(.fractionLength(1))).frame(width: 72, alignment: .trailing)
+                    Text(row.status).frame(width: 120, alignment: .leading)
+                    Text(row.notes ?? "").frame(minWidth: 100, alignment: .leading)
                 }
-                ForEach(snap.rows) { row in
-                    HStack {
-                        Text(row.instrumentName).frame(maxWidth: .infinity, alignment: .leading)
-                        Text(row.researchTargetPct, format: .number.precision(.fractionLength(1))).frame(width: 72, alignment: .trailing)
-                        Text(row.userTargetPct, format: .number.precision(.fractionLength(1))).frame(width: 72, alignment: .trailing)
-                        Text(row.currentValueBase, format: .currency(code: dbManager.baseCurrency).precision(.fractionLength(2))).frame(width: 120, alignment: .trailing)
-                        Text(row.actualPct, format: .number.precision(.fractionLength(1))).frame(width: 72, alignment: .trailing)
-                        Text(row.flag ?? "").frame(width: 120, alignment: .leading)
-                        Text(row.notes ?? "").frame(minWidth: 100, alignment: .leading)
-                    }
-                }
-                HStack {
-                    Text("Totals").frame(maxWidth: .infinity, alignment: .leading)
-                    Spacer().frame(width: 72)
-                    Spacer().frame(width: 72)
-                    Text(snap.totalValueBase, format: .currency(code: dbManager.baseCurrency).precision(.fractionLength(2))).frame(width: 120, alignment: .trailing)
-                    Text(100, format: .number.precision(.fractionLength(1))).frame(width: 72, alignment: .trailing)
-                    Spacer().frame(width: 120)
-                    Spacer().frame(minWidth: 100)
-                }
+            }
+            HStack {
+                Text("Totals").frame(maxWidth: .infinity, alignment: .leading)
+                Spacer().frame(width: 72)
+                Spacer().frame(width: 72)
+                Text(snap.totalValueBase, format: .currency(code: dbManager.baseCurrency).precision(.fractionLength(2))).frame(width: 120, alignment: .trailing)
+                Text(totalPct, format: .number.precision(.fractionLength(1))).frame(width: 72, alignment: .trailing)
+                Spacer().frame(width: 120)
+                Spacer().frame(minWidth: 100)
             }
         } else {
             Text("No valued positions in the latest snapshot.")

--- a/DragonShieldTests/PortfolioValuationServiceTests.swift
+++ b/DragonShieldTests/PortfolioValuationServiceTests.swift
@@ -36,7 +36,7 @@ final class PortfolioValuationServiceTests: XCTestCase {
         return manager
     }
 
-    func testSnapshotAggregatesAndFlags() {
+    func testSnapshotAggregatesAndStatuses() {
         let manager = setupManager()
         let service = PortfolioValuationService(dbManager: manager)
         let snap = service.snapshot(themeId: 1)
@@ -44,10 +44,43 @@ final class PortfolioValuationServiceTests: XCTestCase {
         XCTAssertEqual(snap.excludedFxCount, 1)
         let rows = Dictionary(uniqueKeysWithValues: snap.rows.map { ($0.instrumentId, $0) })
         XCTAssertEqual(rows[1]?.currentValueBase, 1500, accuracy: 0.01)
+        XCTAssertEqual(rows[1]?.status, "OK")
         XCTAssertEqual(rows[2]?.currentValueBase, 450, accuracy: 0.01)
         XCTAssertEqual(rows[2]?.notes, "Tech")
-        XCTAssertEqual(rows[3]?.flag, "FX missing — excluded")
-        XCTAssertEqual(rows[4]?.flag, "No position")
+        XCTAssertEqual(rows[2]?.status, "OK")
+        XCTAssertEqual(rows[3]?.status, "FX missing — excluded")
+        XCTAssertEqual(rows[4]?.status, "No position")
+        sqlite3_close(manager.db)
+    }
+
+    func testRateInvertsWhenOnlyBaseRatePresent() {
+        let manager = DatabaseManager()
+        var db: OpaquePointer?
+        sqlite3_open(":memory:", &db)
+        manager.db = db
+        manager.baseCurrency = "USD"
+        let sql = """
+        CREATE TABLE PortfolioThemeStatus (id INTEGER PRIMARY KEY, code TEXT, name TEXT, color_hex TEXT, is_default INTEGER);
+        INSERT INTO PortfolioThemeStatus VALUES (1,'ACTIVE','Active','#fff',1);
+        CREATE TABLE PortfolioTheme (id INTEGER PRIMARY KEY, name TEXT, code TEXT, status_id INTEGER, archived_at TEXT, soft_delete INTEGER DEFAULT 0);
+        INSERT INTO PortfolioTheme VALUES (1,'Core','CORE',1,NULL,0);
+        CREATE TABLE PortfolioThemeAsset (theme_id INTEGER, instrument_id INTEGER, research_target_pct REAL, user_target_pct REAL, notes TEXT, PRIMARY KEY(theme_id,instrument_id));
+        INSERT INTO PortfolioThemeAsset VALUES (1,1,100,100,NULL);
+        CREATE TABLE Instruments (instrument_id INTEGER PRIMARY KEY, instrument_name TEXT, currency TEXT);
+        INSERT INTO Instruments VALUES (1,'AAPL','CHF');
+        CREATE TABLE PositionReports (position_id INTEGER PRIMARY KEY AUTOINCREMENT, import_session_id INTEGER, instrument_id INTEGER, quantity REAL, current_price REAL, report_date TEXT);
+        INSERT INTO PositionReports (import_session_id,instrument_id,quantity,current_price,report_date) VALUES (10,1,10,10,'2025-08-20T14:05:00Z');
+        CREATE TABLE ExchangeRates (currency_code TEXT, rate_date TEXT, rate_to_chf REAL);
+        INSERT INTO ExchangeRates VALUES ('USD','2025-08-20T14:00:00Z',0.8);
+        INSERT INTO ExchangeRates VALUES ('CHF','2025-08-20T14:00:00Z',1.0);
+        """
+        sqlite3_exec(db, sql, nil, nil, nil)
+        let service = PortfolioValuationService(dbManager: manager)
+        let snap = service.snapshot(themeId: 1)
+        XCTAssertEqual(snap.rows.first?.currentValueBase, 125, accuracy: 0.01)
+        XCTAssertEqual(snap.rows.first?.status, "OK")
+        let df = ISO8601DateFormatter()
+        XCTAssertEqual(df.string(from: snap.fxAsOf!), "2025-08-20T14:00:00Z")
         sqlite3_close(manager.db)
     }
 }


### PR DESCRIPTION
## Summary
- show all theme instruments even when FX or positions missing
- resolve FX using identity and inverted rates and log structured snapshot metrics
- keep valuation table visible with per-row status indicators

## Testing
- `make setup` (fails: No rule to make target 'setup')
- `make fmt` (fails: No rule to make target 'fmt')
- `make lint` (fails: No rule to make target 'lint')
- `make migrate` (fails: No rule to make target 'migrate')
- `make build` (fails: No rule to make target 'build')
- `make test` (fails: No rule to make target 'test')
- `swift test` (fails: Could not find Package.swift)
- `xcodebuild test -project DragonShield.xcodeproj -scheme DragonShield` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a74d15095c832386497349ac879f8a