### PR TITLE
Enable Portfolio Theme Updates by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Introduce PortfolioThemeUpdate table and CRUD helpers for theme update timelines
+- Enable Updates tab and quick New Update entry points for Portfolio Themes by default
+- Fix compile errors in Theme Update views and allow specifying initial tab for details modal
 - Add deviation analytics with tolerance controls to Portfolio Theme valuation table
 - Add description and optional institution link to Portfolio Themes with migration 012
 - Align Composition table headers with data columns and add per-instrument notes pop-up in Portfolio Theme details

--- a/DragonShield/DatabaseManager+PortfolioThemeUpdates.swift
+++ b/DragonShield/DatabaseManager+PortfolioThemeUpdates.swift
@@ -1,0 +1,171 @@
+// DragonShield/DatabaseManager+PortfolioThemeUpdates.swift
+// MARK: - Version 1.0
+// MARK: - History
+// - Initial creation: CRUD helpers for PortfolioThemeUpdate with optimistic concurrency.
+
+import SQLite3
+import Foundation
+
+extension DatabaseManager {
+    func ensurePortfolioThemeUpdateTable() {
+        let sql = """
+        CREATE TABLE IF NOT EXISTS PortfolioThemeUpdate (
+            id INTEGER PRIMARY KEY,
+            theme_id INTEGER NOT NULL REFERENCES PortfolioTheme(id) ON DELETE CASCADE,
+            title TEXT NOT NULL CHECK (LENGTH(title) BETWEEN 1 AND 120),
+            body_text TEXT NOT NULL CHECK (LENGTH(body_text) BETWEEN 1 AND 5000),
+            type TEXT NOT NULL CHECK (type IN ('General','Research','Rebalance','Risk')),
+            author TEXT NOT NULL,
+            positions_asof TEXT NULL,
+            total_value_chf REAL NULL,
+            created_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
+            updated_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now'))
+        );
+        CREATE INDEX IF NOT EXISTS idx_ptu_theme_order ON PortfolioThemeUpdate(theme_id, created_at DESC);
+        """
+        if sqlite3_exec(db, sql, nil, nil, nil) != SQLITE_OK {
+            LoggingService.shared.log("ensurePortfolioThemeUpdateTable failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+    }
+
+    func listThemeUpdates(themeId: Int) -> [PortfolioThemeUpdate] {
+        var items: [PortfolioThemeUpdate] = []
+        let sql = "SELECT id, theme_id, title, body_text, type, author, positions_asof, total_value_chf, created_at, updated_at FROM PortfolioThemeUpdate WHERE theme_id = ? ORDER BY created_at DESC"
+        var stmt: OpaquePointer?
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            sqlite3_bind_int(stmt, 1, Int32(themeId))
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                let id = Int(sqlite3_column_int(stmt, 0))
+                let themeId = Int(sqlite3_column_int(stmt, 1))
+                let title = String(cString: sqlite3_column_text(stmt, 2))
+                let body = String(cString: sqlite3_column_text(stmt, 3))
+                let typeStr = String(cString: sqlite3_column_text(stmt, 4))
+                let author = String(cString: sqlite3_column_text(stmt, 5))
+                let posAsOf = sqlite3_column_text(stmt, 6).map { String(cString: $0) }
+                let value = sqlite3_column_type(stmt, 7) == SQLITE_NULL ? nil : sqlite3_column_double(stmt, 7)
+                let created = String(cString: sqlite3_column_text(stmt, 8))
+                let updated = String(cString: sqlite3_column_text(stmt, 9))
+                if let type = PortfolioThemeUpdate.UpdateType(rawValue: typeStr) {
+                    let item = PortfolioThemeUpdate(id: id, themeId: themeId, title: title, bodyText: body, type: type, author: author, positionsAsOf: posAsOf, totalValueChf: value, createdAt: created, updatedAt: updated)
+                    items.append(item)
+                }
+            }
+        } else {
+            LoggingService.shared.log("Failed to prepare listThemeUpdates: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+        sqlite3_finalize(stmt)
+        return items
+    }
+
+    func createThemeUpdate(themeId: Int, title: String, bodyText: String, type: PortfolioThemeUpdate.UpdateType, author: String, positionsAsOf: String?, totalValueChf: Double?) -> PortfolioThemeUpdate? {
+        guard PortfolioThemeUpdate.isValidTitle(title), PortfolioThemeUpdate.isValidBody(bodyText) else {
+            LoggingService.shared.log("Invalid title/body for theme update", type: .info, logger: .database)
+            return nil
+        }
+        let sql = "INSERT INTO PortfolioThemeUpdate (theme_id, title, body_text, type, author, positions_asof, total_value_chf) VALUES (?,?,?,?,?,?,?)"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            LoggingService.shared.log("prepare createThemeUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            return nil
+        }
+        defer { sqlite3_finalize(stmt) }
+        let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        sqlite3_bind_int(stmt, 1, Int32(themeId))
+        sqlite3_bind_text(stmt, 2, title, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 3, bodyText, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 4, type.rawValue, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 5, author, -1, SQLITE_TRANSIENT)
+        if let pos = positionsAsOf {
+            sqlite3_bind_text(stmt, 6, pos, -1, SQLITE_TRANSIENT)
+        } else {
+            sqlite3_bind_null(stmt, 6)
+        }
+        if let val = totalValueChf {
+            sqlite3_bind_double(stmt, 7, val)
+        } else {
+            sqlite3_bind_null(stmt, 7)
+        }
+        guard sqlite3_step(stmt) == SQLITE_DONE else {
+            LoggingService.shared.log("createThemeUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            return nil
+        }
+        let id = Int(sqlite3_last_insert_rowid(db))
+        LoggingService.shared.log("createThemeUpdate themeId=\(themeId) id=\(id)", logger: .database)
+        return getThemeUpdate(id: id)
+    }
+
+    func getThemeUpdate(id: Int) -> PortfolioThemeUpdate? {
+        let sql = "SELECT id, theme_id, title, body_text, type, author, positions_asof, total_value_chf, created_at, updated_at FROM PortfolioThemeUpdate WHERE id = ?"
+        var stmt: OpaquePointer?
+        var item: PortfolioThemeUpdate?
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            sqlite3_bind_int(stmt, 1, Int32(id))
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                let id = Int(sqlite3_column_int(stmt, 0))
+                let themeId = Int(sqlite3_column_int(stmt, 1))
+                let title = String(cString: sqlite3_column_text(stmt, 2))
+                let body = String(cString: sqlite3_column_text(stmt, 3))
+                let typeStr = String(cString: sqlite3_column_text(stmt, 4))
+                let author = String(cString: sqlite3_column_text(stmt, 5))
+                let posAsOf = sqlite3_column_text(stmt, 6).map { String(cString: $0) }
+                let value = sqlite3_column_type(stmt, 7) == SQLITE_NULL ? nil : sqlite3_column_double(stmt, 7)
+                let created = String(cString: sqlite3_column_text(stmt, 8))
+                let updated = String(cString: sqlite3_column_text(stmt, 9))
+                if let type = PortfolioThemeUpdate.UpdateType(rawValue: typeStr) {
+                    item = PortfolioThemeUpdate(id: id, themeId: themeId, title: title, bodyText: body, type: type, author: author, positionsAsOf: posAsOf, totalValueChf: value, createdAt: created, updatedAt: updated)
+                }
+            }
+        } else {
+            LoggingService.shared.log("Failed to prepare getThemeUpdate: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+        sqlite3_finalize(stmt)
+        return item
+    }
+
+    func updateThemeUpdate(id: Int, title: String, bodyText: String, type: PortfolioThemeUpdate.UpdateType, expectedUpdatedAt: String) -> PortfolioThemeUpdate? {
+        guard PortfolioThemeUpdate.isValidTitle(title), PortfolioThemeUpdate.isValidBody(bodyText) else {
+            LoggingService.shared.log("Invalid title/body for updateThemeUpdate", type: .info, logger: .database)
+            return nil
+        }
+        let sql = "UPDATE PortfolioThemeUpdate SET title = ?, body_text = ?, type = ?, updated_at = STRFTIME('%Y-%m-%dT%H:%M:%fZ','now') WHERE id = ? AND updated_at = ?"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            LoggingService.shared.log("prepare updateThemeUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            return nil
+        }
+        defer { sqlite3_finalize(stmt) }
+        let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        sqlite3_bind_text(stmt, 1, title, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 2, bodyText, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 3, type.rawValue, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_int(stmt, 4, Int32(id))
+        sqlite3_bind_text(stmt, 5, expectedUpdatedAt, -1, SQLITE_TRANSIENT)
+        guard sqlite3_step(stmt) == SQLITE_DONE else {
+            LoggingService.shared.log("updateThemeUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            return nil
+        }
+        if sqlite3_changes(db) == 0 {
+            LoggingService.shared.log("updateThemeUpdate concurrency conflict id=\(id)", type: .info, logger: .database)
+            return nil
+        }
+        LoggingService.shared.log("updateThemeUpdate id=\(id)", logger: .database)
+        return getThemeUpdate(id: id)
+    }
+
+    func deleteThemeUpdate(id: Int) -> Bool {
+        let sql = "DELETE FROM PortfolioThemeUpdate WHERE id = ?"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            LoggingService.shared.log("prepare deleteThemeUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            return false
+        }
+        defer { sqlite3_finalize(stmt) }
+        sqlite3_bind_int(stmt, 1, Int32(id))
+        guard sqlite3_step(stmt) == SQLITE_DONE else {
+            LoggingService.shared.log("deleteThemeUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            return false
+        }
+        LoggingService.shared.log("deleteThemeUpdate id=\(id)", logger: .database)
+        return true
+    }
+}

--- a/DragonShield/DatabaseManager.swift
+++ b/DragonShield/DatabaseManager.swift
@@ -58,7 +58,6 @@ class DatabaseManager: ObservableObject {
         let mode = DatabaseMode(rawValue: savedMode ?? "production") ?? .production
         self.dbMode = mode
         self.dbPath = appDir.appendingPathComponent(DatabaseManager.fileName(for: mode)).path
-
         
         #if DEBUG
         let shouldForceReCopy = UserDefaults.standard.bool(forKey: UserDefaultsKeys.forceOverwriteDatabaseOnDebug)
@@ -91,6 +90,7 @@ class DatabaseManager: ObservableObject {
         ensurePortfolioThemeStatusDefault()
         ensurePortfolioThemeTable()
         ensurePortfolioThemeAssetTable()
+        ensurePortfolioThemeUpdateTable()
         let version = loadConfiguration()
         self.dbVersion = version
         DispatchQueue.main.async { self.dbVersion = version }

--- a/DragonShield/Models/PortfolioThemeUpdate.swift
+++ b/DragonShield/Models/PortfolioThemeUpdate.swift
@@ -1,0 +1,36 @@
+// DragonShield/Models/PortfolioThemeUpdate.swift
+// MARK: - Version 1.0
+// MARK: - History
+// - Initial creation: Represents plain text update entries for a portfolio theme with breadcrumb support.
+
+import Foundation
+
+struct PortfolioThemeUpdate: Identifiable, Codable {
+    enum UpdateType: String, CaseIterable, Codable {
+        case General
+        case Research
+        case Rebalance
+        case Risk
+    }
+
+    let id: Int
+    let themeId: Int
+    var title: String
+    var bodyText: String
+    var type: UpdateType
+    let author: String
+    var positionsAsOf: String?
+    var totalValueChf: Double?
+    let createdAt: String
+    var updatedAt: String
+
+    static func isValidTitle(_ title: String) -> Bool {
+        let count = title.trimmingCharacters(in: .whitespacesAndNewlines).count
+        return count >= 1 && count <= 120
+    }
+
+    static func isValidBody(_ body: String) -> Bool {
+        let count = body.trimmingCharacters(in: .whitespacesAndNewlines).count
+        return count >= 1 && count <= 5000
+    }
+}

--- a/DragonShield/Views/NewThemeUpdateView.swift
+++ b/DragonShield/Views/NewThemeUpdateView.swift
@@ -1,0 +1,17 @@
+// DragonShield/Views/NewThemeUpdateView.swift
+// Wrapper view to keep project references valid while using ThemeUpdateEditorView.
+
+import SwiftUI
+
+struct NewThemeUpdateView: View {
+    @EnvironmentObject var dbManager: DatabaseManager
+    let themeId: Int
+    let themeName: String
+    var onSave: (PortfolioThemeUpdate) -> Void
+    var onCancel: () -> Void
+
+    var body: some View {
+        ThemeUpdateEditorView(themeId: themeId, themeName: themeName, onSave: onSave, onCancel: onCancel)
+            .environmentObject(dbManager)
+    }
+}

--- a/DragonShield/Views/PortfolioThemeDetailView.swift
+++ b/DragonShield/Views/PortfolioThemeDetailView.swift
@@ -3,15 +3,24 @@
 
 import SwiftUI
 
+enum DetailTab: String, CaseIterable {
+    case composition
+    case valuation
+    case updates
+}
+
 struct PortfolioThemeDetailView: View {
     @EnvironmentObject var dbManager: DatabaseManager
     let themeId: Int
     let origin: String
-    var onSave: (PortfolioTheme) -> Void = { _ in }
-    var onArchive: () -> Void = {}
-    var onUnarchive: (Int) -> Void = { _ in }
-    var onSoftDelete: () -> Void = {}
+    let initialTab: DetailTab
+    var onSave: (PortfolioTheme) -> Void
+    var onArchive: () -> Void
+    var onUnarchive: (Int) -> Void
+    var onSoftDelete: () -> Void
     @Environment(\.dismiss) private var dismiss
+    @AppStorage(UserDefaultsKeys.portfolioThemeDetailLastTab) private var lastTabRaw: String = DetailTab.composition.rawValue
+    @State private var selectedTab: DetailTab = .composition
 
     @State private var theme: PortfolioTheme?
     @State private var name: String = ""
@@ -50,32 +59,31 @@ struct PortfolioThemeDetailView: View {
     private let labelWidth: CGFloat = 140
     private let noteMaxLength = NoteEditorView.maxLength
 
+    init(themeId: Int, origin: String, initialTab: DetailTab = .composition, onSave: @escaping (PortfolioTheme) -> Void = { _ in }, onArchive: @escaping () -> Void = {}, onUnarchive: @escaping (Int) -> Void = { _ in }, onSoftDelete: @escaping () -> Void = {}) {
+        self.themeId = themeId
+        self.origin = origin
+        self.initialTab = initialTab
+        self.onSave = onSave
+        self.onArchive = onArchive
+        self.onUnarchive = onUnarchive
+        self.onSoftDelete = onSoftDelete
+    }
+
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
-                if isReadOnly {
-                    Text("Archived theme - read only")
-                        .frame(maxWidth: .infinity)
-                        .padding(8)
-                        .background(Color.yellow.opacity(0.1))
+                TabView(selection: $selectedTab) {
+                    compositionTab
+                        .tag(DetailTab.composition)
+                        .tabItem { Text("Composition") }
+                    valuationTab
+                        .tag(DetailTab.valuation)
+                        .tabItem { Text("Valuation") }
+                    updatesTab
+                        .tag(DetailTab.updates)
+                        .tabItem { Text("Updates") }
                 }
-
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 24) {
-                        headerBlock
-                        Divider()
-                        compositionSection
-                        Divider()
-                        valuationSection
-                        Divider()
-                        dangerZone
-                    }
-                    .padding(24)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                }
-
                 Divider()
-
                 HStack {
                     Spacer()
                     Button("Cancel") { dismiss() }
@@ -92,6 +100,11 @@ struct PortfolioThemeDetailView: View {
         .onAppear {
             loadTheme()
             runValuation()
+            selectedTab = initialTab
+            lastTabRaw = selectedTab.rawValue
+        }
+        .onChange(of: selectedTab) { _, newValue in
+            lastTabRaw = newValue.rawValue
         }
         .sheet(isPresented: $showAdd) { addSheet }
         .sheet(isPresented: $showAddInstitution) {
@@ -128,6 +141,43 @@ struct PortfolioThemeDetailView: View {
     }
 
     // MARK: - Sections
+
+    private var compositionTab: some View {
+        VStack(spacing: 0) {
+            if isReadOnly {
+                Text("Archived theme - read only")
+                    .frame(maxWidth: .infinity)
+                    .padding(8)
+                    .background(Color.yellow.opacity(0.1))
+            }
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    headerBlock
+                    Divider()
+                    compositionSection
+                    Divider()
+                    dangerZone
+                }
+                .padding(24)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    private var valuationTab: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                valuationSection
+            }
+            .padding(24)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var updatesTab: some View {
+        PortfolioThemeUpdatesView(themeId: themeId)
+            .environmentObject(dbManager)
+    }
 
     private var headerBlock: some View {
         VStack(alignment: .leading, spacing: 12) {

--- a/DragonShield/Views/PortfolioThemeUpdatesView.swift
+++ b/DragonShield/Views/PortfolioThemeUpdatesView.swift
@@ -1,0 +1,85 @@
+// DragonShield/Views/PortfolioThemeUpdatesView.swift
+// MARK: - Version 1.0
+// MARK: - History
+// - Initial creation: Lists and manages theme updates with fast-path creation.
+
+import SwiftUI
+
+struct PortfolioThemeUpdatesView: View {
+    @EnvironmentObject var dbManager: DatabaseManager
+    let themeId: Int
+
+    @State private var updates: [PortfolioThemeUpdate] = []
+    @State private var showEditor = false
+    @State private var editingUpdate: PortfolioThemeUpdate?
+    @State private var themeName: String = ""
+    @State private var isArchived: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            if isArchived {
+                Text("Theme archived — composition locked; updates permitted")
+                    .frame(maxWidth: .infinity)
+                    .padding(8)
+                    .background(Color.yellow.opacity(0.1))
+            }
+            HStack {
+                Button("+ New Update") { showEditor = true }
+                Spacer()
+            }
+            List {
+                ForEach(updates) { update in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("\(update.createdAt) • \(update.author) • \(update.type.rawValue)")
+                            .font(.subheadline)
+                        Text("Title: \(update.title)").fontWeight(.semibold)
+                        Text(update.bodyText)
+                        Text("Breadcrumb: Positions \(update.positionsAsOf ?? "—") • Total CHF \(formatted(update.totalValueChf))")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    .contextMenu {
+                        Button("Edit") { editingUpdate = update }
+                        Button("Delete", role: .destructive) {
+                            _ = dbManager.deleteThemeUpdate(id: update.id)
+                            load()
+                        }
+                    }
+                }
+            }
+        }
+        .onAppear { load() }
+        .sheet(isPresented: $showEditor) {
+            ThemeUpdateEditorView(themeId: themeId, themeName: themeName, onSave: { _ in
+                showEditor = false
+                load()
+            }, onCancel: {
+                showEditor = false
+            })
+            .environmentObject(dbManager)
+        }
+        .sheet(item: $editingUpdate) { upd in
+            ThemeUpdateEditorView(themeId: themeId, themeName: themeName, existing: upd, onSave: { _ in
+                editingUpdate = nil
+                load()
+            }, onCancel: {
+                editingUpdate = nil
+            })
+            .environmentObject(dbManager)
+        }
+    }
+
+    private func load() {
+        updates = dbManager.listThemeUpdates(themeId: themeId)
+        let themes = dbManager.fetchPortfolioThemes(includeArchived: true, includeSoftDeleted: false, search: nil)
+        if let theme = themes.first(where: { $0.id == themeId }) {
+            themeName = theme.name
+            isArchived = theme.archivedAt != nil
+        }
+    }
+
+    private func formatted(_ value: Double?) -> String {
+        guard let v = value else { return "—" }
+        return v.formatted(.currency(code: dbManager.baseCurrency).precision(.fractionLength(2)))
+    }
+}

--- a/DragonShield/Views/ThemeUpdateEditorView.swift
+++ b/DragonShield/Views/ThemeUpdateEditorView.swift
@@ -1,0 +1,97 @@
+// DragonShield/Views/ThemeUpdateEditorView.swift
+// MARK: - Version 1.0
+// MARK: - History
+// - Initial creation: Plain text editor for portfolio theme updates with breadcrumb capture.
+
+import SwiftUI
+
+struct ThemeUpdateEditorView: View {
+    @EnvironmentObject var dbManager: DatabaseManager
+    let themeId: Int
+    let themeName: String
+    var existing: PortfolioThemeUpdate?
+    var onSave: (PortfolioThemeUpdate) -> Void
+    var onCancel: () -> Void
+
+    @State private var title: String
+    @State private var bodyText: String
+    @State private var type: PortfolioThemeUpdate.UpdateType
+    @State private var positionsAsOf: String?
+    @State private var totalValueChf: Double?
+
+    init(themeId: Int, themeName: String, existing: PortfolioThemeUpdate? = nil, onSave: @escaping (PortfolioThemeUpdate) -> Void, onCancel: @escaping () -> Void) {
+        self.themeId = themeId
+        self.themeName = themeName
+        self.existing = existing
+        self.onSave = onSave
+        self.onCancel = onCancel
+        _title = State(initialValue: existing?.title ?? "")
+        _bodyText = State(initialValue: existing?.bodyText ?? "")
+        _type = State(initialValue: existing?.type ?? .General)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(existing == nil ? "New Update — \(themeName)" : "Edit Update — \(themeName)")
+                .font(.headline)
+            TextField("Title", text: $title)
+            Picker("Type", selection: $type) {
+                ForEach(PortfolioThemeUpdate.UpdateType.allCases, id: \.self) { t in
+                    Text(t.rawValue).tag(t)
+                }
+            }
+            TextEditor(text: $bodyText)
+                .frame(minHeight: 120)
+            Text("\(bodyText.count) / 5000")
+                .font(.caption)
+                .foregroundColor(bodyText.count > 5000 ? .red : .secondary)
+            Text("On save we will capture: Positions \(positionsAsOf ?? "—") • Total CHF \(formatted(totalValueChf))")
+                .font(.footnote)
+                .foregroundColor(.secondary)
+            HStack {
+                Spacer()
+                Button("Cancel") { onCancel() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Save") { save() }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(!valid)
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 520, minHeight: 340)
+        .onAppear { loadSnapshot() }
+    }
+
+    private var valid: Bool {
+        PortfolioThemeUpdate.isValidTitle(title) && PortfolioThemeUpdate.isValidBody(bodyText)
+    }
+
+    private func formatted(_ value: Double?) -> String {
+        guard let v = value else { return "—" }
+        return v.formatted(.currency(code: dbManager.baseCurrency).precision(.fractionLength(2)))
+    }
+
+    private func loadSnapshot() {
+        let fx = FXConversionService(dbManager: dbManager)
+        let service = PortfolioValuationService(dbManager: dbManager, fxService: fx)
+        let snap = service.snapshot(themeId: themeId)
+        if let asOf = snap.positionsAsOf {
+            positionsAsOf = ISO8601DateFormatter().string(from: asOf)
+        } else {
+            positionsAsOf = nil
+        }
+        totalValueChf = snap.totalValueBase
+    }
+
+    private func save() {
+        if let existing = existing {
+            if let updated = dbManager.updateThemeUpdate(id: existing.id, title: title, bodyText: bodyText, type: type, expectedUpdatedAt: existing.updatedAt) {
+                onSave(updated)
+            }
+        } else {
+            if let created = dbManager.createThemeUpdate(themeId: themeId, title: title, bodyText: bodyText, type: type, author: "system", positionsAsOf: positionsAsOf, totalValueChf: totalValueChf) {
+                onSave(created)
+            }
+        }
+    }
+}

--- a/DragonShield/db/migrations/013_portfolio_theme_update.sql
+++ b/DragonShield/db/migrations/013_portfolio_theme_update.sql
@@ -1,0 +1,21 @@
+-- migrate:up
+-- Purpose: Introduce PortfolioThemeUpdate table for recording theme-level update timeline entries.
+-- Assumptions: PortfolioTheme table exists and uses integer primary keys; no existing update records.
+-- Idempotency: use IF NOT EXISTS and CHECK constraints to enforce domain values.
+CREATE TABLE IF NOT EXISTS PortfolioThemeUpdate (
+  id               INTEGER PRIMARY KEY,
+  theme_id         INTEGER NOT NULL REFERENCES PortfolioTheme(id) ON DELETE CASCADE,
+  title            TEXT    NOT NULL CHECK (LENGTH(title) BETWEEN 1 AND 120),
+  body_text        TEXT    NOT NULL CHECK (LENGTH(body_text) BETWEEN 1 AND 5000),
+  type             TEXT    NOT NULL CHECK (type IN ('General','Research','Rebalance','Risk')),
+  author           TEXT    NOT NULL,
+  positions_asof   TEXT    NULL,
+  total_value_chf  REAL    NULL,
+  created_at       TEXT    NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
+  updated_at       TEXT    NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+CREATE INDEX IF NOT EXISTS idx_ptu_theme_order ON PortfolioThemeUpdate(theme_id, created_at DESC);
+
+-- migrate:down
+DROP INDEX IF EXISTS idx_ptu_theme_order;
+DROP TABLE IF EXISTS PortfolioThemeUpdate;

--- a/DragonShield/helpers/UserDefaultsKeys.swift
+++ b/DragonShield/helpers/UserDefaultsKeys.swift
@@ -21,4 +21,6 @@ struct UserDefaultsKeys {
     static let positionsFontSize = "positionsFontSize"
     /// Persist selected segment in Currencies & FX maintenance view.
     static let currenciesFxSegment = "currenciesFxSegment"
+    /// Remember last-used tab in Portfolio Theme Details.
+    static let portfolioThemeDetailLastTab = "portfolioThemeDetailLastTab"
 }

--- a/DragonShieldTests/PortfolioThemeUpdateAccessTests.swift
+++ b/DragonShieldTests/PortfolioThemeUpdateAccessTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+import SwiftUI
+import SQLite3
+@testable import DragonShield
+
+final class PortfolioThemeUpdateAccessTests: XCTestCase {
+    func testEditorViewInitializes() {
+        let manager = DatabaseManager()
+        var mem: OpaquePointer?
+        sqlite3_open(":memory:", &mem)
+        manager.db = mem
+        let view = ThemeUpdateEditorView(themeId: 1, themeName: "Test", onSave: { _ in }, onCancel: {})
+            .environmentObject(manager)
+        XCTAssertNotNil(view.body)
+        sqlite3_close(mem)
+    }
+}

--- a/DragonShieldTests/PortfolioThemeUpdateTests.swift
+++ b/DragonShieldTests/PortfolioThemeUpdateTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+import SQLite3
+@testable import DragonShield
+
+final class PortfolioThemeUpdateTests: XCTestCase {
+    var manager: DatabaseManager!
+    var memdb: OpaquePointer?
+
+    override func setUp() {
+        super.setUp()
+        manager = DatabaseManager()
+        sqlite3_open(":memory:", &memdb)
+        manager.db = memdb
+        sqlite3_exec(manager.db, "PRAGMA foreign_keys = ON;", nil, nil, nil)
+        sqlite3_exec(manager.db, "CREATE TABLE PortfolioTheme(id INTEGER PRIMARY KEY);", nil, nil, nil)
+        sqlite3_exec(manager.db, "INSERT INTO PortfolioTheme(id) VALUES (1);", nil, nil, nil)
+        manager.ensurePortfolioThemeUpdateTable()
+    }
+
+    override func tearDown() {
+        sqlite3_close(memdb)
+        memdb = nil
+        manager = nil
+        super.tearDown()
+    }
+
+    func testCreateUpdateDeleteFlow() {
+        let created = manager.createThemeUpdate(themeId: 1, title: "Raised cash", bodyText: "Trimmed VOO", type: .Rebalance, author: "Alice", positionsAsOf: "2025-09-02T09:30:00Z", totalValueChf: 2104500)
+        XCTAssertNotNil(created)
+        var list = manager.listThemeUpdates(themeId: 1)
+        XCTAssertEqual(list.count, 1)
+        let first = list[0]
+        XCTAssertEqual(first.author, "Alice")
+
+        let updated = manager.updateThemeUpdate(id: first.id, title: "Raise cash to 15%", bodyText: "Adjust further", type: .Rebalance, expectedUpdatedAt: first.updatedAt)
+        XCTAssertNotNil(updated)
+        let stale = manager.updateThemeUpdate(id: first.id, title: "Stale", bodyText: "Stale", type: .General, expectedUpdatedAt: first.updatedAt)
+        XCTAssertNil(stale)
+
+        let deleteOk = manager.deleteThemeUpdate(id: first.id)
+        XCTAssertTrue(deleteOk)
+        list = manager.listThemeUpdates(themeId: 1)
+        XCTAssertTrue(list.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- Enable Portfolio Theme Updates tab unconditionally and remove feature flag gating
- Always expose quick “New Update” actions from the themes list

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68a873cb5a208323ab0feb3d4382859f