### PR TITLE
Align composition headers and add note editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Align Composition table headers with data columns and add per-instrument notes pop-up in Portfolio Theme details
+- Enforce consistent 2000-character limit for portfolio asset notes
 - Remove Notes column from Portfolio Theme valuation table and align totals under Current Value
 - Ensure Portfolio Theme valuation shows all instruments, resolves FX via identity and inversion, and keeps table visible for zero totals
 - Share FXConversionService using latest flagged rates for consistent CHF conversion across views

--- a/DragonShield/Views/NoteEditorView.swift
+++ b/DragonShield/Views/NoteEditorView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct NoteEditorView: View {
+    let title: String
+    @Binding var note: String
+    let isReadOnly: Bool
+    let onSave: () -> Void
+    let onCancel: () -> Void
+    static let maxLength = 2000
+
+    var isOverLimit: Bool { note.count > Self.maxLength }
+    var saveDisabled: Bool { isReadOnly || isOverLimit }
+    var countColor: Color { isOverLimit ? .red : .secondary }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(title).font(.headline)
+            TextEditor(text: $note)
+                .frame(minHeight: 140)
+                .disabled(isReadOnly)
+            Text("\(note.count) / \(Self.maxLength) characters")
+                .frame(maxWidth: .infinity, alignment: .trailing)
+                .foregroundColor(countColor)
+            HStack {
+                Spacer()
+                Button("Cancel") {
+                    onCancel()
+                }
+                .keyboardShortcut(.cancelAction)
+                Button("Save") {
+                    onSave()
+                }
+                .keyboardShortcut(.defaultAction)
+                .keyboardShortcut("s", modifiers: [.command])
+                .disabled(saveDisabled)
+            }
+        }
+        .padding(20)
+        .frame(minWidth: 400, minHeight: 220)
+    }
+}

