### PR TITLE
Fix portfolio valuation FX parity with positions view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Share FXConversionService between Positions and Portfolio valuation to align CHF values and expose FX parity logging
 - Ensure Portfolio Theme valuation shows all instruments, resolves FX via identity and inversion, and keeps table visible for zero totals
 - Log warning when FX rate_date cannot be parsed and fallback is used
 - Handle valuation event serialization errors with explicit logging

--- a/DragonShield/FXConversionService.swift
+++ b/DragonShield/FXConversionService.swift
@@ -1,0 +1,55 @@
+import Foundation
+import SQLite3
+
+struct FXConversionService {
+    struct Result {
+        let value: Double
+        let rate: Double
+        let rateAsOf: Date
+    }
+
+    static func convert(amount: Double, fromCcy: String, toCcy: String, asOf: Date, db: DatabaseManager) -> Result? {
+        let from = fromCcy.uppercased()
+        let to = toCcy.uppercased()
+        if from == to {
+            return Result(value: amount, rate: 1.0, rateAsOf: asOf)
+        }
+        guard let database = db.db else { return nil }
+        let df = ISO8601DateFormatter()
+        let dateStr = df.string(from: asOf)
+        let sql = "SELECT rate_to_chf, rate_date FROM ExchangeRates WHERE currency_code = ? AND rate_date <= ? ORDER BY rate_date DESC LIMIT 1"
+
+        func query(_ ccy: String) -> (Double, Date)? {
+            var stmt: OpaquePointer?
+            defer { sqlite3_finalize(stmt) }
+            guard sqlite3_prepare_v2(database, sql, -1, &stmt, nil) == SQLITE_OK else { return nil }
+            sqlite3_bind_text(stmt, 1, ccy, -1, nil)
+            sqlite3_bind_text(stmt, 2, dateStr, -1, nil)
+            guard sqlite3_step(stmt) == SQLITE_ROW else { return nil }
+            let rate = sqlite3_column_double(stmt, 0)
+            let date: Date
+            if let cString = sqlite3_column_text(stmt, 1), let d = df.date(from: String(cString: cString)) {
+                date = d
+            } else {
+                LoggingService.shared.log("Failed to parse rate_date for currency '\(ccy)', falling back to snapshot date.", type: .warning, logger: .database)
+                date = asOf
+            }
+            return (rate, date)
+        }
+
+        if to == "CHF" {
+            if from == "CHF" { return Result(value: amount, rate: 1.0, rateAsOf: asOf) }
+            guard let info = query(from) else { return nil }
+            return Result(value: amount * info.0, rate: info.0, rateAsOf: info.1)
+        } else if from == "CHF" {
+            guard let info = query(to) else { return nil }
+            let rate = 1.0 / info.0
+            return Result(value: amount * rate, rate: rate, rateAsOf: info.1)
+        } else {
+            guard let fromInfo = query(from), let toInfo = query(to) else { return nil }
+            let rate = fromInfo.0 / toInfo.0
+            let usedDate = max(fromInfo.1, toInfo.1)
+            return Result(value: amount * rate, rate: rate, rateAsOf: usedDate)
+        }
+    }
+}

--- a/DragonShield/ViewModels/PositionsViewModel.swift
+++ b/DragonShield/ViewModels/PositionsViewModel.swift
@@ -89,18 +89,16 @@ class PositionsViewModel: ObservableObject {
           symbolCache[currency] = currency
         }
 
