### PR TITLE
Centralize FX conversion for CHF valuations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Centralize FX conversion for CHF valuations across positions and portfolio themes
 - Ensure Portfolio Theme valuation shows all instruments, resolves FX via identity and inversion, and keeps table visible for zero totals
 - Log warning when FX rate_date cannot be parsed and fallback is used
 - Handle valuation event serialization errors with explicit logging

--- a/DragonShield/DatabaseManager+ExchangeRates.swift
+++ b/DragonShield/DatabaseManager+ExchangeRates.swift
@@ -50,7 +50,13 @@ extension DatabaseManager {
                 let id = Int(sqlite3_column_int(statement, 0))
                 let code = String(cString: sqlite3_column_text(statement, 1))
                 let dateStr = String(cString: sqlite3_column_text(statement, 2))
-                let rateDate = DateFormatter.iso8601DateOnly.date(from: dateStr) ?? Date()
+                let rateDate: Date
+                if let d = DateFormatter.iso8601DateOnly.date(from: dateStr) {
+                    rateDate = d
+                } else {
+                    LoggingService.shared.log("Failed to parse rate_date for currency \(code)", type: .warning, logger: .database)
+                    rateDate = Date()
+                }
                 let rateToChf = sqlite3_column_double(statement, 3)
                 let source = String(cString: sqlite3_column_text(statement, 4))
                 let apiProv = sqlite3_column_text(statement, 5).map { String(cString: $0) }
@@ -83,7 +89,13 @@ extension DatabaseManager {
                 let id = Int(sqlite3_column_int(statement, 0))
                 let code = String(cString: sqlite3_column_text(statement, 1))
                 let dateStr = String(cString: sqlite3_column_text(statement, 2))
-                let rateDate = DateFormatter.iso8601DateOnly.date(from: dateStr) ?? Date()
+                let rateDate: Date
+                if let d = DateFormatter.iso8601DateOnly.date(from: dateStr) {
+                    rateDate = d
+                } else {
+                    LoggingService.shared.log("Failed to parse rate_date for currency \(code)", type: .warning, logger: .database)
+                    rateDate = Date()
+                }
                 let rateToChf = sqlite3_column_double(statement, 3)
                 let source = String(cString: sqlite3_column_text(statement, 4))
                 let apiProv = sqlite3_column_text(statement, 5).map { String(cString: $0) }

--- a/DragonShield/DatabaseManager+FXConversion.swift
+++ b/DragonShield/DatabaseManager+FXConversion.swift
@@ -1,0 +1,61 @@
+import SQLite3
+import Foundation
+
+extension DatabaseManager {
+    /// Returns the exchange rate from a source currency to a target currency as of the given date.
+    /// - Parameters:
+    ///   - source: The currency code of the value being converted.
+    ///   - target: The currency code of the desired target currency.
+    ///   - date: The date for which the rate should be effective. If nil, the latest rate is used.
+    /// - Returns: A tuple containing the rate and the date of the rate used, or nil if no rate is available for either currency.
+    func exchangeRate(from source: String, to target: String, asOf date: Date?) -> (rate: Double, rateDate: Date)? {
+        let src = source.uppercased()
+        let tgt = target.uppercased()
+        if src == tgt {
+            return (1.0, date ?? Date())
+        }
+        func latestRate(for code: String) -> (Double, Date)? {
+            if code == "CHF" {
+                return (1.0, date ?? Date())
+            }
+            guard let info = fetchExchangeRates(currencyCode: code, upTo: date).first else { return nil }
+            return (info.rateToChf, info.rateDate)
+        }
+        guard let srcInfo = latestRate(for: src), let tgtInfo = latestRate(for: tgt) else {
+            return nil
+        }
+        let usedDate = max(srcInfo.1, tgtInfo.1)
+        let rate: Double
+        if tgt == "CHF" {
+            rate = srcInfo.0
+        } else if src == "CHF" {
+            rate = 1.0 / tgtInfo.0
+        } else {
+            rate = srcInfo.0 / tgtInfo.0
+        }
+        return (rate, usedDate)
+    }
+
+    /// Converts an amount from one currency to another using the stored FX rates.
+    /// - Parameters:
+    ///   - amount: The numeric amount in the source currency.
+    ///   - source: The currency code of the amount.
+    ///   - target: The currency code to convert into.
+    ///   - date: The effective date of the conversion. If nil, the latest rates are used.
+    /// - Returns: The converted amount and the rate date used, or nil if a rate is missing.
+    func convert(amount: Double, from source: String, to target: String, asOf date: Date?) -> (value: Double, rateDate: Date)? {
+        guard let (rate, rateDate) = exchangeRate(from: source, to: target, asOf: date) else { return nil }
+        return (amount * rate, rateDate)
+    }
+
+    /// Convenience helper to convert an amount to CHF.
+    /// - Parameters:
+    ///   - amount: The numeric amount in the source currency.
+    ///   - currency: The currency code of the amount.
+    ///   - date: The effective date of the conversion. If nil, the latest rate is used.
+    /// - Returns: The CHF value and the rate date used, or nil if a rate is missing.
+    func convertToChf(amount: Double, currency: String, asOf date: Date?) -> (valueChf: Double, rateDate: Date)? {
+        convert(amount: amount, from: currency, to: "CHF", asOf: date)
+    }
+}
+

--- a/DragonShield/PortfolioValuationService.swift
+++ b/DragonShield/PortfolioValuationService.swift
@@ -85,8 +85,9 @@ final class PortfolioValuationService {
                 if nativeValue == 0 {
                     status = "No position"
                     noPos += 1
-                } else if let rate = fetchRate(from: currency, to: dbManager.baseCurrency, asOf: positionsAsOf, fxAsOf: &fxAsOf) {
-                    valueBase = nativeValue * rate
+                } else if let converted = dbManager.convert(amount: nativeValue, from: currency, to: dbManager.baseCurrency, asOf: positionsAsOf) {
+                    valueBase = converted.value
+                    if converted.rateDate > (fxAsOf ?? .distantPast) { fxAsOf = converted.rateDate }
                     included += 1
                 } else {
                     status = "FX missing — excluded"
@@ -132,54 +133,5 @@ final class PortfolioValuationService {
 
         return ValuationSnapshot(positionsAsOf: positionsAsOf, fxAsOf: fxAsOf, totalValueBase: total, rows: rows, excludedFxCount: excludedFx, missingCurrencies: Array(missing))
     }
-
-    private func fetchRate(from valueCcy: String, to baseCcy: String, asOf: Date?, fxAsOf: inout Date?) -> Double? {
-        if valueCcy == baseCcy { return 1.0 }
-        guard let db = dbManager.db else { return nil }
-        let dateStr = asOf.map { Self.dateFormatter.string(from: $0) } ?? Self.dateFormatter.string(from: Date())
-        let sql = "SELECT rate_to_chf, rate_date FROM ExchangeRates WHERE currency_code = ? AND rate_date <= ? ORDER BY rate_date DESC LIMIT 1"
-
-        func query(_ ccy: String) -> (Double, Date)? {
-            var stmt: OpaquePointer?
-            defer { sqlite3_finalize(stmt) }
-            if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
-                sqlite3_bind_text(stmt, 1, ccy, -1, nil)
-                sqlite3_bind_text(stmt, 2, dateStr, -1, nil)
-                if sqlite3_step(stmt) == SQLITE_ROW {
-                    let rate = sqlite3_column_double(stmt, 0)
-                    let date: Date
-                    if let cString = sqlite3_column_text(stmt, 1),
-                       let d = Self.dateFormatter.date(from: String(cString: cString)) {
-                        date = d
-                    } else {
-                        LoggingService.shared.log("Failed to parse rate_date for currency '\(ccy)', falling back to position date.", type: .warning, logger: .database)
-                        date = asOf ?? Date()
-                    }
-                    return (rate, date)
-                }
-            }
-            return nil
-        }
-
-        guard let valueInfo = query(valueCcy) else { return nil }
-        let baseInfo: (Double, Date)
-        if baseCcy == "CHF" {
-            baseInfo = (1.0, valueInfo.1)
-        } else if let info = query(baseCcy) {
-            baseInfo = info
-        } else {
-            return nil
-        }
-
-        let usedDate = max(valueInfo.1, baseInfo.1)
-        if usedDate > (fxAsOf ?? .distantPast) { fxAsOf = usedDate }
-
-        if baseCcy == "CHF" {
-            return valueInfo.0
-        } else if valueCcy == "CHF" {
-            return 1.0 / baseInfo.0
-        } else {
-            return valueInfo.0 / baseInfo.0
-        }
-    }
 }
+

--- a/DragonShield/ViewModels/PositionsViewModel.swift
+++ b/DragonShield/ViewModels/PositionsViewModel.swift
@@ -69,7 +69,6 @@ class PositionsViewModel: ObservableObject {
       var total: Double = 0
       var orig: [Int: Double] = [:]
       var chf: [Int: Double?] = [:]
-      var rateCache: [String: Double] = [:]
       var symbolCache: [String: String] = [:]
       var missingRate = false
 
@@ -89,27 +88,12 @@ class PositionsViewModel: ObservableObject {
           symbolCache[currency] = currency
         }
 
-        var valueCHF = valueOrig
-        if currency != "CHF" {
-          var rate = rateCache[currency]
-          if rate == nil {
-            let rates = db.fetchExchangeRates(currencyCode: currency, upTo: nil)
-            if let r = rates.first?.rateToChf {
-              rateCache[currency] = r
-              rate = r
-            }
-          }
-          if let r = rate {
-            valueCHF *= r
-            chf[key] = valueCHF
-            total += valueCHF
-          } else {
-            missingRate = true
-            chf[key] = nil
-          }
+        if let converted = db.convertToChf(amount: valueOrig, currency: currency, asOf: nil) {
+          chf[key] = converted.valueChf
+          total += converted.valueChf
         } else {
-          chf[key] = valueCHF
-          total += valueCHF
+          missingRate = true
+          chf[key] = nil
         }
       }
 
@@ -138,3 +122,4 @@ class PositionsViewModel: ObservableObject {
     calculateValues(positions: positions, db: db)
   }
 }
+

--- a/DragonShieldTests/FXConversionTests.swift
+++ b/DragonShieldTests/FXConversionTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+import SQLite3
+@testable import DragonShield
+
+final class FXConversionTests: XCTestCase {
+    func testConvertToChfUsesExchangeRate() {
+        let manager = DatabaseManager()
+        var db: OpaquePointer?
+        sqlite3_open(":memory:", &db)
+        manager.db = db
+        let sql = """
+        CREATE TABLE ExchangeRates (
+            rate_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            currency_code TEXT,
+            rate_date TEXT,
+            rate_to_chf REAL,
+            rate_source TEXT,
+            api_provider TEXT,
+            is_latest INTEGER,
+            created_at TEXT
+        );
+        INSERT INTO ExchangeRates (currency_code, rate_date, rate_to_chf, rate_source, api_provider, is_latest, created_at)
+        VALUES ('USD','2025-01-01',0.9,'manual',NULL,1,'2025-01-01 00:00:00');
+        """
+        sqlite3_exec(db, sql, nil, nil, nil)
+        let result = manager.convertToChf(amount: 100, currency: "USD", asOf: nil)
+        XCTAssertEqual(result?.valueChf, 90, accuracy: 0.0001)
+        sqlite3_close(db)
+    }
+
+    func testConvertToChfIdentityForChf() {
+        let manager = DatabaseManager()
+        var db: OpaquePointer?
+        sqlite3_open(":memory:", &db)
+        manager.db = db
+        let result = manager.convertToChf(amount: 50, currency: "CHF", asOf: nil)
+        XCTAssertEqual(result?.valueChf, 50, accuracy: 0.0001)
+        sqlite3_close(db)
+    }
+
+    func testConvertToChfMissingRateReturnsNil() {
+        let manager = DatabaseManager()
+        var db: OpaquePointer?
+        sqlite3_open(":memory:", &db)
+        manager.db = db
+        let sql = """
+        CREATE TABLE ExchangeRates (
+            rate_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            currency_code TEXT,
+            rate_date TEXT,
+            rate_to_chf REAL,
+            rate_source TEXT,
+            api_provider TEXT,
+            is_latest INTEGER,
+            created_at TEXT
+        );
+        """
+        sqlite3_exec(db, sql, nil, nil, nil)
+        let result = manager.convertToChf(amount: 10, currency: "JPY", asOf: nil)
+        XCTAssertNil(result)
+        sqlite3_close(db)
+    }
+}
+

--- a/DragonShieldTests/PortfolioValuationServiceTests.swift
+++ b/DragonShieldTests/PortfolioValuationServiceTests.swift
@@ -29,8 +29,18 @@ final class PortfolioValuationServiceTests: XCTestCase {
         INSERT INTO PositionReports (import_session_id,instrument_id,quantity,current_price,report_date) VALUES (10,1,5,100,'2025-08-20T14:05:00Z');
         INSERT INTO PositionReports (import_session_id,instrument_id,quantity,current_price,report_date) VALUES (10,2,50,10,'2025-08-20T14:05:00Z');
         INSERT INTO PositionReports (import_session_id,instrument_id,quantity,current_price,report_date) VALUES (10,3,7,100,'2025-08-20T14:05:00Z');
-        CREATE TABLE ExchangeRates (currency_code TEXT, rate_date TEXT, rate_to_chf REAL);
-        INSERT INTO ExchangeRates VALUES ('USD','2025-08-20T14:00:00Z',0.9);
+        CREATE TABLE ExchangeRates (
+            rate_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            currency_code TEXT,
+            rate_date TEXT,
+            rate_to_chf REAL,
+            rate_source TEXT,
+            api_provider TEXT,
+            is_latest INTEGER,
+            created_at TEXT
+        );
+        INSERT INTO ExchangeRates (currency_code, rate_date, rate_to_chf, rate_source, api_provider, is_latest, created_at)
+        VALUES ('USD','2025-08-20',0.9,'manual',NULL,1,'2025-08-20 00:00:00');
         """
         sqlite3_exec(db, sql, nil, nil, nil)
         return manager
@@ -70,9 +80,18 @@ final class PortfolioValuationServiceTests: XCTestCase {
         INSERT INTO Instruments VALUES (1,'AAPL','CHF');
         CREATE TABLE PositionReports (position_id INTEGER PRIMARY KEY AUTOINCREMENT, import_session_id INTEGER, instrument_id INTEGER, quantity REAL, current_price REAL, report_date TEXT);
         INSERT INTO PositionReports (import_session_id,instrument_id,quantity,current_price,report_date) VALUES (10,1,10,10,'2025-08-20T14:05:00Z');
-        CREATE TABLE ExchangeRates (currency_code TEXT, rate_date TEXT, rate_to_chf REAL);
-        INSERT INTO ExchangeRates VALUES ('USD','2025-08-20T14:00:00Z',0.8);
-        INSERT INTO ExchangeRates VALUES ('CHF','2025-08-20T14:00:00Z',1.0);
+        CREATE TABLE ExchangeRates (
+            rate_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            currency_code TEXT,
+            rate_date TEXT,
+            rate_to_chf REAL,
+            rate_source TEXT,
+            api_provider TEXT,
+            is_latest INTEGER,
+            created_at TEXT
+        );
+        INSERT INTO ExchangeRates (currency_code, rate_date, rate_to_chf, rate_source, api_provider, is_latest, created_at)
+        VALUES ('USD','2025-08-20',0.8,'manual',NULL,1,'2025-08-20 00:00:00');
         """
         sqlite3_exec(db, sql, nil, nil, nil)
         let service = PortfolioValuationService(dbManager: manager)
@@ -80,7 +99,7 @@ final class PortfolioValuationServiceTests: XCTestCase {
         XCTAssertEqual(snap.rows.first?.currentValueBase, 125, accuracy: 0.01)
         XCTAssertEqual(snap.rows.first?.status, "OK")
         let df = ISO8601DateFormatter()
-        XCTAssertEqual(df.string(from: snap.fxAsOf!), "2025-08-20T14:00:00Z")
+        XCTAssertEqual(df.string(from: snap.fxAsOf!), "2025-08-20T00:00:00Z")
         sqlite3_close(manager.db)
     }
 
@@ -102,8 +121,18 @@ final class PortfolioValuationServiceTests: XCTestCase {
         INSERT INTO Instruments VALUES (1,'MSFT','USD');
         CREATE TABLE PositionReports (position_id INTEGER PRIMARY KEY AUTOINCREMENT, import_session_id INTEGER, instrument_id INTEGER, quantity REAL, current_price REAL, report_date TEXT);
         INSERT INTO PositionReports (import_session_id,instrument_id,quantity,current_price,report_date) VALUES (10,1,50,10,'2025-08-20T14:05:00Z');
-        CREATE TABLE ExchangeRates (currency_code TEXT, rate_date TEXT, rate_to_chf REAL);
-        INSERT INTO ExchangeRates VALUES ('USD','invalid',0.9);
+        CREATE TABLE ExchangeRates (
+            rate_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            currency_code TEXT,
+            rate_date TEXT,
+            rate_to_chf REAL,
+            rate_source TEXT,
+            api_provider TEXT,
+            is_latest INTEGER,
+            created_at TEXT
+        );
+        INSERT INTO ExchangeRates (currency_code, rate_date, rate_to_chf, rate_source, api_provider, is_latest, created_at)
+        VALUES ('USD','invalid',0.9,'manual',NULL,1,'2025-08-20 00:00:00');
         """
         sqlite3_exec(db, sql, nil, nil, nil)
         let service = PortfolioValuationService(dbManager: manager)
@@ -125,3 +154,4 @@ final class PortfolioValuationServiceTests: XCTestCase {
         sqlite3_close(manager.db)
     }
 }
+


### PR DESCRIPTION
## Summary
- add shared FX conversion helpers on DatabaseManager
- use shared FX conversion in portfolio theme snapshots and position calculations
- log FX rate date parse failures and add FX conversion tests

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -scheme DragonShield -configuration Debug build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a767eda0648323b95f498fb9898232