--- a/DragonShield/Views/PortfolioThemeDetailView.swift
+++ b/DragonShield/Views/PortfolioThemeDetailView.swift
@@ -29,8 +29,11 @@ struct PortfolioThemeDetailView: View {
     @State private var addUserPct: Double = 0
     @State private var addNotes: String = ""
     @State private var alertItem: AlertItem?
+    @State private var editingAsset: PortfolioThemeAsset?
+    @State private var noteDraft: String = ""
 
     private let labelWidth: CGFloat = 140
+    private let noteMaxLength = NoteEditorView.maxLength
 
     var body: some View {
         NavigationStack {
@@ -76,6 +79,27 @@ struct PortfolioThemeDetailView: View {
             runValuation()
         }
         .sheet(isPresented: $showAdd) { addSheet }
+        .sheet(item: $editingAsset) { asset in
+            NoteEditorView(
+                title: "Edit Note — \(instrumentName(asset.instrumentId))",
+                note: $noteDraft,
+                isReadOnly: isReadOnly,
+                onSave: {
+                    var trimmed = noteDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if trimmed.count > noteMaxLength {
+                        trimmed = String(trimmed.prefix(noteMaxLength))
+                    }
+                    var updated = asset
+                    updated.notes = trimmed.isEmpty ? nil : trimmed
+                    if let idx = assets.firstIndex(where: { $0.id == asset.id }) {
+                        assets[idx] = updated
+                    }
+                    save(updated)
+                    editingAsset = nil
+                },
+                onCancel: { editingAsset = nil }
+            )
+        }
         .alert(item: $alertItem) { item in
             Alert(title: Text(item.title), message: Text(item.message), dismissButton: .default(Text("OK"), action: item.action))
         }
@@ -114,11 +138,24 @@ struct PortfolioThemeDetailView: View {
                 Text("No instruments attached")
             } else {
                 HStack(spacing: 12) {
-                    Text("Instrument").frame(maxWidth: .infinity, alignment: .leading)
-                    Text("Research %").frame(width: 80, alignment: .trailing)
-                    Text("User %").frame(width: 80, alignment: .trailing)
-                    Text("Notes").frame(minWidth: 100, alignment: .leading)
-                    Spacer().frame(width: 40)
+                    Text("Instrument")
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    Text("Research %")
+                        .frame(width: 80, alignment: .trailing)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    Text("User %")
+                        .frame(width: 80, alignment: .trailing)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    Text("Notes")
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    Spacer().frame(width: 28)
+                    Spacer().frame(width: 28)
                 }
                 ForEach($assets) { $asset in
                     HStack(alignment: .center, spacing: 12) {
@@ -144,8 +181,12 @@ struct PortfolioThemeDetailView: View {
                         TextField("", text: Binding(
                             get: { $asset.wrappedValue.notes ?? "" },
                             set: { newValue in
-                                let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                                var trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                                if trimmed.count > noteMaxLength {
+                                    trimmed = String(trimmed.prefix(noteMaxLength))
+                                }
                                 $asset.wrappedValue.notes = trimmed.isEmpty ? nil : trimmed
+                                save($asset.wrappedValue)
                             }
                         ))
                         .frame(minWidth: 100, maxWidth: .infinity)
@@ -153,14 +194,25 @@ struct PortfolioThemeDetailView: View {
                         .truncationMode(.tail)
                         .help($asset.wrappedValue.notes ?? "")
                         .disabled(isReadOnly)
-                        .onChange(of: asset.notes) {
-                            save($asset.wrappedValue)
+                        Button {
+                            editingAsset = $asset.wrappedValue
+                            noteDraft = $asset.wrappedValue.notes ?? ""
+                        } label: {
+                            Image(systemName: "note.text")
                         }
+                        .buttonStyle(.borderless)
+                        .frame(width: 28)
+                        .help(isReadOnly ? "Read-only — theme archived" : "Edit note")
+                        .accessibilityLabel("Edit note for \(instrumentName($asset.wrappedValue.instrumentId))")
+                        .disabled(isReadOnly)
                         if !isReadOnly {
                             Button(action: { remove($asset.wrappedValue) }) {
                                 Image(systemName: "trash")
                             }
                             .buttonStyle(.borderless)
+                            .frame(width: 28)
+                        } else {
+                            Spacer().frame(width: 28)
                         }
                     }
                 }
@@ -320,7 +372,16 @@ private var dangerZone: some View {
                     GridRow {
                         Text("Notes")
                             .frame(width: labelWidth, alignment: .trailing)
-                        TextField("Notes", text: $addNotes)
+                        TextField("Notes", text: Binding(
+                            get: { addNotes },
+                            set: { newValue in
+                                var trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                                if trimmed.count > noteMaxLength {
+                                    trimmed = String(trimmed.prefix(noteMaxLength))
+                                }
+                                addNotes = trimmed
+                            }
+                        ))
                     }
                 }
             }
@@ -451,7 +512,8 @@ private var dangerZone: some View {
     private func addInstrument() {
         let userPct = addUserPct == addResearchPct ? nil : addUserPct
         let trimmedNotes = addNotes.trimmingCharacters(in: .whitespacesAndNewlines)
-        let notesToSave = trimmedNotes.isEmpty ? nil : trimmedNotes
+        let limitedNotes = String(trimmedNotes.prefix(noteMaxLength))
+        let notesToSave = limitedNotes.isEmpty ? nil : limitedNotes
         if dbManager.createThemeAsset(themeId: themeId, instrumentId: addInstrumentId, researchPct: addResearchPct, userPct: userPct, notes: notesToSave) != nil {
             showAdd = false
             addResearchPct = 0

--- a/DragonShieldTests/NoteEditorViewTests.swift
+++ b/DragonShieldTests/NoteEditorViewTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+import SwiftUI
+@testable import DragonShield
+
+final class NoteEditorViewTests: XCTestCase {
+    func testViewInitializes() {
+        let view = NoteEditorView(
+            title: "Edit Note — Test",
+            note: .constant("sample"),
+            isReadOnly: false,
+            onSave: {},
+            onCancel: {}
+        )
+        XCTAssertNotNil(view.body)
+    }
+    func testSaveDisabledWhenOverLimit() {
+        let longNote = String(repeating: "a", count: NoteEditorView.maxLength + 1)
+        let view = NoteEditorView(
+            title: "Edit Note — Test",
+            note: .constant(longNote),
+            isReadOnly: false,
+            onSave: {},
+            onCancel: {}
+        )
+        XCTAssertTrue(view.saveDisabled)
+        XCTAssertTrue(view.isOverLimit)
+    }
+
+    func testSaveDisabledWhenReadOnly() {
+        let view = NoteEditorView(
+            title: "Edit Note — Test",
+            note: .constant("sample"),
+            isReadOnly: true,
+            onSave: {},
+            onCancel: {}
+        )
+        XCTAssertTrue(view.saveDisabled)
+    }
+
+    func testCountColorTurnsRedWhenOverLimit() {
+        let longNote = String(repeating: "a", count: NoteEditorView.maxLength + 1)
+        let view = NoteEditorView(
+            title: "Edit Note — Test",
+            note: .constant(longNote),
+            isReadOnly: false,
+            onSave: {},
+            onCancel: {}
+        )
+        XCTAssertEqual(view.countColor, .red)
+    }
+}


### PR DESCRIPTION
## Summary
- align Composition headers with data columns for consistent layout
- add per-instrument note editor pop-up via note icon
- enforce consistent note length limits and explicit saves
- cover note editor behaviors with unit tests

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68a836edc9048323935c500280bd2b70