-        var valueCHF = valueOrig
         if currency != "CHF" {
           var rate = rateCache[currency]
           if rate == nil {
-            let rates = db.fetchExchangeRates(currencyCode: currency, upTo: nil)
-            if let r = rates.first?.rateToChf {
-              rateCache[currency] = r
-              rate = r
+            if let conv = FXConversionService.convert(amount: 1, fromCcy: currency, toCcy: "CHF", asOf: Date(), db: db) {
+              rate = conv.rate
+              rateCache[currency] = conv.rate
             }
           }
           if let r = rate {
-            valueCHF *= r
+            let valueCHF = valueOrig * r
             chf[key] = valueCHF
             total += valueCHF
           } else {
@@ -108,8 +106,8 @@ class PositionsViewModel: ObservableObject {
             chf[key] = nil
           }
         } else {
-          chf[key] = valueCHF
-          total += valueCHF
+          chf[key] = valueOrig
+          total += valueOrig
         }
       }
 

--- a/DragonShield/Views/PortfolioThemeDetailView.swift
+++ b/DragonShield/Views/PortfolioThemeDetailView.swift
@@ -202,7 +202,11 @@ private var valuationSection: some View {
                     Text(row.instrumentName).frame(maxWidth: .infinity, alignment: .leading)
                     Text(row.researchTargetPct, format: .number.precision(.fractionLength(1))).frame(width: 72, alignment: .trailing)
                     Text(row.userTargetPct, format: .number.precision(.fractionLength(1))).frame(width: 72, alignment: .trailing)
-                    Text(row.currentValueBase, format: .currency(code: dbManager.baseCurrency).precision(.fractionLength(2))).frame(width: 120, alignment: .trailing)
+                    if let value = row.currentValueBase {
+                        Text(value, format: .currency(code: dbManager.baseCurrency).precision(.fractionLength(2))).frame(width: 120, alignment: .trailing)
+                    } else {
+                        Text("—").frame(width: 120, alignment: .trailing)
+                    }
                     Text(row.actualPct, format: .number.precision(.fractionLength(1))).frame(width: 72, alignment: .trailing)
                     Text(row.status).frame(width: 120, alignment: .leading)
                     Text(row.notes ?? "").frame(minWidth: 100, alignment: .leading)

--- a/DragonShieldTests/FXConversionServiceTests.swift
+++ b/DragonShieldTests/FXConversionServiceTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+import SQLite3
+@testable import DragonShield
+
+final class FXConversionServiceTests: XCTestCase {
+    private func makeDB() -> DatabaseManager {
+        let manager = DatabaseManager()
+        var db: OpaquePointer?
+        sqlite3_open(":memory:", &db)
+        manager.db = db
+        let sql = """
+        CREATE TABLE ExchangeRates (currency_code TEXT, rate_date TEXT, rate_to_chf REAL);
+        INSERT INTO ExchangeRates VALUES ('USD','2025-01-01T00:00:00Z',0.9);
+        INSERT INTO ExchangeRates VALUES ('EUR','2025-01-01T00:00:00Z',1.1);
+        """
+        sqlite3_exec(db, sql, nil, nil, nil)
+        return manager
+    }
+
+    func testIdentity() {
+        let db = makeDB()
+        let result = FXConversionService.convert(amount: 100, fromCcy: "CHF", toCcy: "CHF", asOf: Date(), db: db)
+        XCTAssertEqual(result?.value, 100, accuracy: 0.01)
+        sqlite3_close(db.db)
+    }
+
+    func testDirect() {
+        let db = makeDB()
+        let asOf = ISO8601DateFormatter().date(from: "2025-02-01T00:00:00Z")!
+        let result = FXConversionService.convert(amount: 100, fromCcy: "USD", toCcy: "CHF", asOf: asOf, db: db)
+        XCTAssertEqual(result?.value, 90, accuracy: 0.01)
+        sqlite3_close(db.db)
+    }
+
+    func testReverse() {
+        let db = makeDB()
+        let asOf = ISO8601DateFormatter().date(from: "2025-02-01T00:00:00Z")!
+        let result = FXConversionService.convert(amount: 90, fromCcy: "CHF", toCcy: "USD", asOf: asOf, db: db)
+        XCTAssertEqual(result?.value, 100, accuracy: 0.01)
+        sqlite3_close(db.db)
+    }
+
+    func testMissing() {
+        let db = makeDB()
+        let asOf = ISO8601DateFormatter().date(from: "2025-02-01T00:00:00Z")!
+        let result = FXConversionService.convert(amount: 100, fromCcy: "JPY", toCcy: "CHF", asOf: asOf, db: db)
+        XCTAssertNil(result)
+        sqlite3_close(db.db)
+    }
+}

--- a/DragonShieldTests/PortfolioValuationServiceTests.swift
+++ b/DragonShieldTests/PortfolioValuationServiceTests.swift
@@ -43,12 +43,13 @@ final class PortfolioValuationServiceTests: XCTestCase {
         XCTAssertEqual(snap.totalValueBase, 1950, accuracy: 0.01)
         XCTAssertEqual(snap.excludedFxCount, 1)
         let rows = Dictionary(uniqueKeysWithValues: snap.rows.map { ($0.instrumentId, $0) })
-        XCTAssertEqual(rows[1]?.currentValueBase, 1500, accuracy: 0.01)
+        XCTAssertEqual(rows[1]?.currentValueBase ?? 0, 1500, accuracy: 0.01)
         XCTAssertEqual(rows[1]?.status, "OK")
-        XCTAssertEqual(rows[2]?.currentValueBase, 450, accuracy: 0.01)
+        XCTAssertEqual(rows[2]?.currentValueBase ?? 0, 450, accuracy: 0.01)
         XCTAssertEqual(rows[2]?.notes, "Tech")
         XCTAssertEqual(rows[2]?.status, "OK")
         XCTAssertEqual(rows[3]?.status, "FX missing — excluded")
+        XCTAssertNil(rows[3]?.currentValueBase)
         XCTAssertEqual(rows[4]?.status, "No position")
         sqlite3_close(manager.db)
     }
@@ -77,7 +78,7 @@ final class PortfolioValuationServiceTests: XCTestCase {
         sqlite3_exec(db, sql, nil, nil, nil)
         let service = PortfolioValuationService(dbManager: manager)
         let snap = service.snapshot(themeId: 1)
-        XCTAssertEqual(snap.rows.first?.currentValueBase, 125, accuracy: 0.01)
+        XCTAssertEqual(snap.rows.first?.currentValueBase ?? 0, 125, accuracy: 0.01)
         XCTAssertEqual(snap.rows.first?.status, "OK")
         let df = ISO8601DateFormatter()
         XCTAssertEqual(df.string(from: snap.fxAsOf!), "2025-08-20T14:00:00Z")
@@ -122,6 +123,7 @@ final class PortfolioValuationServiceTests: XCTestCase {
         Thread.sleep(forTimeInterval: 0.1)
         let log = LoggingService.shared.readLog()
         XCTAssertTrue(log.contains("\"themeId\":1"))
+        XCTAssertTrue(log.contains("\"fx_source\":\"PositionsParity\""))
         sqlite3_close(manager.db)
     }
 }

--- a/DragonShieldTests/ValuationParityTests.swift
+++ b/DragonShieldTests/ValuationParityTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+import SQLite3
+@testable import DragonShield
+
+final class ValuationParityTests: XCTestCase {
+    private func setupManager() -> DatabaseManager {
+        let manager = DatabaseManager()
+        var db: OpaquePointer?
+        sqlite3_open(":memory:", &db)
+        manager.db = db
+        manager.baseCurrency = "CHF"
+        let sql = """
+        CREATE TABLE PortfolioThemeStatus (id INTEGER PRIMARY KEY, code TEXT, name TEXT, color_hex TEXT, is_default INTEGER);
+        INSERT INTO PortfolioThemeStatus VALUES (1,'ACTIVE','Active','#fff',1);
+        CREATE TABLE PortfolioTheme (id INTEGER PRIMARY KEY, name TEXT, code TEXT, status_id INTEGER, archived_at TEXT, soft_delete INTEGER DEFAULT 0);
+        INSERT INTO PortfolioTheme VALUES (1,'Core','CORE',1,NULL,0);
+        CREATE TABLE PortfolioThemeAsset (theme_id INTEGER, instrument_id INTEGER, research_target_pct REAL, user_target_pct REAL, notes TEXT, PRIMARY KEY(theme_id,instrument_id));
+        INSERT INTO PortfolioThemeAsset VALUES (1,1,50,50,NULL);
+        INSERT INTO PortfolioThemeAsset VALUES (1,2,50,50,NULL);
+        CREATE TABLE Instruments (instrument_id INTEGER PRIMARY KEY, instrument_name TEXT, currency TEXT);
+        INSERT INTO Instruments VALUES (1,'AAPL','CHF');
+        INSERT INTO Instruments VALUES (2,'MSFT','USD');
+        CREATE TABLE PositionReports (position_id INTEGER PRIMARY KEY AUTOINCREMENT, import_session_id INTEGER, instrument_id INTEGER, quantity REAL, current_price REAL, report_date TEXT);
+        INSERT INTO PositionReports (import_session_id,instrument_id,quantity,current_price,report_date) VALUES (10,1,10,100,'2025-08-20T14:05:00Z');
+        INSERT INTO PositionReports (import_session_id,instrument_id,quantity,current_price,report_date) VALUES (10,2,5,10,'2025-08-20T14:05:00Z');
+        CREATE TABLE ExchangeRates (currency_code TEXT, rate_date TEXT, rate_to_chf REAL);
+        INSERT INTO ExchangeRates VALUES ('USD','2025-08-20T14:00:00Z',0.9);
+        """
+        sqlite3_exec(db, sql, nil, nil, nil)
+        return manager
+    }
+
+    func testParityBetweenPositionsAndValuation() {
+        let manager = setupManager()
+        let positions = manager.fetchPositionReports()
+        let model = PositionsViewModel()
+        let exp = expectation(description: "values")
+        model.calculateValues(positions: positions, db: manager)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { exp.fulfill() }
+        wait(for: [exp], timeout: 1.0)
+        let service = PortfolioValuationService(dbManager: manager)
+        let snap = service.snapshot(themeId: 1)
+        for row in snap.rows where row.status == "OK" {
+            if let valOpt = model.positionValueCHF[row.instrumentId], let vmVal = valOpt, let v = row.currentValueBase {
+                XCTAssertEqual(vmVal, v, accuracy: 0.01)
+            }
+        }
+        sqlite3_close(manager.db)
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce stateless FXConversionService and reuse in Positions and Portfolio valuations
- Treat missing FX as excluded rows and surface max FX timestamp; log FX source
- Add unit tests for FX conversion scenarios and parity with Positions view

## Testing
- `apt-get update` *(failed: repository InRelease not signed)*
- `make setup` *(failed: No rule to make target)*
- `make fmt && make lint` *(failed: No rule to make target)*
- `make migrate` *(failed: No rule to make target)*
- `make build` *(failed: No rule to make target)*
- `make test` *(failed: No rule to make target)*

------
https://chatgpt.com/codex/tasks/task_e_68a75dcf5a2483239512a6720efa0b1a