### PR TITLE
test: handle mixed-case currency codes in valuation snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Cover mixed-case currency codes in portfolio valuation snapshot tests
 - Ensure Portfolio Theme valuation shows all instruments, resolves FX via identity and inversion, and keeps table visible for zero totals
 - Log warning when FX rate_date cannot be parsed and fallback is used
 - Handle valuation event serialization errors with explicit logging

--- a/DragonShieldTests/PortfolioValuationServiceTests.swift
+++ b/DragonShieldTests/PortfolioValuationServiceTests.swift
@@ -124,4 +124,33 @@ final class PortfolioValuationServiceTests: XCTestCase {
         XCTAssertTrue(log.contains("\"themeId\":1"))
         sqlite3_close(manager.db)
     }
+
+    func testSnapshotHandlesMixedCaseCurrencyCodes() {
+        let manager = DatabaseManager()
+        var db: OpaquePointer?
+        sqlite3_open(":memory:", &db)
+        manager.db = db
+        manager.baseCurrency = "cHf"
+        let sql = """
+        CREATE TABLE PortfolioThemeStatus (id INTEGER PRIMARY KEY, code TEXT, name TEXT, color_hex TEXT, is_default INTEGER);
+        INSERT INTO PortfolioThemeStatus VALUES (1,'ACTIVE','Active','#fff',1);
+        CREATE TABLE PortfolioTheme (id INTEGER PRIMARY KEY, name TEXT, code TEXT, status_id INTEGER, archived_at TEXT, soft_delete INTEGER DEFAULT 0);
+        INSERT INTO PortfolioTheme VALUES (1,'Core','CORE',1,NULL,0);
+        CREATE TABLE PortfolioThemeAsset (theme_id INTEGER, instrument_id INTEGER, research_target_pct REAL, user_target_pct REAL, notes TEXT, PRIMARY KEY(theme_id,instrument_id));
+        INSERT INTO PortfolioThemeAsset VALUES (1,1,100,100,NULL);
+        CREATE TABLE Instruments (instrument_id INTEGER PRIMARY KEY, instrument_name TEXT, currency TEXT);
+        INSERT INTO Instruments VALUES (1,'MSFT','uSd');
+        CREATE TABLE PositionReports (position_id INTEGER PRIMARY KEY AUTOINCREMENT, import_session_id INTEGER, instrument_id INTEGER, quantity REAL, current_price REAL, report_date TEXT);
+        INSERT INTO PositionReports (import_session_id,instrument_id,quantity,current_price,report_date) VALUES (10,1,50,10,'2025-08-20T14:05:00Z');
+        CREATE TABLE ExchangeRates (currency_code TEXT, rate_date TEXT, rate_to_chf REAL);
+        INSERT INTO ExchangeRates VALUES ('Usd','2025-08-20T14:00:00Z',0.9);
+        """
+        sqlite3_exec(db, sql, nil, nil, nil)
+        let service = PortfolioValuationService(dbManager: manager)
+        let snap = service.snapshot(themeId: 1)
+        XCTAssertEqual(snap.excludedFxCount, 0)
+        XCTAssertEqual(snap.rows.first?.currentValueBase, 450, accuracy: 0.01)
+        XCTAssertEqual(snap.rows.first?.status, "OK")
+        sqlite3_close(manager.db)
+    }
 }


### PR DESCRIPTION
## Summary
- test valuation snapshot with mixed-case currency codes to ensure FX lookup is case-insensitive
- document test coverage

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -project DragonShield.xcodeproj -scheme DragonShield` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a764e86f848323a0297a4471ffcd3c