### PR TITLE
feat: support markdown and pinning for theme updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Render Portfolio Theme update timestamps in local yyyy-MM-dd HH:mm format
+- Add selection footer bar with Edit/Delete/Pin actions and keyboard shortcuts
+- Provide Markdown help popover in Update editor
+- Support Markdown bodies and pinning for Portfolio Theme updates with migration 014
 - Introduce PortfolioThemeUpdate table and CRUD helpers for theme update timelines
 - Log invalid theme update types, fetch themes directly for Updates view, and record author from macOS user
 - Enable Updates tab and quick New Update entry points for Portfolio Themes by default

--- a/DragonShield/Core/DateFormatting.swift
+++ b/DragonShield/Core/DateFormatting.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+enum DateFormatting {
+    private static let isoFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    private static let isoFormatterFallback = ISO8601DateFormatter()
+
+    private static let displayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd HH:mm"
+        f.timeZone = .current
+        return f
+    }()
+
+    static func friendly(_ iso: String?) -> String {
+        guard let iso = iso else { return "—" }
+        if let date = isoFormatter.date(from: iso) ?? isoFormatterFallback.date(from: iso) {
+            return displayFormatter.string(from: date)
+        }
+        return iso
+    }
+}

--- a/DragonShield/Core/MarkdownRenderer.swift
+++ b/DragonShield/Core/MarkdownRenderer.swift
@@ -1,0 +1,15 @@
+import Foundation
+import SwiftUI
+
+enum MarkdownRenderer {
+    static func attributedString(from markdown: String) -> AttributedString {
+        let sanitized = markdown.replacingOccurrences(of: "<", with: "&lt;")
+        var attr = (try? AttributedString(markdown: sanitized, options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace))) ?? AttributedString(sanitized)
+        for run in attr.runs {
+            if let link = run.link, let scheme = link.scheme?.lowercased(), scheme != "http" && scheme != "https" {
+                attr[run.range].link = nil
+            }
+        }
+        return attr
+    }
+}

--- a/DragonShield/DatabaseManager+PortfolioThemeUpdates.swift
+++ b/DragonShield/DatabaseManager+PortfolioThemeUpdates.swift
@@ -1,7 +1,7 @@
 // DragonShield/DatabaseManager+PortfolioThemeUpdates.swift
-// MARK: - Version 1.0
+// MARK: - Version 1.1
 // MARK: - History
-// - Initial creation: CRUD helpers for PortfolioThemeUpdate with optimistic concurrency.
+// - 1.0 -> 1.1: Support Markdown bodies and pinning with ordering options.
 
 import SQLite3
 import Foundation
