### PR TITLE
feat(theme): add description and institution link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Add description and optional institution link to Portfolio Themes with migration 012
 - Align Composition table headers with data columns and add per-instrument notes pop-up in Portfolio Theme details
 - Enforce consistent 2000-character limit for portfolio asset notes
 - Remove Notes column from Portfolio Theme valuation table and align totals under Current Value

--- a/DragonShield/Models/PortfolioTheme.swift
+++ b/DragonShield/Models/PortfolioTheme.swift
@@ -1,6 +1,7 @@
 // DragonShield/Models/PortfolioTheme.swift
-// MARK: - Version 1.2
+// MARK: - Version 1.3
 // MARK: - History
+// - Added description and optional institutionId for richer metadata.
 // - Added optional totalValueBase and instrumentCount for list overview metrics.
 // - Conformed to Hashable for SwiftUI List selection compatibility.
 // - Initial creation: Represents user-defined portfolio themes.
@@ -12,10 +13,8 @@ struct PortfolioTheme: Identifiable, Hashable {
     let id: Int
     var name: String
     let code: String
-    // This property does not exist in the database table or creation method,
-    // so it should be removed from the main struct if not used elsewhere.
-    // For now, we will assume it might be used in other contexts.
-    // var description: String?
+    var description: String?
+    var institutionId: Int?
     var statusId: Int
     var createdAt: String
     var updatedAt: String

--- a/DragonShield/Views/AddPortfolioThemeView.swift
+++ b/DragonShield/Views/AddPortfolioThemeView.swift
@@ -82,6 +82,8 @@ struct AddPortfolioThemeView: View {
         let newTheme = dbManager.createPortfolioTheme(
             name: self.name,
             code: self.code,
+            description: nil,
+            institutionId: nil,
             statusId: self.statusId
         )
 

--- a/DragonShield/Views/EditPortfolioThemeView.swift
+++ b/DragonShield/Views/EditPortfolioThemeView.swift
@@ -89,6 +89,8 @@ struct EditPortfolioThemeView: View {
         let success = dbManager.updatePortfolioTheme(
             id: theme.id,
             name: name,
+            description: theme.description,
+            institutionId: theme.institutionId,
             statusId: statusId,
             archivedAt: theme.archivedAt
         )

--- a/DragonShield/Views/InstitutionsView.swift
+++ b/DragonShield/Views/InstitutionsView.swift
@@ -114,6 +114,7 @@ struct InstitutionsView: View {
 struct AddInstitutionView: View {
     @Environment(\.presentationMode) private var presentationMode
     @EnvironmentObject var dbManager: DatabaseManager
+    var onAdd: ((Int) -> Void)? = nil
 
     @State private var name = ""
     @State private var bic = ""
@@ -176,7 +177,7 @@ struct AddInstitutionView: View {
     }
 
     private func save() {
-        let success = dbManager.addInstitution(
+        let newId = dbManager.addInstitution(
             name: name.trimmingCharacters(in: .whitespacesAndNewlines),
             bic: bic.isEmpty ? nil : bic,
             type: type.isEmpty ? nil : type,
@@ -186,8 +187,9 @@ struct AddInstitutionView: View {
             countryCode: countryCode.isEmpty ? nil : countryCode,
             notes: notes.isEmpty ? nil : notes,
             isActive: isActive)
-        if success {
+        if let id = newId {
             NotificationCenter.default.post(name: NSNotification.Name("RefreshInstitutions"), object: nil)
+            onAdd?(id)
             alertMessage = "✅ Added"
         } else {
             alertMessage = "❌ Failed"

--- a/DragonShield/Views/PortfolioThemeDetailView.swift
+++ b/DragonShield/Views/PortfolioThemeDetailView.swift
@@ -18,6 +18,10 @@ struct PortfolioThemeDetailView: View {
     @State private var code: String = ""
     @State private var statusId: Int = 0
     @State private var statuses: [PortfolioThemeStatus] = []
+    @State private var descriptionText: String = ""
+    @State private var institutionId: Int? = nil
+    @State private var institutions: [DatabaseManager.InstitutionData] = []
+    @State private var showAddInstitution = false
 
     @State private var assets: [PortfolioThemeAsset] = []
     @State private var valuation: ValuationSnapshot?
@@ -79,6 +83,13 @@ struct PortfolioThemeDetailView: View {
             runValuation()
         }
         .sheet(isPresented: $showAdd) { addSheet }
+        .sheet(isPresented: $showAddInstitution) {
+            AddInstitutionView { id in
+                institutions = dbManager.fetchInstitutions()
+                institutionId = id
+            }
+            .environmentObject(dbManager)
+        }
         .sheet(item: $editingAsset) { asset in
             NoteEditorView(
                 title: "Edit Note — \(instrumentName(asset.instrumentId))",
@@ -108,22 +119,44 @@ struct PortfolioThemeDetailView: View {
     // MARK: - Sections
 
     private var headerBlock: some View {
-        HStack(spacing: 16) {
-            TextField("Name", text: $name)
-                .disabled(isReadOnly)
-            Text(code)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 4)
-                .background(Capsule().stroke(Color.secondary))
-            Picker("Status", selection: $statusId) {
-                ForEach(statuses) { status in
-                    Text(status.name).tag(status.id)
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 16) {
+                TextField("Name", text: $name)
+                    .disabled(isReadOnly)
+                Text(code)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Capsule().stroke(Color.secondary))
+                Picker("Status", selection: $statusId) {
+                    ForEach(statuses) { status in
+                        Text(status.name).tag(status.id)
+                    }
                 }
+                .labelsHidden()
+                .disabled(isReadOnly)
+                Text("Archived at: \(theme?.archivedAt ?? "-")")
+                    .foregroundColor(.secondary)
             }
-            .labelsHidden()
-            .disabled(isReadOnly)
-            Text("Archived at: \(theme?.archivedAt ?? "-")")
-                .foregroundColor(.secondary)
+            VStack(alignment: .trailing, spacing: 4) {
+                TextEditor(text: $descriptionText)
+                    .frame(minHeight: 60)
+                    .disabled(isReadOnly)
+                Text("\(descriptionText.count) / 2000")
+                    .font(.caption)
+                    .foregroundColor(descriptionText.count > 2000 ? .red : .secondary)
+            }
+            HStack {
+                Picker("Institution", selection: $institutionId) {
+                    Text("None").tag(nil as Int?)
+                    ForEach(institutions) { inst in
+                        Text(inst.name).tag(inst.id as Int?)
+                    }
+                }
+                .pickerStyle(MenuPickerStyle())
+                .disabled(isReadOnly)
+                Button("Add New…") { showAddInstitution = true }
+                    .disabled(isReadOnly)
+            }
         }
     }
 
@@ -414,7 +447,9 @@ private var dangerZone: some View {
         return "-"
     }
 
-    private var valid: Bool { PortfolioTheme.isValidName(name) }
+    private var valid: Bool {
+        PortfolioTheme.isValidName(name) && descriptionText.count <= 2000
+    }
     private var isReadOnly: Bool { theme?.archivedAt != nil }
     private var researchTotal: Double { assets.reduce(0) { $0 + $1.researchTargetPct } }
     private var userTotal: Double { assets.reduce(0) { $0 + $1.userTargetPct } }
@@ -451,6 +486,9 @@ private var dangerZone: some View {
         name = fetched.name
         code = fetched.code
         statusId = fetched.statusId
+        descriptionText = fetched.description ?? ""
+        institutionId = fetched.institutionId
+        institutions = dbManager.fetchInstitutions()
         loadAssets()
         LoggingService.shared.log("open theme detail themeId=\(fetched.id) code=\(fetched.code) origin=\(origin) result=opened", logger: .ui)
         if fetched.archivedAt != nil {
@@ -470,10 +508,11 @@ private var dangerZone: some View {
 
     private func saveTheme() {
         guard var current = theme else { return }
-        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
-        current.name = trimmed
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        current.name = trimmedName
         current.statusId = statusId
-        if dbManager.updatePortfolioTheme(id: current.id, name: current.name, statusId: current.statusId, archivedAt: current.archivedAt) {
+        let desc = descriptionText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if dbManager.updatePortfolioTheme(id: current.id, name: current.name, description: desc.isEmpty ? nil : desc, institutionId: institutionId, statusId: current.statusId, archivedAt: current.archivedAt) {
             onSave(current)
             dismiss()
         } else {

--- a/DragonShield/db/migrations/012_portfolio_theme_metadata.sql
+++ b/DragonShield/db/migrations/012_portfolio_theme_metadata.sql
@@ -1,0 +1,11 @@
+-- migrate:up
+-- Purpose: Add description and optional institution link to portfolio themes for richer metadata.
+-- Assumptions: Existing PortfolioTheme rows have no description or institution reference; Institutions table exists.
+-- Idempotency: use IF NOT EXISTS and content checks where possible
+ALTER TABLE PortfolioTheme ADD COLUMN description TEXT CHECK (LENGTH(description) <= 2000);
+ALTER TABLE PortfolioTheme ADD COLUMN institution_id INTEGER REFERENCES Institutions(institution_id) ON DELETE SET NULL;
+CREATE INDEX IF NOT EXISTS idx_portfolio_theme_institution_id ON PortfolioTheme(institution_id);
+
+-- migrate:down
+DROP INDEX IF EXISTS idx_portfolio_theme_institution_id;
+-- SQLite cannot drop columns; rebuild from backup per db management plan.

--- a/DragonShieldTests/PortfolioThemeAssetSequentialUpdateTests.swift
+++ b/DragonShieldTests/PortfolioThemeAssetSequentialUpdateTests.swift
@@ -37,7 +37,7 @@ final class PortfolioThemeAssetSequentialUpdateTests: XCTestCase {
         """
         sqlite3_exec(manager.db, sql, nil, nil, nil)
         manager.ensurePortfolioThemeAssetTable()
-        _ = manager.createPortfolioTheme(name: "Growth", code: "GROWTH", statusId: 1)
+        _ = manager.createPortfolioTheme(name: "Growth", code: "GROWTH", description: nil, institutionId: nil, statusId: 1)
         sqlite3_exec(manager.db, "INSERT INTO Instruments (instrument_name, sub_class_id, currency) VALUES ('Apple',1,'USD');", nil, nil, nil)
     }
 

--- a/DragonShieldTests/PortfolioThemeAssetTests.swift
+++ b/DragonShieldTests/PortfolioThemeAssetTests.swift
@@ -37,7 +37,7 @@ final class PortfolioThemeAssetTests: XCTestCase {
         """
         sqlite3_exec(manager.db, sql, nil, nil, nil)
         manager.ensurePortfolioThemeAssetTable()
-        _ = manager.createPortfolioTheme(name: "Growth", code: "GROWTH", statusId: 1)
+        _ = manager.createPortfolioTheme(name: "Growth", code: "GROWTH", description: nil, institutionId: nil, statusId: 1)
         sqlite3_exec(manager.db, "INSERT INTO Instruments (instrument_name, sub_class_id, currency) VALUES ('Apple',1,'USD');", nil, nil, nil)
     }
 

--- a/DragonShieldTests/PortfolioThemeDetailLayoutTests.swift
+++ b/DragonShieldTests/PortfolioThemeDetailLayoutTests.swift
@@ -32,7 +32,7 @@ final class PortfolioThemeDetailLayoutTests: XCTestCase {
         );
         """
         sqlite3_exec(manager.db, sql, nil, nil, nil)
-        _ = manager.createPortfolioTheme(name: "Growth", code: "GROWTH", statusId: 1)
+        _ = manager.createPortfolioTheme(name: "Growth", code: "GROWTH", description: nil, institutionId: nil, statusId: 1)
         let view = PortfolioThemeDetailView(themeId: 1, origin: "test").environmentObject(manager)
         XCTAssertNotNil(view.body)
         sqlite3_close(mem)

--- a/DragonShieldTests/PortfolioThemeInstrumentCountTests.swift
+++ b/DragonShieldTests/PortfolioThemeInstrumentCountTests.swift
@@ -40,7 +40,7 @@ final class PortfolioThemeInstrumentCountTests: XCTestCase {
     func testFetchThemesReturnsInstrumentCount() {
         let manager = DatabaseManager()
         setup(manager)
-        _ = manager.createPortfolioTheme(name: "Growth", code: "GROWTH", statusId: 1)
+        _ = manager.createPortfolioTheme(name: "Growth", code: "GROWTH", description: nil, institutionId: nil, statusId: 1)
         sqlite3_exec(manager.db, "INSERT INTO Instruments (instrument_name, sub_class_id, currency) VALUES ('Apple',1,'USD');", nil, nil, nil)
         sqlite3_exec(manager.db, "INSERT INTO Instruments (instrument_name, sub_class_id, currency) VALUES ('Tesla',1,'USD');", nil, nil, nil)
         guard let theme = manager.fetchPortfolioThemes().first else { XCTFail(); return }
@@ -54,7 +54,7 @@ final class PortfolioThemeInstrumentCountTests: XCTestCase {
     func testGetThemeReturnsInstrumentCount() {
         let manager = DatabaseManager()
         setup(manager)
-        guard let theme = manager.createPortfolioTheme(name: "Income", code: "INCOME", statusId: 1) else { XCTFail(); return }
+        guard let theme = manager.createPortfolioTheme(name: "Income", code: "INCOME", description: nil, institutionId: nil, statusId: 1) else { XCTFail(); return }
         sqlite3_exec(manager.db, "INSERT INTO Instruments (instrument_name, sub_class_id, currency) VALUES ('BondA',1,'USD');", nil, nil, nil)
         sqlite3_exec(manager.db, "INSERT INTO Instruments (instrument_name, sub_class_id, currency) VALUES ('BondB',1,'USD');", nil, nil, nil)
         _ = manager.createThemeAsset(themeId: theme.id, instrumentId: 1, researchPct: 50.0)

--- a/DragonShieldTests/PortfolioThemeNavigationTests.swift
+++ b/DragonShieldTests/PortfolioThemeNavigationTests.swift
@@ -24,7 +24,7 @@ final class PortfolioThemeNavigationTests: XCTestCase {
         """
         sqlite3_exec(manager.db, sql, nil, nil, nil)
         manager.ensurePortfolioThemeTable()
-        guard let theme = manager.createPortfolioTheme(name: "Growth", code: "GROWTH", statusId: 1) else { XCTFail(); return }
+        guard let theme = manager.createPortfolioTheme(name: "Growth", code: "GROWTH", description: nil, institutionId: nil, statusId: 1) else { XCTFail(); return }
         XCTAssertTrue(manager.archivePortfolioTheme(id: theme.id))
         XCTAssertTrue(manager.softDeletePortfolioTheme(id: theme.id))
         XCTAssertNil(manager.getPortfolioTheme(id: theme.id))

--- a/DragonShieldTests/PortfolioThemeTests.swift
+++ b/DragonShieldTests/PortfolioThemeTests.swift
@@ -38,11 +38,62 @@ final class PortfolioThemeTests: XCTestCase {
         """
         sqlite3_exec(manager.db, statusSQL, nil, nil, nil)
         manager.ensurePortfolioThemeTable()
-        let theme = manager.createPortfolioTheme(name: "Growth", code: "GROWTH", statusId: 1)
+        let theme = manager.createPortfolioTheme(name: "Growth", code: "GROWTH", description: nil, institutionId: nil, statusId: 1)
         XCTAssertNotNil(theme)
         let fetched = manager.fetchPortfolioThemes()
         XCTAssertEqual(fetched.count, 1)
         XCTAssertEqual(fetched.first?.name, "Growth")
+        sqlite3_close(memdb)
+    }
+
+    func testDescriptionAndInstitutionPersistence() {
+        let manager = DatabaseManager()
+        var memdb: OpaquePointer?
+        sqlite3_open(":memory:", &memdb)
+        manager.db = memdb
+        let setupSQL = """
+        CREATE TABLE IF NOT EXISTS PortfolioThemeStatus (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            code TEXT NOT NULL UNIQUE CHECK (code GLOB '[A-Z][A-Z0-9_]*'),
+            name TEXT NOT NULL UNIQUE,
+            color_hex TEXT NOT NULL CHECK (color_hex GLOB '#[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]'),
+            is_default BOOLEAN NOT NULL DEFAULT 0,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_portfolio_theme_status_default ON PortfolioThemeStatus(is_default) WHERE is_default = 1;
+        INSERT INTO PortfolioThemeStatus (code, name, color_hex, is_default) VALUES
+            ('DRAFT','Draft','#9AA0A6',1);
+        CREATE TABLE Institutions (institution_id INTEGER PRIMARY KEY, institution_name TEXT);
+        INSERT INTO Institutions (institution_name) VALUES ('Credit Suisse');
+        """
+        sqlite3_exec(manager.db, setupSQL, nil, nil, nil)
+        manager.ensurePortfolioThemeTable()
+        let theme = manager.createPortfolioTheme(name: "Growth", code: "GROWTH", description: "Test", institutionId: 1, statusId: 1)
+        XCTAssertEqual(theme?.description, "Test")
+        XCTAssertEqual(theme?.institutionId, 1)
+        let ok = manager.updatePortfolioTheme(id: theme!.id, name: "Growth", description: "New", institutionId: nil, statusId: 1, archivedAt: nil)
+        XCTAssertTrue(ok)
+        let fetched = manager.getPortfolioTheme(id: theme!.id)
+        XCTAssertEqual(fetched?.description, "New")
+        XCTAssertNil(fetched?.institutionId)
+        sqlite3_close(memdb)
+    }
+
+    func testDescriptionTooLongFails() {
+        let manager = DatabaseManager()
+        var memdb: OpaquePointer?
+        sqlite3_open(":memory:", &memdb)
+        manager.db = memdb
+        let setupSQL = """
+        CREATE TABLE PortfolioThemeStatus (id INTEGER PRIMARY KEY, code TEXT, name TEXT, color_hex TEXT, is_default INTEGER);
+        INSERT INTO PortfolioThemeStatus VALUES (1,'ACTIVE','Active','#fff',1);
+        """
+        sqlite3_exec(manager.db, setupSQL, nil, nil, nil)
+        manager.ensurePortfolioThemeTable()
+        let longDesc = String(repeating: "a", count: 2001)
+        let theme = manager.createPortfolioTheme(name: "Growth", code: "GROWTH", description: longDesc, institutionId: nil, statusId: 1)
+        XCTAssertNil(theme)
         sqlite3_close(memdb)
     }
 }


### PR DESCRIPTION
## Summary
- allow portfolio themes to store optional long description and owning institution
- expose description and institution picker in theme detail view
- add migration and tests for new metadata
- simplify schema constraints, remove redundant triggers, and clean up institution picker and description trimming

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68a85b1530f08323998fdea974533a81