### PR TITLE
feat: add portfolio theme updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Introduce PortfolioThemeUpdate table and CRUD helpers for theme update timelines
+- Add Updates tab and quick New Update entry points for Portfolio Themes
 - Add deviation analytics with tolerance controls to Portfolio Theme valuation table
 - Add description and optional institution link to Portfolio Themes with migration 012
 - Align Composition table headers with data columns and add per-instrument notes pop-up in Portfolio Theme details

--- a/DragonShield/DatabaseManager+PortfolioThemeUpdates.swift
+++ b/DragonShield/DatabaseManager+PortfolioThemeUpdates.swift
@@ -1,0 +1,171 @@
+// DragonShield/DatabaseManager+PortfolioThemeUpdates.swift
+// MARK: - Version 1.0
+// MARK: - History
+// - Initial creation: CRUD helpers for PortfolioThemeUpdate with optimistic concurrency.
+
+import SQLite3
+import Foundation
+
+extension DatabaseManager {
+    func ensurePortfolioThemeUpdateTable() {
+        let sql = """
+        CREATE TABLE IF NOT EXISTS PortfolioThemeUpdate (
+            id INTEGER PRIMARY KEY,
+            theme_id INTEGER NOT NULL REFERENCES PortfolioTheme(id) ON DELETE CASCADE,
+            title TEXT NOT NULL CHECK (LENGTH(title) BETWEEN 1 AND 120),
+            body_text TEXT NOT NULL CHECK (LENGTH(body_text) BETWEEN 1 AND 5000),
+            type TEXT NOT NULL CHECK (type IN ('General','Research','Rebalance','Risk')),
+            author TEXT NOT NULL,
+            positions_asof TEXT NULL,
+            total_value_chf REAL NULL,
+            created_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
+            updated_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now'))
+        );
+        CREATE INDEX IF NOT EXISTS idx_ptu_theme_order ON PortfolioThemeUpdate(theme_id, created_at DESC);
+        """
+        if sqlite3_exec(db, sql, nil, nil, nil) != SQLITE_OK {
+            LoggingService.shared.log("ensurePortfolioThemeUpdateTable failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+    }
+
+    func listThemeUpdates(themeId: Int) -> [PortfolioThemeUpdate] {
+        var items: [PortfolioThemeUpdate] = []
+        let sql = "SELECT id, theme_id, title, body_text, type, author, positions_asof, total_value_chf, created_at, updated_at FROM PortfolioThemeUpdate WHERE theme_id = ? ORDER BY created_at DESC"
+        var stmt: OpaquePointer?
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            sqlite3_bind_int(stmt, 1, Int32(themeId))
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                let id = Int(sqlite3_column_int(stmt, 0))
+                let themeId = Int(sqlite3_column_int(stmt, 1))
+                let title = String(cString: sqlite3_column_text(stmt, 2))
+                let body = String(cString: sqlite3_column_text(stmt, 3))
+                let typeStr = String(cString: sqlite3_column_text(stmt, 4))
+                let author = String(cString: sqlite3_column_text(stmt, 5))
+                let posAsOf = sqlite3_column_text(stmt, 6).map { String(cString: $0) }
+                let value = sqlite3_column_type(stmt, 7) == SQLITE_NULL ? nil : sqlite3_column_double(stmt, 7)
+                let created = String(cString: sqlite3_column_text(stmt, 8))
+                let updated = String(cString: sqlite3_column_text(stmt, 9))
+                if let type = PortfolioThemeUpdate.UpdateType(rawValue: typeStr) {
+                    let item = PortfolioThemeUpdate(id: id, themeId: themeId, title: title, bodyText: body, type: type, author: author, positionsAsOf: posAsOf, totalValueChf: value, createdAt: created, updatedAt: updated)
+                    items.append(item)
+                }
+            }
+        } else {
+            LoggingService.shared.log("Failed to prepare listThemeUpdates: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+        sqlite3_finalize(stmt)
+        return items
+    }
+
+    func createThemeUpdate(themeId: Int, title: String, bodyText: String, type: PortfolioThemeUpdate.UpdateType, author: String, positionsAsOf: String?, totalValueChf: Double?) -> PortfolioThemeUpdate? {
+        guard PortfolioThemeUpdate.isValidTitle(title), PortfolioThemeUpdate.isValidBody(bodyText) else {
+            LoggingService.shared.log("Invalid title/body for theme update", type: .info, logger: .database)
+            return nil
+        }
+        let sql = "INSERT INTO PortfolioThemeUpdate (theme_id, title, body_text, type, author, positions_asof, total_value_chf) VALUES (?,?,?,?,?,?,?)"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            LoggingService.shared.log("prepare createThemeUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            return nil
+        }
+        defer { sqlite3_finalize(stmt) }
+        let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        sqlite3_bind_int(stmt, 1, Int32(themeId))
+        sqlite3_bind_text(stmt, 2, title, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 3, bodyText, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 4, type.rawValue, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 5, author, -1, SQLITE_TRANSIENT)
+        if let pos = positionsAsOf {
+            sqlite3_bind_text(stmt, 6, pos, -1, SQLITE_TRANSIENT)
+        } else {
+            sqlite3_bind_null(stmt, 6)
+        }
+        if let val = totalValueChf {
+            sqlite3_bind_double(stmt, 7, val)
+        } else {
+            sqlite3_bind_null(stmt, 7)
+        }
+        guard sqlite3_step(stmt) == SQLITE_DONE else {
+            LoggingService.shared.log("createThemeUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            return nil
+        }
+        let id = Int(sqlite3_last_insert_rowid(db))
+        LoggingService.shared.log("createThemeUpdate themeId=\(themeId) id=\(id)", logger: .database)
+        return getThemeUpdate(id: id)
+    }
+
+    func getThemeUpdate(id: Int) -> PortfolioThemeUpdate? {
+        let sql = "SELECT id, theme_id, title, body_text, type, author, positions_asof, total_value_chf, created_at, updated_at FROM PortfolioThemeUpdate WHERE id = ?"
+        var stmt: OpaquePointer?
+        var item: PortfolioThemeUpdate?
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            sqlite3_bind_int(stmt, 1, Int32(id))
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                let id = Int(sqlite3_column_int(stmt, 0))
+                let themeId = Int(sqlite3_column_int(stmt, 1))
+                let title = String(cString: sqlite3_column_text(stmt, 2))
+                let body = String(cString: sqlite3_column_text(stmt, 3))
+                let typeStr = String(cString: sqlite3_column_text(stmt, 4))
+                let author = String(cString: sqlite3_column_text(stmt, 5))
+                let posAsOf = sqlite3_column_text(stmt, 6).map { String(cString: $0) }
+                let value = sqlite3_column_type(stmt, 7) == SQLITE_NULL ? nil : sqlite3_column_double(stmt, 7)
+                let created = String(cString: sqlite3_column_text(stmt, 8))
+                let updated = String(cString: sqlite3_column_text(stmt, 9))
+                if let type = PortfolioThemeUpdate.UpdateType(rawValue: typeStr) {
+                    item = PortfolioThemeUpdate(id: id, themeId: themeId, title: title, bodyText: body, type: type, author: author, positionsAsOf: posAsOf, totalValueChf: value, createdAt: created, updatedAt: updated)
+                }
+            }
+        } else {
+            LoggingService.shared.log("Failed to prepare getThemeUpdate: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+        sqlite3_finalize(stmt)
+        return item
+    }
+
+    func updateThemeUpdate(id: Int, title: String, bodyText: String, type: PortfolioThemeUpdate.UpdateType, expectedUpdatedAt: String) -> PortfolioThemeUpdate? {
+        guard PortfolioThemeUpdate.isValidTitle(title), PortfolioThemeUpdate.isValidBody(bodyText) else {
+            LoggingService.shared.log("Invalid title/body for updateThemeUpdate", type: .info, logger: .database)
+            return nil
+        }
+        let sql = "UPDATE PortfolioThemeUpdate SET title = ?, body_text = ?, type = ?, updated_at = STRFTIME('%Y-%m-%dT%H:%M:%fZ','now') WHERE id = ? AND updated_at = ?"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            LoggingService.shared.log("prepare updateThemeUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            return nil
+        }
+        defer { sqlite3_finalize(stmt) }
+        let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        sqlite3_bind_text(stmt, 1, title, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 2, bodyText, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 3, type.rawValue, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_int(stmt, 4, Int32(id))
+        sqlite3_bind_text(stmt, 5, expectedUpdatedAt, -1, SQLITE_TRANSIENT)
+        guard sqlite3_step(stmt) == SQLITE_DONE else {
+            LoggingService.shared.log("updateThemeUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            return nil
+        }
+        if sqlite3_changes(db) == 0 {
+            LoggingService.shared.log("updateThemeUpdate concurrency conflict id=\(id)", type: .info, logger: .database)
+            return nil
+        }
+        LoggingService.shared.log("updateThemeUpdate id=\(id)", logger: .database)
+        return getThemeUpdate(id: id)
+    }
+
+    func deleteThemeUpdate(id: Int) -> Bool {
+        let sql = "DELETE FROM PortfolioThemeUpdate WHERE id = ?"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            LoggingService.shared.log("prepare deleteThemeUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            return false
+        }
+        defer { sqlite3_finalize(stmt) }
+        sqlite3_bind_int(stmt, 1, Int32(id))
+        guard sqlite3_step(stmt) == SQLITE_DONE else {
+            LoggingService.shared.log("deleteThemeUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            return false
+        }
+        LoggingService.shared.log("deleteThemeUpdate id=\(id)", logger: .database)
+        return true
+    }
+}

--- a/DragonShield/DatabaseManager.swift
+++ b/DragonShield/DatabaseManager.swift
@@ -41,6 +41,8 @@ class DatabaseManager: ObservableObject {
     @Published var dbModified: Date?
     @Published var includeDirectRealEstate: Bool = true
     @Published var directRealEstateTargetCHF: Double = 0.0
+    // Feature flags
+    @Published var portfolioThemeUpdatesEnabled: Bool
 
     // ==============================================================================
     // == CORRECTED INIT METHOD                                                    ==
@@ -58,6 +60,7 @@ class DatabaseManager: ObservableObject {
         let mode = DatabaseMode(rawValue: savedMode ?? "production") ?? .production
         self.dbMode = mode
         self.dbPath = appDir.appendingPathComponent(DatabaseManager.fileName(for: mode)).path
+        self.portfolioThemeUpdatesEnabled = (mode == .test)
 
         
         #if DEBUG
@@ -91,6 +94,7 @@ class DatabaseManager: ObservableObject {
         ensurePortfolioThemeStatusDefault()
         ensurePortfolioThemeTable()
         ensurePortfolioThemeAssetTable()
+        ensurePortfolioThemeUpdateTable()
         let version = loadConfiguration()
         self.dbVersion = version
         DispatchQueue.main.async { self.dbVersion = version }

--- a/DragonShield/Models/PortfolioThemeUpdate.swift
+++ b/DragonShield/Models/PortfolioThemeUpdate.swift
@@ -1,0 +1,36 @@
+// DragonShield/Models/PortfolioThemeUpdate.swift
+// MARK: - Version 1.0
+// MARK: - History
+// - Initial creation: Represents plain text update entries for a portfolio theme with breadcrumb support.
+
+import Foundation
+
+struct PortfolioThemeUpdate: Identifiable, Codable {
+    enum UpdateType: String, CaseIterable, Codable {
+        case General
+        case Research
+        case Rebalance
+        case Risk
+    }
+
+    let id: Int
+    let themeId: Int
+    var title: String
+    var bodyText: String
+    var type: UpdateType
+    let author: String
+    var positionsAsOf: String?
+    var totalValueChf: Double?
+    let createdAt: String
+    var updatedAt: String
+
+    static func isValidTitle(_ title: String) -> Bool {
+        let count = title.trimmingCharacters(in: .whitespacesAndNewlines).count
+        return count >= 1 && count <= 120
+    }
+
+    static func isValidBody(_ body: String) -> Bool {
+        let count = body.trimmingCharacters(in: .whitespacesAndNewlines).count
+        return count >= 1 && count <= 5000
+    }
+}

--- a/DragonShield/Views/ThemeUpdateEditorView.swift
+++ b/DragonShield/Views/ThemeUpdateEditorView.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+import AppKit
+
+struct ThemeUpdateEditorView: View {
+    @EnvironmentObject var dbManager: DatabaseManager
+    let theme: PortfolioTheme
+    var update: PortfolioThemeUpdate?
+    var onSave: (PortfolioThemeUpdate) -> Void
+    var onCancel: () -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var title: String
+    @State private var bodyText: String
+    @State private var type: PortfolioThemeUpdate.UpdateType
+    @State private var positionsAsOf: String? = nil
+    @State private var totalValue: Double? = nil
+    @State private var showAlert = false
+
+    private let fmt = ISO8601DateFormatter()
+
+    init(theme: PortfolioTheme, update: PortfolioThemeUpdate? = nil, onSave: @escaping (PortfolioThemeUpdate) -> Void, onCancel: @escaping () -> Void) {
+        self.theme = theme
+        self.update = update
+        self.onSave = onSave
+        self.onCancel = onCancel
+        _title = State(initialValue: update?.title ?? "")
+        _bodyText = State(initialValue: update?.bodyText ?? "")
+        _type = State(initialValue: update?.type ?? .General)
+        if let up = update {
+            _positionsAsOf = State(initialValue: up.positionsAsOf)
+            _totalValue = State(initialValue: up.totalValueChf)
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Title (1–120):")
+            TextField("", text: $title)
+                .textFieldStyle(.roundedBorder)
+            Picker("Type:", selection: $type) {
+                ForEach(PortfolioThemeUpdate.UpdateType.allCases, id: \.self) { t in
+                    Text(t.rawValue).tag(t)
+                }
+            }
+            Text("Body (plain text, 1–5000):")
+            TextEditor(text: $bodyText)
+                .frame(minHeight: 120)
+                .border(Color.secondary)
+            Text("\(bodyText.count) / 5000 characters")
+                .font(.caption)
+                .foregroundColor(bodyText.count > 5000 ? .red : .secondary)
+            Text("On save we will capture: Positions \(positionsAsOf ?? "—") • Total CHF \(totalValue.map { String(format: "%.2f", $0) } ?? "—")")
+                .font(.footnote)
+                .foregroundColor(.secondary)
+            Spacer()
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss(); onCancel() }
+                Button("Save") { save() }
+                    .disabled(!valid)
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 500, minHeight: 400)
+        .onAppear(perform: captureSnapshot)
+        .alert("This update was modified elsewhere. Please reload and try again.", isPresented: $showAlert) {
+            Button("OK", role: .cancel) { }
+        }
+    }
+
+    private var valid: Bool {
+        PortfolioThemeUpdate.isValidTitle(title) && PortfolioThemeUpdate.isValidBody(bodyText)
+    }
+
+    private func captureSnapshot() {
+        guard update == nil else { return }
+        let fx = FXConversionService(dbManager: dbManager)
+        let service = PortfolioValuationService(dbManager: dbManager, fxService: fx)
+        let snap = service.snapshot(themeId: theme.id)
+        positionsAsOf = snap.positionsAsOf.map { fmt.string(from: $0) }
+        totalValue = snap.positionsAsOf == nil ? nil : snap.totalValueBase
+    }
+
+    private func save() {
+        if let existing = update {
+            if let updated = dbManager.updateThemeUpdate(id: existing.id, title: title, bodyText: bodyText, type: type, expectedUpdatedAt: existing.updatedAt) {
+                onSave(updated)
+                dismiss()
+            } else {
+                showAlert = true
+            }
+        } else {
+            let author = NSFullUserName()
+            if let created = dbManager.createThemeUpdate(themeId: theme.id, title: title, bodyText: bodyText, type: type, author: author, positionsAsOf: positionsAsOf, totalValueChf: totalValue) {
+                onSave(created)
+                dismiss()
+            }
+        }
+    }
+}

--- a/DragonShield/db/migrations/013_portfolio_theme_update.sql
+++ b/DragonShield/db/migrations/013_portfolio_theme_update.sql
@@ -1,0 +1,21 @@
+-- migrate:up
+-- Purpose: Introduce PortfolioThemeUpdate table for recording theme-level update timeline entries.
+-- Assumptions: PortfolioTheme table exists and uses integer primary keys; no existing update records.
+-- Idempotency: use IF NOT EXISTS and CHECK constraints to enforce domain values.
+CREATE TABLE IF NOT EXISTS PortfolioThemeUpdate (
+  id               INTEGER PRIMARY KEY,
+  theme_id         INTEGER NOT NULL REFERENCES PortfolioTheme(id) ON DELETE CASCADE,
+  title            TEXT    NOT NULL CHECK (LENGTH(title) BETWEEN 1 AND 120),
+  body_text        TEXT    NOT NULL CHECK (LENGTH(body_text) BETWEEN 1 AND 5000),
+  type             TEXT    NOT NULL CHECK (type IN ('General','Research','Rebalance','Risk')),
+  author           TEXT    NOT NULL,
+  positions_asof   TEXT    NULL,
+  total_value_chf  REAL    NULL,
+  created_at       TEXT    NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
+  updated_at       TEXT    NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+CREATE INDEX IF NOT EXISTS idx_ptu_theme_order ON PortfolioThemeUpdate(theme_id, created_at DESC);
+
+-- migrate:down
+DROP INDEX IF EXISTS idx_ptu_theme_order;
+DROP TABLE IF EXISTS PortfolioThemeUpdate;

--- a/DragonShieldTests/PortfolioThemeUpdateTests.swift
+++ b/DragonShieldTests/PortfolioThemeUpdateTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+import SQLite3
+@testable import DragonShield
+
+final class PortfolioThemeUpdateTests: XCTestCase {
+    var manager: DatabaseManager!
+    var memdb: OpaquePointer?
+
+    override func setUp() {
+        super.setUp()
+        manager = DatabaseManager()
+        sqlite3_open(":memory:", &memdb)
+        manager.db = memdb
+        sqlite3_exec(manager.db, "PRAGMA foreign_keys = ON;", nil, nil, nil)
+        sqlite3_exec(manager.db, "CREATE TABLE PortfolioTheme(id INTEGER PRIMARY KEY);", nil, nil, nil)
+        sqlite3_exec(manager.db, "INSERT INTO PortfolioTheme(id) VALUES (1);", nil, nil, nil)
+        manager.ensurePortfolioThemeUpdateTable()
+    }
+
+    override func tearDown() {
+        sqlite3_close(memdb)
+        memdb = nil
+        manager = nil
+        super.tearDown()
+    }
+
+    func testCreateUpdateDeleteFlow() {
+        let created = manager.createThemeUpdate(themeId: 1, title: "Raised cash", bodyText: "Trimmed VOO", type: .Rebalance, author: "Alice", positionsAsOf: "2025-09-02T09:30:00Z", totalValueChf: 2104500)
+        XCTAssertNotNil(created)
+        var list = manager.listThemeUpdates(themeId: 1)
+        XCTAssertEqual(list.count, 1)
+        let first = list[0]
+        XCTAssertEqual(first.author, "Alice")
+
+        let updated = manager.updateThemeUpdate(id: first.id, title: "Raise cash to 15%", bodyText: "Adjust further", type: .Rebalance, expectedUpdatedAt: first.updatedAt)
+        XCTAssertNotNil(updated)
+        let stale = manager.updateThemeUpdate(id: first.id, title: "Stale", bodyText: "Stale", type: .General, expectedUpdatedAt: first.updatedAt)
+        XCTAssertNil(stale)
+
+        let deleteOk = manager.deleteThemeUpdate(id: first.id)
+        XCTAssertTrue(deleteOk)
+        list = manager.listThemeUpdates(themeId: 1)
+        XCTAssertTrue(list.isEmpty)
+    }
+}

--- a/DragonShieldTests/PortfolioThemesListViewNewUpdateTests.swift
+++ b/DragonShieldTests/PortfolioThemesListViewNewUpdateTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import DragonShield
+
+final class PortfolioThemesListViewNewUpdateTests: XCTestCase {
+    @MainActor
+    func testInvokeNewUpdateSetsSheet() {
+        let manager = DatabaseManager()
+        manager.portfolioThemeUpdatesEnabled = true
+        var view = PortfolioThemesListView()
+        view.dbManager = manager
+        let theme = PortfolioTheme(id: 1, name: "T", code: "T", statusId: 1, createdAt: "", updatedAt: "", archivedAt: nil, softDelete: false)
+        view.themes = [theme]
+        view.selectedThemeId = 1
+        view.invokeNewUpdate(source: "toolbar")
+        XCTAssertEqual(view.newUpdateTheme?.id, 1)
+    }
+}


### PR DESCRIPTION
## Summary
- add PortfolioThemeUpdate model and database helpers
- create migration for PortfolioThemeUpdate table
- add tests for theme update CRUD flow
- add access points for theme updates with new tab and fast-path actions

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift)*
- `sqlite3 "$DBFILE" "SELECT name FROM sqlite_master WHERE name='PortfolioThemeUpdate';"`
- `sqlite3 "$DBFILE" "PRAGMA table_info('PortfolioThemeUpdate');"`


------
https://chatgpt.com/codex/tasks/task_e_68a873cb5a208323ab0feb3d4382859f