@@ -14,23 +14,27 @@ extension DatabaseManager {
             theme_id INTEGER NOT NULL REFERENCES PortfolioTheme(id) ON DELETE CASCADE,
             title TEXT NOT NULL CHECK (LENGTH(title) BETWEEN 1 AND 120),
             body_text TEXT NOT NULL CHECK (LENGTH(body_text) BETWEEN 1 AND 5000),
+            body_markdown TEXT NOT NULL CHECK (LENGTH(body_markdown) BETWEEN 1 AND 5000),
             type TEXT NOT NULL CHECK (type IN ('General','Research','Rebalance','Risk')),
             author TEXT NOT NULL,
+            pinned INTEGER NOT NULL DEFAULT 0 CHECK (pinned IN (0,1)),
             positions_asof TEXT NULL,
             total_value_chf REAL NULL,
             created_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
             updated_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now'))
         );
         CREATE INDEX IF NOT EXISTS idx_ptu_theme_order ON PortfolioThemeUpdate(theme_id, created_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_ptu_theme_pinned_order ON PortfolioThemeUpdate(theme_id, pinned DESC, created_at DESC);
         """
         if sqlite3_exec(db, sql, nil, nil, nil) != SQLITE_OK {
             LoggingService.shared.log("ensurePortfolioThemeUpdateTable failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
         }
     }
 
-    func listThemeUpdates(themeId: Int) -> [PortfolioThemeUpdate] {
+    func listThemeUpdates(themeId: Int, pinnedFirst: Bool = true) -> [PortfolioThemeUpdate] {
         var items: [PortfolioThemeUpdate] = []
-        let sql = "SELECT id, theme_id, title, body_text, type, author, positions_asof, total_value_chf, created_at, updated_at FROM PortfolioThemeUpdate WHERE theme_id = ? ORDER BY created_at DESC"
+        let order = pinnedFirst ? "pinned DESC, created_at DESC" : "created_at DESC"
+        let sql = "SELECT id, theme_id, title, body_markdown, type, author, pinned, positions_asof, total_value_chf, created_at, updated_at FROM PortfolioThemeUpdate WHERE theme_id = ? ORDER BY \(order)"
         var stmt: OpaquePointer?
         if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
             sqlite3_bind_int(stmt, 1, Int32(themeId))
@@ -41,12 +45,13 @@ extension DatabaseManager {
                 let body = String(cString: sqlite3_column_text(stmt, 3))
                 let typeStr = String(cString: sqlite3_column_text(stmt, 4))
                 let author = String(cString: sqlite3_column_text(stmt, 5))
-                let posAsOf = sqlite3_column_text(stmt, 6).map { String(cString: $0) }
-                let value = sqlite3_column_type(stmt, 7) == SQLITE_NULL ? nil : sqlite3_column_double(stmt, 7)
-                let created = String(cString: sqlite3_column_text(stmt, 8))
-                let updated = String(cString: sqlite3_column_text(stmt, 9))
+                let pinned = sqlite3_column_int(stmt, 6) == 1
+                let posAsOf = sqlite3_column_text(stmt, 7).map { String(cString: $0) }
+                let value = sqlite3_column_type(stmt, 8) == SQLITE_NULL ? nil : sqlite3_column_double(stmt, 8)
+                let created = String(cString: sqlite3_column_text(stmt, 9))
+                let updated = String(cString: sqlite3_column_text(stmt, 10))
                 if let type = PortfolioThemeUpdate.UpdateType(rawValue: typeStr) {
-                    let item = PortfolioThemeUpdate(id: id, themeId: themeId, title: title, bodyText: body, type: type, author: author, positionsAsOf: posAsOf, totalValueChf: value, createdAt: created, updatedAt: updated)
+                    let item = PortfolioThemeUpdate(id: id, themeId: themeId, title: title, bodyMarkdown: body, type: type, author: author, pinned: pinned, positionsAsOf: posAsOf, totalValueChf: value, createdAt: created, updatedAt: updated)
                     items.append(item)
                 } else {
                     LoggingService.shared.log("Invalid update type '\(typeStr)' for theme update id \(id). Skipping row.", type: .warning, logger: .database)
@@ -59,12 +64,12 @@ extension DatabaseManager {
         return items
     }
 
-    func createThemeUpdate(themeId: Int, title: String, bodyText: String, type: PortfolioThemeUpdate.UpdateType, author: String, positionsAsOf: String?, totalValueChf: Double?) -> PortfolioThemeUpdate? {
-        guard PortfolioThemeUpdate.isValidTitle(title), PortfolioThemeUpdate.isValidBody(bodyText) else {
+    func createThemeUpdate(themeId: Int, title: String, bodyMarkdown: String, type: PortfolioThemeUpdate.UpdateType, pinned: Bool, author: String, positionsAsOf: String?, totalValueChf: Double?) -> PortfolioThemeUpdate? {
+        guard PortfolioThemeUpdate.isValidTitle(title), PortfolioThemeUpdate.isValidBody(bodyMarkdown) else {
             LoggingService.shared.log("Invalid title/body for theme update", type: .info, logger: .database)
             return nil
         }
-        let sql = "INSERT INTO PortfolioThemeUpdate (theme_id, title, body_text, type, author, positions_asof, total_value_chf) VALUES (?,?,?,?,?,?,?)"
+        let sql = "INSERT INTO PortfolioThemeUpdate (theme_id, title, body_text, body_markdown, type, author, pinned, positions_asof, total_value_chf) VALUES (?,?,?,?,?,?,?,?,?)"
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
             LoggingService.shared.log("prepare createThemeUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
@@ -74,30 +79,33 @@ extension DatabaseManager {
         let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
         sqlite3_bind_int(stmt, 1, Int32(themeId))
         sqlite3_bind_text(stmt, 2, title, -1, SQLITE_TRANSIENT)
-        sqlite3_bind_text(stmt, 3, bodyText, -1, SQLITE_TRANSIENT)
-        sqlite3_bind_text(stmt, 4, type.rawValue, -1, SQLITE_TRANSIENT)
-        sqlite3_bind_text(stmt, 5, author, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 3, bodyMarkdown, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 4, bodyMarkdown, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 5, type.rawValue, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 6, author, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_int(stmt, 7, pinned ? 1 : 0)
         if let pos = positionsAsOf {
-            sqlite3_bind_text(stmt, 6, pos, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_text(stmt, 8, pos, -1, SQLITE_TRANSIENT)
         } else {
-            sqlite3_bind_null(stmt, 6)
+            sqlite3_bind_null(stmt, 8)
         }
         if let val = totalValueChf {
-            sqlite3_bind_double(stmt, 7, val)
+            sqlite3_bind_double(stmt, 9, val)
         } else {
-            sqlite3_bind_null(stmt, 7)
+            sqlite3_bind_null(stmt, 9)
         }
         guard sqlite3_step(stmt) == SQLITE_DONE else {
             LoggingService.shared.log("createThemeUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
             return nil
         }
         let id = Int(sqlite3_last_insert_rowid(db))
-        LoggingService.shared.log("createThemeUpdate themeId=\(themeId) id=\(id)", logger: .database)
-        return getThemeUpdate(id: id)
+        guard let item = getThemeUpdate(id: id) else { return nil }
+        LoggingService.shared.log("{\"themeId\":\(themeId),\"updateId\":\(id),\"actor\":\"\(author)\",\"op\":\"create\",\"pinned\":\(pinned ? 1 : 0),\"created_at\":\"\(item.createdAt)\"}", logger: .database)
+        return item
     }
 
     func getThemeUpdate(id: Int) -> PortfolioThemeUpdate? {
-        let sql = "SELECT id, theme_id, title, body_text, type, author, positions_asof, total_value_chf, created_at, updated_at FROM PortfolioThemeUpdate WHERE id = ?"
+        let sql = "SELECT id, theme_id, title, body_markdown, type, author, pinned, positions_asof, total_value_chf, created_at, updated_at FROM PortfolioThemeUpdate WHERE id = ?"
         var stmt: OpaquePointer?
         var item: PortfolioThemeUpdate?
         if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
@@ -109,12 +117,13 @@ extension DatabaseManager {
                 let body = String(cString: sqlite3_column_text(stmt, 3))
                 let typeStr = String(cString: sqlite3_column_text(stmt, 4))
                 let author = String(cString: sqlite3_column_text(stmt, 5))
-                let posAsOf = sqlite3_column_text(stmt, 6).map { String(cString: $0) }
-                let value = sqlite3_column_type(stmt, 7) == SQLITE_NULL ? nil : sqlite3_column_double(stmt, 7)
-                let created = String(cString: sqlite3_column_text(stmt, 8))
-                let updated = String(cString: sqlite3_column_text(stmt, 9))
+                let pinned = sqlite3_column_int(stmt, 6) == 1
+                let posAsOf = sqlite3_column_text(stmt, 7).map { String(cString: $0) }
+                let value = sqlite3_column_type(stmt, 8) == SQLITE_NULL ? nil : sqlite3_column_double(stmt, 8)
+                let created = String(cString: sqlite3_column_text(stmt, 9))
+                let updated = String(cString: sqlite3_column_text(stmt, 10))
                 if let type = PortfolioThemeUpdate.UpdateType(rawValue: typeStr) {
-                    item = PortfolioThemeUpdate(id: id, themeId: themeId, title: title, bodyText: body, type: type, author: author, positionsAsOf: posAsOf, totalValueChf: value, createdAt: created, updatedAt: updated)
+                    item = PortfolioThemeUpdate(id: id, themeId: themeId, title: title, bodyMarkdown: body, type: type, author: author, pinned: pinned, positionsAsOf: posAsOf, totalValueChf: value, createdAt: created, updatedAt: updated)
                 } else {
                     LoggingService.shared.log("Invalid update type '\(typeStr)' for theme update id \(id).", type: .warning, logger: .database)
                 }
@@ -126,12 +135,29 @@ extension DatabaseManager {
         return item
     }
 
-    func updateThemeUpdate(id: Int, title: String, bodyText: String, type: PortfolioThemeUpdate.UpdateType, expectedUpdatedAt: String) -> PortfolioThemeUpdate? {
-        guard PortfolioThemeUpdate.isValidTitle(title), PortfolioThemeUpdate.isValidBody(bodyText) else {
-            LoggingService.shared.log("Invalid title/body for updateThemeUpdate", type: .info, logger: .database)
-            return nil
+    func updateThemeUpdate(id: Int, title: String?, bodyMarkdown: String?, type: PortfolioThemeUpdate.UpdateType?, pinned: Bool?, actor: String, expectedUpdatedAt: String, source: String? = nil) -> PortfolioThemeUpdate? {
+        var sets: [String] = []
+        var bind: [Any] = []
+        if let title = title {
+            sets.append("title = ?")
+            bind.append(title)
         }
-        let sql = "UPDATE PortfolioThemeUpdate SET title = ?, body_text = ?, type = ?, updated_at = STRFTIME('%Y-%m-%dT%H:%M:%fZ','now') WHERE id = ? AND updated_at = ?"
+        if let body = bodyMarkdown {
+            sets.append("body_text = ?")
+            bind.append(body)
+            sets.append("body_markdown = ?")
+            bind.append(body)
+        }
+        if let type = type {
+            sets.append("type = ?")
+            bind.append(type.rawValue)
+        }
+        if let p = pinned {
+            sets.append("pinned = ?")
+            bind.append(p ? 1 : 0)
+        }
+        sets.append("updated_at = STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')")
+        let sql = "UPDATE PortfolioThemeUpdate SET \(sets.joined(separator: ", ")) WHERE id = ? AND updated_at = ?"
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
             LoggingService.shared.log("prepare updateThemeUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
@@ -139,11 +165,17 @@ extension DatabaseManager {
         }
         defer { sqlite3_finalize(stmt) }
         let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
-        sqlite3_bind_text(stmt, 1, title, -1, SQLITE_TRANSIENT)
-        sqlite3_bind_text(stmt, 2, bodyText, -1, SQLITE_TRANSIENT)
-        sqlite3_bind_text(stmt, 3, type.rawValue, -1, SQLITE_TRANSIENT)
-        sqlite3_bind_int(stmt, 4, Int32(id))
-        sqlite3_bind_text(stmt, 5, expectedUpdatedAt, -1, SQLITE_TRANSIENT)
+        var index: Int32 = 1
+        for value in bind {
+            if let s = value as? String {
+                sqlite3_bind_text(stmt, index, s, -1, SQLITE_TRANSIENT)
+            } else if let i = value as? Int {
+                sqlite3_bind_int(stmt, index, Int32(i))
+            }
+            index += 1
+        }
+        sqlite3_bind_int(stmt, index, Int32(id)); index += 1
+        sqlite3_bind_text(stmt, index, expectedUpdatedAt, -1, SQLITE_TRANSIENT)
         guard sqlite3_step(stmt) == SQLITE_DONE else {
             LoggingService.shared.log("updateThemeUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
             return nil
@@ -152,11 +184,23 @@ extension DatabaseManager {
             LoggingService.shared.log("updateThemeUpdate concurrency conflict id=\(id)", type: .info, logger: .database)
             return nil
         }
-        LoggingService.shared.log("updateThemeUpdate id=\(id)", logger: .database)
-        return getThemeUpdate(id: id)
+        guard let item = getThemeUpdate(id: id) else { return nil }
+        let op: String
+        if let p = pinned, title == nil && bodyMarkdown == nil && type == nil {
+            op = p ? "pin" : "unpin"
+        } else {
+            op = "edit"
+        }
+        var log = "{\\\"themeId\\\":\(item.themeId),\\\"updateId\\\":\(id),\\\"actor\\\":\\\"\(actor)\\\",\\\"op\\\":\\\"\(op)\\\",\\\"pinned\\\":\(item.pinned ? 1 : 0),\\\"updated_at\\\":\\\"\(item.updatedAt)\\\""
+        if let source = source {
+            log += ",\\\"source\\\":\\\"\(source)\\\""
+        }
+        log += "}"
+        LoggingService.shared.log(log, logger: .database)
+        return item
     }
 
-    func deleteThemeUpdate(id: Int) -> Bool {
+    func deleteThemeUpdate(id: Int, themeId: Int, actor: String, source: String? = nil) -> Bool {
         let sql = "DELETE FROM PortfolioThemeUpdate WHERE id = ?"
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
@@ -169,7 +213,12 @@ extension DatabaseManager {
             LoggingService.shared.log("deleteThemeUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
             return false
         }
-        LoggingService.shared.log("deleteThemeUpdate id=\(id)", logger: .database)
+        var log = "{\\\"themeId\\\":\(themeId),\\\"updateId\\\":\(id),\\\"actor\\\":\\\"\(actor)\\\",\\\"op\\\":\\\"delete\\\",\\\"pinned\\\":0,\\\"updated_at\\\":\\\"\(ISO8601DateFormatter().string(from: Date()))\\\""
+        if let source = source {
+            log += ",\\\"source\\\":\\\"\(source)\\\""
+        }
+        log += "}"
+        LoggingService.shared.log(log, logger: .database)
         return true
     }
 }

--- a/DragonShield/Models/PortfolioThemeUpdate.swift
+++ b/DragonShield/Models/PortfolioThemeUpdate.swift
@@ -1,11 +1,11 @@
 // DragonShield/Models/PortfolioThemeUpdate.swift
-// MARK: - Version 1.0
+// MARK: - Version 1.1
 // MARK: - History
-// - Initial creation: Represents plain text update entries for a portfolio theme with breadcrumb support.
+// - 1.0 -> 1.1: Add Markdown body and pin flag for Phase 6B updates.
 
 import Foundation
 
-struct PortfolioThemeUpdate: Identifiable, Codable {
+struct PortfolioThemeUpdate: Identifiable, Codable, Hashable {
     enum UpdateType: String, CaseIterable, Codable {
         case General
         case Research
@@ -16,9 +16,10 @@ struct PortfolioThemeUpdate: Identifiable, Codable {
     let id: Int
     let themeId: Int
     var title: String
-    var bodyText: String
+    var bodyMarkdown: String
     var type: UpdateType
     let author: String
+    var pinned: Bool
     var positionsAsOf: String?
     var totalValueChf: Double?
     let createdAt: String

--- a/DragonShield/Views/PortfolioThemeUpdatesView.swift
+++ b/DragonShield/Views/PortfolioThemeUpdatesView.swift
@@ -1,7 +1,8 @@
 // DragonShield/Views/PortfolioThemeUpdatesView.swift
-// MARK: - Version 1.0
+// MARK: - Version 1.2
 // MARK: - History
-// - Initial creation: Lists and manages theme updates with fast-path creation.
+// - 1.1 -> 1.2: Friendly timestamps, selection with footer action bar, and keyboard shortcuts.
+// - 1.0 -> 1.1: Support Markdown rendering, pinning, and ordering toggle.
 
 import SwiftUI
 
@@ -14,6 +15,9 @@ struct PortfolioThemeUpdatesView: View {
     @State private var editingUpdate: PortfolioThemeUpdate?
     @State private var themeName: String = ""
     @State private var isArchived: Bool = false
+    @State private var pinnedFirst: Bool = true
+    @State private var selectedId: Int?
+    @State private var showDeleteConfirm = false
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -26,27 +30,70 @@ struct PortfolioThemeUpdatesView: View {
             HStack {
                 Button("+ New Update") { showEditor = true }
                 Spacer()
+                Toggle("Pinned first", isOn: $pinnedFirst)
+                    .toggleStyle(.checkbox)
+                    .onChange(of: pinnedFirst) { _ in load() }
             }
-            List {
+            List(selection: $selectedId) {
                 ForEach(updates) { update in
                     VStack(alignment: .leading, spacing: 4) {
-                        Text("\(update.createdAt) • \(update.author) • \(update.type.rawValue)")
+                        Text("\(DateFormatting.friendly(update.createdAt)) • \(update.author) • \(update.type.rawValue)\(update.updatedAt > update.createdAt ? \" • edited\" : \"\")")
                             .font(.subheadline)
-                        Text("Title: \(update.title)").fontWeight(.semibold)
-                        Text(update.bodyText)
-                        Text("Breadcrumb: Positions \(update.positionsAsOf ?? "—") • Total CHF \(formatted(update.totalValueChf))")
+                        HStack {
+                            Text("Title: \(update.title)").fontWeight(.semibold)
+                            if update.pinned { Image(systemName: "star.fill") }
+                        }
+                        Text(MarkdownRenderer.attributedString(from: update.bodyMarkdown))
+                            .lineLimit(3)
+                        Text("Breadcrumb: Positions \(DateFormatting.friendly(update.positionsAsOf)) • Total CHF \(formatted(update.totalValueChf))")
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }
+                    .tag(update.id)
+                    .contentShape(Rectangle())
+                    .onTapGesture { selectedId = update.id }
+                    .onTapGesture(count: 2) { editingUpdate = update }
                     .contextMenu {
                         Button("Edit") { editingUpdate = update }
+                        if update.pinned {
+                            Button("Unpin") {
+                                _ = dbManager.updateThemeUpdate(id: update.id, title: nil, bodyMarkdown: nil, type: nil, pinned: false, actor: NSFullUserName(), expectedUpdatedAt: update.updatedAt)
+                                load()
+                            }
+                        } else {
+                            Button("Pin") {
+                                _ = dbManager.updateThemeUpdate(id: update.id, title: nil, bodyMarkdown: nil, type: nil, pinned: true, actor: NSFullUserName(), expectedUpdatedAt: update.updatedAt)
+                                load()
+                            }
+                        }
                         Button("Delete", role: .destructive) {
-                            _ = dbManager.deleteThemeUpdate(id: update.id)
+                            _ = dbManager.deleteThemeUpdate(id: update.id, themeId: themeId, actor: NSFullUserName())
                             load()
                         }
                     }
                 }
             }
+            .onDeleteCommand { deleteSelected() }
+            .onKeyPress(.return) { _ in
+                if let sel = selectedUpdate() { editingUpdate = sel }
+                return .ignored
+            }
+            Divider()
+            HStack {
+                Button("Edit") { if let sel = selectedUpdate() { editingUpdate = sel } }
+                    .disabled(selectedId == nil)
+                Button("Delete") { showDeleteConfirm = true }
+                    .disabled(selectedId == nil)
+                Button(selectedUpdate()?.pinned == true ? "Unpin" : "Pin") {
+                    if let sel = selectedUpdate() {
+                        _ = dbManager.updateThemeUpdate(id: sel.id, title: nil, bodyMarkdown: nil, type: nil, pinned: !sel.pinned, actor: NSFullUserName(), expectedUpdatedAt: sel.updatedAt, source: "footer")
+                        load()
+                    }
+                }
+                .disabled(selectedId == nil)
+                Spacer()
+            }
+            .padding(.top, 4)
         }
         .onAppear { load() }
         .sheet(isPresented: $showEditor) {
@@ -64,17 +111,34 @@ struct PortfolioThemeUpdatesView: View {
                 load()
             }, onCancel: {
                 editingUpdate = nil
-            })
+            }, source: selectedId != nil ? "footer" : nil)
             .environmentObject(dbManager)
+        }
+        .alert("Delete this update? This action can't be undone.", isPresented: $showDeleteConfirm) {
+            Button("Cancel", role: .cancel) {}
+            Button("Delete", role: .destructive) { deleteSelected() }
         }
     }
 
     private func load() {
-        updates = dbManager.listThemeUpdates(themeId: themeId)
+        updates = dbManager.listThemeUpdates(themeId: themeId, pinnedFirst: pinnedFirst)
         if let theme = dbManager.getPortfolioTheme(id: themeId) {
             themeName = theme.name
             isArchived = theme.archivedAt != nil
         }
+        if !updates.contains(where: { $0.id == selectedId }) {
+            selectedId = nil
+        }
+    }
+
+    private func selectedUpdate() -> PortfolioThemeUpdate? {
+        updates.first(where: { $0.id == selectedId })
+    }
+
+    private func deleteSelected() {
+        guard let sel = selectedUpdate() else { return }
+        _ = dbManager.deleteThemeUpdate(id: sel.id, themeId: themeId, actor: NSFullUserName(), source: "footer")
+        load()
     }
 
     private func formatted(_ value: Double?) -> String {

--- a/DragonShield/Views/ThemeUpdateEditorView.swift
+++ b/DragonShield/Views/ThemeUpdateEditorView.swift
@@ -1,7 +1,8 @@
 // DragonShield/Views/ThemeUpdateEditorView.swift
-// MARK: - Version 1.0
+// MARK: - Version 1.2
 // MARK: - History
-// - Initial creation: Plain text editor for portfolio theme updates with breadcrumb capture.
+// - 1.1 -> 1.2: Friendly timestamps, Markdown help popover, and optional logging source.
+// - 1.0 -> 1.1: Add Markdown editing with preview and pin toggle.
 
 import SwiftUI
 
@@ -12,22 +13,30 @@ struct ThemeUpdateEditorView: View {
     var existing: PortfolioThemeUpdate?
     var onSave: (PortfolioThemeUpdate) -> Void
     var onCancel: () -> Void
+    var source: String? = nil
+
+    enum Mode { case write, preview }
 
     @State private var title: String
-    @State private var bodyText: String
+    @State private var bodyMarkdown: String
     @State private var type: PortfolioThemeUpdate.UpdateType
+    @State private var pinned: Bool
+    @State private var mode: Mode = .write
     @State private var positionsAsOf: String?
     @State private var totalValueChf: Double?
+    @State private var showHelp = false
 
-    init(themeId: Int, themeName: String, existing: PortfolioThemeUpdate? = nil, onSave: @escaping (PortfolioThemeUpdate) -> Void, onCancel: @escaping () -> Void) {
+    init(themeId: Int, themeName: String, existing: PortfolioThemeUpdate? = nil, onSave: @escaping (PortfolioThemeUpdate) -> Void, onCancel: @escaping () -> Void, source: String? = nil) {
         self.themeId = themeId
         self.themeName = themeName
         self.existing = existing
         self.onSave = onSave
         self.onCancel = onCancel
+        self.source = source
         _title = State(initialValue: existing?.title ?? "")
-        _bodyText = State(initialValue: existing?.bodyText ?? "")
+        _bodyMarkdown = State(initialValue: existing?.bodyMarkdown ?? "")
         _type = State(initialValue: existing?.type ?? .General)
+        _pinned = State(initialValue: existing?.pinned ?? false)
     }
 
     var body: some View {
@@ -40,14 +49,39 @@ struct ThemeUpdateEditorView: View {
                     Text(t.rawValue).tag(t)
                 }
             }
-            TextEditor(text: $bodyText)
+            Toggle("Pin this update", isOn: $pinned)
+            HStack {
+                Picker("Mode", selection: $mode) {
+                    Text("Write").tag(Mode.write)
+                    Text("Preview").tag(Mode.preview)
+                }
+                .pickerStyle(.segmented)
+                Button("Help") { showHelp = true }
+                    .buttonStyle(.borderless)
+                    .popover(isPresented: $showHelp) { MarkdownHelpView() }
+            }
+            if mode == .write {
+                TextEditor(text: $bodyMarkdown)
+                    .frame(minHeight: 120)
+            } else {
+                ScrollView {
+                    Text(MarkdownRenderer.attributedString(from: bodyMarkdown))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
                 .frame(minHeight: 120)
-            Text("\(bodyText.count) / 5000")
+            }
+            Text("\(bodyMarkdown.count) / 5000")
                 .font(.caption)
-                .foregroundColor(bodyText.count > 5000 ? .red : .secondary)
-            Text("On save we will capture: Positions \(positionsAsOf ?? "—") • Total CHF \(formatted(totalValueChf))")
-                .font(.footnote)
-                .foregroundColor(.secondary)
+                .foregroundColor(bodyMarkdown.count > 5000 ? .red : .secondary)
+            if let existing = existing {
+                Text("Created: \(DateFormatting.friendly(existing.createdAt))   Edited: \(DateFormatting.friendly(existing.updatedAt))")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            } else {
+                Text("On save we will capture: Positions \(DateFormatting.friendly(positionsAsOf)) • Total CHF \(formatted(totalValueChf))")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
             HStack {
                 Spacer()
                 Button("Cancel") { onCancel() }
@@ -58,12 +92,12 @@ struct ThemeUpdateEditorView: View {
             }
         }
         .padding(24)
-        .frame(minWidth: 520, minHeight: 340)
+        .frame(minWidth: 520, minHeight: 360)
         .onAppear { loadSnapshot() }
     }
 
     private var valid: Bool {
-        PortfolioThemeUpdate.isValidTitle(title) && PortfolioThemeUpdate.isValidBody(bodyText)
+        PortfolioThemeUpdate.isValidTitle(title) && PortfolioThemeUpdate.isValidBody(bodyMarkdown)
     }
 
     private func formatted(_ value: Double?) -> String {
@@ -85,13 +119,44 @@ struct ThemeUpdateEditorView: View {
 
     private func save() {
         if let existing = existing {
-            if let updated = dbManager.updateThemeUpdate(id: existing.id, title: title, bodyText: bodyText, type: type, expectedUpdatedAt: existing.updatedAt) {
+            if let updated = dbManager.updateThemeUpdate(id: existing.id, title: title, bodyMarkdown: bodyMarkdown, type: type, pinned: pinned, actor: NSFullUserName(), expectedUpdatedAt: existing.updatedAt, source: source) {
                 onSave(updated)
             }
         } else {
-            if let created = dbManager.createThemeUpdate(themeId: themeId, title: title, bodyText: bodyText, type: type, author: NSFullUserName(), positionsAsOf: positionsAsOf, totalValueChf: totalValueChf) {
+            if let created = dbManager.createThemeUpdate(themeId: themeId, title: title, bodyMarkdown: bodyMarkdown, type: type, pinned: pinned, author: NSFullUserName(), positionsAsOf: positionsAsOf, totalValueChf: totalValueChf) {
                 onSave(created)
             }
         }
+    }
+}
+
+struct MarkdownHelpView: View {
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .top) {
+                    Text("# Heading\n## Subheading").font(.system(.body, design: .monospaced))
+                    Text(MarkdownRenderer.attributedString(from: "# Heading\n## Subheading"))
+                }
+                HStack(alignment: .top) {
+                    Text("This is **bold**, *italic*, `code`").font(.system(.body, design: .monospaced))
+                    Text(MarkdownRenderer.attributedString(from: "This is **bold**, *italic*, `code`"))
+                }
+                HStack(alignment: .top) {
+                    Text("- Bullet item\n1. Numbered").font(.system(.body, design: .monospaced))
+                    Text(MarkdownRenderer.attributedString(from: "- Bullet item\n1. Numbered"))
+                }
+                HStack(alignment: .top) {
+                    Text("Link: [text](https://example.com)").font(.system(.body, design: .monospaced))
+                    Text(MarkdownRenderer.attributedString(from: "[text](https://example.com)"))
+                }
+                Text("Images and raw HTML are not rendered.")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(width: 300)
     }
 }

--- a/DragonShield/db/migrations/014_portfolio_theme_update_enrich.sql
+++ b/DragonShield/db/migrations/014_portfolio_theme_update_enrich.sql
@@ -1,0 +1,12 @@
+-- migrate:up
+-- Purpose: Add Markdown body and pin flag to PortfolioThemeUpdate, backfilling existing text.
+-- Assumptions: PortfolioThemeUpdate from 6A with body_text column.
+-- Idempotency: use IF NOT EXISTS and content checks where possible
+ALTER TABLE PortfolioThemeUpdate ADD COLUMN body_markdown TEXT NULL;
+ALTER TABLE PortfolioThemeUpdate ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0 CHECK (pinned IN (0,1));
+UPDATE PortfolioThemeUpdate SET body_markdown = COALESCE(body_text, '');
+CREATE INDEX IF NOT EXISTS idx_ptu_theme_pinned_order ON PortfolioThemeUpdate(theme_id, pinned DESC, created_at DESC);
+
+-- migrate:down
+DROP INDEX IF EXISTS idx_ptu_theme_pinned_order;
+-- Columns remain for rollback; recreate table from backup if needed.

--- a/DragonShieldTests/DateFormattingTests.swift
+++ b/DragonShieldTests/DateFormattingTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import DragonShield
+
+final class DateFormattingTests: XCTestCase {
+    func testFriendlyFormat() {
+        let iso = "2025-08-22T15:39:00Z"
+        let friendly = DateFormatting.friendly(iso)
+        XCTAssertTrue(friendly.hasPrefix("2025-08-22 15:39"))
+    }
+}

--- a/DragonShieldTests/PortfolioThemeUpdateTests.swift
+++ b/DragonShieldTests/PortfolioThemeUpdateTests.swift
@@ -24,22 +24,31 @@ final class PortfolioThemeUpdateTests: XCTestCase {
         super.tearDown()
     }
 
-    func testCreateUpdateDeleteFlow() {
-        let created = manager.createThemeUpdate(themeId: 1, title: "Raised cash", bodyText: "Trimmed VOO", type: .Rebalance, author: "Alice", positionsAsOf: "2025-09-02T09:30:00Z", totalValueChf: 2104500)
+    func testCreateUpdateDeleteFlowAndPinning() {
+        let created = manager.createThemeUpdate(themeId: 1, title: "Raised cash", bodyMarkdown: "Trimmed VOO", type: .Rebalance, pinned: true, author: "Alice", positionsAsOf: "2025-09-02T09:30:00Z", totalValueChf: 2104500)
         XCTAssertNotNil(created)
         var list = manager.listThemeUpdates(themeId: 1)
         XCTAssertEqual(list.count, 1)
         let first = list[0]
-        XCTAssertEqual(first.author, "Alice")
+        XCTAssertTrue(first.pinned)
 
-        let updated = manager.updateThemeUpdate(id: first.id, title: "Raise cash to 15%", bodyText: "Adjust further", type: .Rebalance, expectedUpdatedAt: first.updatedAt)
+        let second = manager.createThemeUpdate(themeId: 1, title: "Unpinned", bodyMarkdown: "body", type: .General, pinned: false, author: "Bob", positionsAsOf: nil, totalValueChf: nil)
+        XCTAssertNotNil(second)
+
+        list = manager.listThemeUpdates(themeId: 1)
+        XCTAssertEqual(list.first?.title, "Raised cash")
+
+        list = manager.listThemeUpdates(themeId: 1, pinnedFirst: false)
+        XCTAssertEqual(list.first?.title, "Unpinned")
+
+        let updated = manager.updateThemeUpdate(id: first.id, title: "Raise cash to 15%", bodyMarkdown: "Adjust further", type: .Rebalance, pinned: false, actor: "Alice", expectedUpdatedAt: first.updatedAt)
         XCTAssertNotNil(updated)
-        let stale = manager.updateThemeUpdate(id: first.id, title: "Stale", bodyText: "Stale", type: .General, expectedUpdatedAt: first.updatedAt)
+        let stale = manager.updateThemeUpdate(id: first.id, title: "Stale", bodyMarkdown: nil, type: nil, pinned: nil, actor: "Alice", expectedUpdatedAt: first.updatedAt)
         XCTAssertNil(stale)
 
-        let deleteOk = manager.deleteThemeUpdate(id: first.id)
+        let deleteOk = manager.deleteThemeUpdate(id: first.id, themeId: 1, actor: "Alice")
         XCTAssertTrue(deleteOk)
         list = manager.listThemeUpdates(themeId: 1)
-        XCTAssertTrue(list.isEmpty)
+        XCTAssertEqual(list.count, 1)
     }
 }


### PR DESCRIPTION
## Summary
- render theme update timestamps in local yyyy-MM-dd HH:mm
- add list selection footer with edit, delete, and pin actions
- expose markdown cheat sheet in update editor

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68a89ab430148323ac26ec053d567179