### PR TITLE
Fix valuation rows and improve FX conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Always list theme instruments in valuation table and add robust FX conversion with crypto bridging
 - Fix Portfolio Themes list not updating Total Value after valuations load
 - Add Total Value and Instruments columns with sortable headers to Portfolio Themes list
 - Fix theme total value spinner by loading valuations sequentially

--- a/DragonShield/Views/PortfolioThemeDetailView.swift
+++ b/DragonShield/Views/PortfolioThemeDetailView.swift
@@ -186,36 +186,35 @@ private var valuationSection: some View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(8)
                     .background(Color.gray.opacity(0.1))
-            } else {
+            }
+            HStack {
+                Text("Instrument").frame(maxWidth: .infinity, alignment: .leading)
+                Text("Research %").frame(width: 72, alignment: .trailing)
+                Text("User %").frame(width: 72, alignment: .trailing)
+                Text("Current Value").frame(width: 120, alignment: .trailing)
+                Text("Actual %").frame(width: 72, alignment: .trailing)
+                Text("Status").frame(width: 120, alignment: .leading)
+                Text("Notes").frame(minWidth: 100, alignment: .leading)
+            }
+            ForEach(snap.rows) { row in
                 HStack {
-                    Text("Instrument").frame(maxWidth: .infinity, alignment: .leading)
-                    Text("Research %").frame(width: 72, alignment: .trailing)
-                    Text("User %").frame(width: 72, alignment: .trailing)
-                    Text("Current Value").frame(width: 120, alignment: .trailing)
-                    Text("Actual %").frame(width: 72, alignment: .trailing)
-                    Text("Status").frame(width: 120, alignment: .leading)
-                    Text("Notes").frame(minWidth: 100, alignment: .leading)
+                    Text(row.instrumentName).frame(maxWidth: .infinity, alignment: .leading)
+                    Text(row.researchTargetPct, format: .number.precision(.fractionLength(1))).frame(width: 72, alignment: .trailing)
+                    Text(row.userTargetPct, format: .number.precision(.fractionLength(1))).frame(width: 72, alignment: .trailing)
+                    Text(row.currentValueBase, format: .currency(code: dbManager.baseCurrency).precision(.fractionLength(2))).frame(width: 120, alignment: .trailing)
+                    Text(row.actualPct, format: .number.precision(.fractionLength(1))).frame(width: 72, alignment: .trailing)
+                    Text(row.status ?? "").frame(width: 120, alignment: .leading)
+                    Text(row.notes ?? "").frame(minWidth: 100, alignment: .leading)
                 }
-                ForEach(snap.rows) { row in
-                    HStack {
-                        Text(row.instrumentName).frame(maxWidth: .infinity, alignment: .leading)
-                        Text(row.researchTargetPct, format: .number.precision(.fractionLength(1))).frame(width: 72, alignment: .trailing)
-                        Text(row.userTargetPct, format: .number.precision(.fractionLength(1))).frame(width: 72, alignment: .trailing)
-                        Text(row.currentValueBase, format: .currency(code: dbManager.baseCurrency).precision(.fractionLength(2))).frame(width: 120, alignment: .trailing)
-                        Text(row.actualPct, format: .number.precision(.fractionLength(1))).frame(width: 72, alignment: .trailing)
-                        Text(row.flag ?? "").frame(width: 120, alignment: .leading)
-                        Text(row.notes ?? "").frame(minWidth: 100, alignment: .leading)
-                    }
-                }
-                HStack {
-                    Text("Totals").frame(maxWidth: .infinity, alignment: .leading)
-                    Spacer().frame(width: 72)
-                    Spacer().frame(width: 72)
-                    Text(snap.totalValueBase, format: .currency(code: dbManager.baseCurrency).precision(.fractionLength(2))).frame(width: 120, alignment: .trailing)
-                    Text(100, format: .number.precision(.fractionLength(1))).frame(width: 72, alignment: .trailing)
-                    Spacer().frame(width: 120)
-                    Spacer().frame(minWidth: 100)
-                }
+            }
+            HStack {
+                Text("Totals").frame(maxWidth: .infinity, alignment: .leading)
+                Spacer().frame(width: 72)
+                Spacer().frame(width: 72)
+                Text(snap.totalValueBase, format: .currency(code: dbManager.baseCurrency).precision(.fractionLength(2))).frame(width: 120, alignment: .trailing)
+                Text(100, format: .number.precision(.fractionLength(1))).frame(width: 72, alignment: .trailing)
+                Spacer().frame(width: 120)
+                Spacer().frame(minWidth: 100)
             }
         } else {
             Text("No valued positions in the latest snapshot.")

--- a/DragonShieldTests/PortfolioValuationServiceTests.swift
+++ b/DragonShieldTests/PortfolioValuationServiceTests.swift
@@ -36,7 +36,7 @@ final class PortfolioValuationServiceTests: XCTestCase {
         return manager
     }
 
-    func testSnapshotAggregatesAndFlags() {
+    func testSnapshotAggregatesAndStatuses() {
         let manager = setupManager()
         let service = PortfolioValuationService(dbManager: manager)
         let snap = service.snapshot(themeId: 1)
@@ -46,8 +46,42 @@ final class PortfolioValuationServiceTests: XCTestCase {
         XCTAssertEqual(rows[1]?.currentValueBase, 1500, accuracy: 0.01)
         XCTAssertEqual(rows[2]?.currentValueBase, 450, accuracy: 0.01)
         XCTAssertEqual(rows[2]?.notes, "Tech")
-        XCTAssertEqual(rows[3]?.flag, "FX missing — excluded")
-        XCTAssertEqual(rows[4]?.flag, "No position")
+        XCTAssertEqual(rows[3]?.status, "FX missing — excluded")
+        XCTAssertEqual(rows[4]?.status, "No position")
         sqlite3_close(manager.db)
+    }
+
+    func testFxInversionAndCryptoBridge() {
+        let manager = DatabaseManager()
+        var db: OpaquePointer?
+        sqlite3_open(":memory:", &db)
+        manager.db = db
+        manager.baseCurrency = "USD"
+        let sql = """
+        CREATE TABLE PortfolioThemeStatus (id INTEGER PRIMARY KEY, code TEXT, name TEXT, color_hex TEXT, is_default INTEGER);
+        INSERT INTO PortfolioThemeStatus VALUES (1,'ACTIVE','Active','#fff',1);
+        CREATE TABLE PortfolioTheme (id INTEGER PRIMARY KEY, name TEXT, code TEXT, status_id INTEGER, archived_at TEXT, soft_delete INTEGER DEFAULT 0);
+        INSERT INTO PortfolioTheme VALUES (1,'Alt','ALT',1,NULL,0);
+        CREATE TABLE PortfolioThemeAsset (theme_id INTEGER, instrument_id INTEGER, research_target_pct REAL, user_target_pct REAL, notes TEXT, PRIMARY KEY(theme_id,instrument_id));
+        INSERT INTO PortfolioThemeAsset VALUES (1,1,50,50,NULL);
+        INSERT INTO PortfolioThemeAsset VALUES (1,2,50,50,NULL);
+        CREATE TABLE Instruments (instrument_id INTEGER PRIMARY KEY, instrument_name TEXT, currency TEXT);
+        INSERT INTO Instruments VALUES (1,'CASHCHF','CHF');
+        INSERT INTO Instruments VALUES (2,'BTC','BTC');
+        CREATE TABLE PositionReports (position_id INTEGER PRIMARY KEY AUTOINCREMENT, import_session_id INTEGER, instrument_id INTEGER, quantity REAL, current_price REAL, report_date TEXT);
+        INSERT INTO PositionReports VALUES (1,1,1,100,1,'2025-08-20T14:05:00Z');
+        INSERT INTO PositionReports VALUES (2,1,2,1,10000,'2025-08-20T14:05:00Z');
+        CREATE TABLE ExchangeRates (currency_code TEXT, rate_date TEXT, rate_to_chf REAL);
+        INSERT INTO ExchangeRates VALUES ('USD','2025-08-20T14:00:00Z',0.9);
+        """
+        sqlite3_exec(db, sql, nil, nil, nil)
+
+        let service = PortfolioValuationService(dbManager: manager)
+        let snap = service.snapshot(themeId: 1)
+        let rows = Dictionary(uniqueKeysWithValues: snap.rows.map { ($0.instrumentId, $0) })
+        XCTAssertEqual(rows[1]?.currentValueBase, 111.11, accuracy: 0.01)
+        XCTAssertEqual(rows[2]?.currentValueBase, 9000, accuracy: 0.01)
+        XCTAssertNil(rows[2]?.status)
+        sqlite3_close(db)
     }
 }


### PR DESCRIPTION
## Summary
- list all theme instruments and bridge crypto values through USD when FX is missing
- show valuation table even when totals are zero
- add FX cross-rate resolver with structured valuation logging

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a74d15095c832386497349ac879f8a