### PR TITLE
feat(theme): present details in modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - Fix Portfolio Theme creation to persist database records and improve new theme editor layout
 - Remove Portfolio Themes feature flag; navigation and Theme Status settings are always visible
 - Navigate from Portfolio Themes list to detail view with keyboard, icon, or context menu; archived themes open read-only
+- Present Portfolio Theme details in modal window with aligned Composition and Valuation sections
 - Disable Performance and Rebalancing links in sidebar
 - Ensure new theme popup accepts a theme code and disable Save until required fields are valid
 - Introduce HealthCheckRegistry for startup diagnostics with per-check configuration

--- a/DragonShield/Views/PortfolioThemesListView.swift
+++ b/DragonShield/Views/PortfolioThemesListView.swift
@@ -22,7 +22,7 @@ struct PortfolioThemesListView: View {
     @State private var selectedThemeId: PortfolioTheme.ID?
     @State private var themeToEdit: PortfolioTheme?
     @State private var showingAddSheet = false
-    @State private var navigateThemeId: Int?
+    @State private var themeToOpen: PortfolioTheme?
 
     // State to manage the table's sort order
     @State private var sortOrder = [KeyPathComparator<PortfolioTheme>]()
@@ -69,12 +69,6 @@ struct PortfolioThemesListView: View {
                 }
                 .padding()
             }
-            .navigationDestination(isPresented: Binding(get: { navigateThemeId != nil }, set: { if !$0 { navigateThemeId = nil } })) {
-                if let id = navigateThemeId {
-                    PortfolioThemeDetailView(themeId: id, origin: "themesList")
-                        .environmentObject(dbManager)
-                }
-            }
         }
         .navigationTitle("Portfolio Themes")
         .onAppear { restoreSortOrder(); loadData() }
@@ -84,6 +78,10 @@ struct PortfolioThemesListView: View {
         }
         .sheet(item: $themeToEdit, onDismiss: loadData) { theme in
             EditPortfolioThemeView(theme: theme, onSave: {})
+                .environmentObject(dbManager)
+        }
+        .sheet(item: $themeToOpen, onDismiss: loadData) { theme in
+            PortfolioThemeDetailView(themeId: theme.id, origin: "themesList")
                 .environmentObject(dbManager)
         }
         .alert("Delete Theme", isPresented: $showArchiveAlert) {
@@ -319,6 +317,6 @@ struct PortfolioThemesListView: View {
     }
 
     private func open(_ theme: PortfolioTheme) {
-        navigateThemeId = theme.id
+        themeToOpen = theme
     }
 }


### PR DESCRIPTION
## Summary
- open Portfolio Theme details as modal sheet
- polish Composition grid and Valuation table layout
- document change in changelog

## Testing
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68a8230a9cdc8323af3d8dbdc8341f36