### PR TITLE
Align composition headers and add note editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Align Composition table headers with data columns and add per-instrument notes pop-up in Portfolio Theme details
 - Remove Notes column from Portfolio Theme valuation table and align totals under Current Value
 - Ensure Portfolio Theme valuation shows all instruments, resolves FX via identity and inversion, and keeps table visible for zero totals
 - Share FXConversionService using latest flagged rates for consistent CHF conversion across views

--- a/DragonShield/Views/NoteEditorView.swift
+++ b/DragonShield/Views/NoteEditorView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct NoteEditorView: View {
+    let title: String
+    @Binding var note: String
+    let isReadOnly: Bool
+    let onSave: () -> Void
+    let onCancel: () -> Void
+    @Environment(\.dismiss) private var dismiss
+    private let maxLength = 2000
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(title).font(.headline)
+            TextEditor(text: $note)
+                .frame(minHeight: 140)
+                .disabled(isReadOnly)
+            Text("\(note.count) / \(maxLength) characters")
+                .frame(maxWidth: .infinity, alignment: .trailing)
+                .foregroundColor(note.count > maxLength ? .red : .secondary)
+            HStack {
+                Spacer()
+                Button("Cancel") {
+                    onCancel()
+                    dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
+                Button("Save") {
+                    onSave()
+                    dismiss()
+                }
+                .keyboardShortcut(.defaultAction)
+                .keyboardShortcut("s", modifiers: [.command])
+                .disabled(isReadOnly || note.count > maxLength)
+            }
+        }
+        .padding(20)
+        .frame(minWidth: 400, minHeight: 220)
+    }
+}

--- a/DragonShieldTests/NoteEditorViewTests.swift
+++ b/DragonShieldTests/NoteEditorViewTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+import SwiftUI
+@testable import DragonShield
+
+final class NoteEditorViewTests: XCTestCase {
+    func testViewInitializes() {
+        let view = NoteEditorView(
+            title: "Edit Note — Test",
+            note: .constant("sample"),
+            isReadOnly: false,
+            onSave: {},
+            onCancel: {}
+        )
+        XCTAssertNotNil(view.body)
+    }
+}


### PR DESCRIPTION
## Summary
- align Composition headers with data columns for consistent layout
- add per-instrument note editor pop-up via note icon
- cover new note editor with a basic initialization test

## Testing
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a836edc9048323935c500280bd2b70