### PR TITLE
feat: support markdown and pinning for theme updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Support Markdown bodies and pinning for Portfolio Theme updates with migration 014
+- Render theme update timestamps in local time and expose footer action bar with Markdown help
+- Harden update logging and enforce non-null Markdown schema
+- Validate update edits and surface failures during pin or delete
 - Introduce PortfolioThemeUpdate table and CRUD helpers for theme update timelines
 - Log invalid theme update types, fetch themes directly for Updates view, and record author from macOS user
 - Enable Updates tab and quick New Update entry points for Portfolio Themes by default

--- a/DragonShield/Core/DateFormatting.swift
+++ b/DragonShield/Core/DateFormatting.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+enum DateFormatting {
+    private static let isoFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    private static let displayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd HH:mm"
+        f.timeZone = .current
+        return f
+    }()
+
+    static func userFriendly(_ isoString: String?) -> String {
+        guard let isoString = isoString, let date = isoFormatter.date(from: isoString) else { return "—" }
+        return displayFormatter.string(from: date)
+    }
+}

--- a/DragonShield/Core/MarkdownRenderer.swift
+++ b/DragonShield/Core/MarkdownRenderer.swift
@@ -1,0 +1,15 @@
+import Foundation
+import SwiftUI
+
+enum MarkdownRenderer {
+    static func attributedString(from markdown: String) -> AttributedString {
+        let sanitized = markdown.replacingOccurrences(of: "<", with: "&lt;")
+        var attr = (try? AttributedString(markdown: sanitized, options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace))) ?? AttributedString(sanitized)
+        for run in attr.runs {
+            if let link = run.link, let scheme = link.scheme?.lowercased(), scheme != "http" && scheme != "https" {
+                attr[run.range].link = nil
+            }
+        }
+        return attr
+    }
+}

--- a/DragonShield/DatabaseManager+PortfolioThemeUpdates.swift
+++ b/DragonShield/DatabaseManager+PortfolioThemeUpdates.swift
@@ -1,12 +1,23 @@
 // DragonShield/DatabaseManager+PortfolioThemeUpdates.swift
-// MARK: - Version 1.0
+// MARK: - Version 1.1
 // MARK: - History
-// - Initial creation: CRUD helpers for PortfolioThemeUpdate with optimistic concurrency.
+// - 1.0 -> 1.1: Support Markdown bodies and pinning with ordering options.
 
 import SQLite3
 import Foundation
 
 extension DatabaseManager {
+    private static let isoDateFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        return f
+    }()
+
+    private func logDatabaseAction(_ payload: [String: Any]) {
+        if let data = try? JSONSerialization.data(withJSONObject: payload),
+           let log = String(data: data, encoding: .utf8) {
+            LoggingService.shared.log(log, logger: .database)
+        }
+    }
     func ensurePortfolioThemeUpdateTable() {
         let sql = """
         CREATE TABLE IF NOT EXISTS PortfolioThemeUpdate (
@@ -14,23 +25,27 @@ extension DatabaseManager {
             theme_id INTEGER NOT NULL REFERENCES PortfolioTheme(id) ON DELETE CASCADE,
             title TEXT NOT NULL CHECK (LENGTH(title) BETWEEN 1 AND 120),
             body_text TEXT NOT NULL CHECK (LENGTH(body_text) BETWEEN 1 AND 5000),
+            body_markdown TEXT NOT NULL CHECK (LENGTH(body_markdown) BETWEEN 1 AND 5000),
             type TEXT NOT NULL CHECK (type IN ('General','Research','Rebalance','Risk')),
             author TEXT NOT NULL,
+            pinned INTEGER NOT NULL DEFAULT 0 CHECK (pinned IN (0,1)),
             positions_asof TEXT NULL,
             total_value_chf REAL NULL,
             created_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
             updated_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now'))
         );
         CREATE INDEX IF NOT EXISTS idx_ptu_theme_order ON PortfolioThemeUpdate(theme_id, created_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_ptu_theme_pinned_order ON PortfolioThemeUpdate(theme_id, pinned DESC, created_at DESC);
         """
         if sqlite3_exec(db, sql, nil, nil, nil) != SQLITE_OK {
             LoggingService.shared.log("ensurePortfolioThemeUpdateTable failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
         }
     }
 
-    func listThemeUpdates(themeId: Int) -> [PortfolioThemeUpdate] {
+    func listThemeUpdates(themeId: Int, pinnedFirst: Bool = true) -> [PortfolioThemeUpdate] {
         var items: [PortfolioThemeUpdate] = []
-        let sql = "SELECT id, theme_id, title, body_text, type, author, positions_asof, total_value_chf, created_at, updated_at FROM PortfolioThemeUpdate WHERE theme_id = ? ORDER BY created_at DESC"
+        let order = pinnedFirst ? "pinned DESC, created_at DESC" : "created_at DESC"
+        let sql = "SELECT id, theme_id, title, body_markdown, type, author, pinned, positions_asof, total_value_chf, created_at, updated_at FROM PortfolioThemeUpdate WHERE theme_id = ? ORDER BY \(order)"
         var stmt: OpaquePointer?
         if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
             sqlite3_bind_int(stmt, 1, Int32(themeId))
@@ -41,12 +56,13 @@ extension DatabaseManager {
                 let body = String(cString: sqlite3_column_text(stmt, 3))
                 let typeStr = String(cString: sqlite3_column_text(stmt, 4))
                 let author = String(cString: sqlite3_column_text(stmt, 5))
-                let posAsOf = sqlite3_column_text(stmt, 6).map { String(cString: $0) }
-                let value = sqlite3_column_type(stmt, 7) == SQLITE_NULL ? nil : sqlite3_column_double(stmt, 7)
-                let created = String(cString: sqlite3_column_text(stmt, 8))
-                let updated = String(cString: sqlite3_column_text(stmt, 9))
+                let pinned = sqlite3_column_int(stmt, 6) == 1
+                let posAsOf = sqlite3_column_text(stmt, 7).map { String(cString: $0) }
+                let value = sqlite3_column_type(stmt, 8) == SQLITE_NULL ? nil : sqlite3_column_double(stmt, 8)
+                let created = String(cString: sqlite3_column_text(stmt, 9))
+                let updated = String(cString: sqlite3_column_text(stmt, 10))
                 if let type = PortfolioThemeUpdate.UpdateType(rawValue: typeStr) {
-                    let item = PortfolioThemeUpdate(id: id, themeId: themeId, title: title, bodyText: body, type: type, author: author, positionsAsOf: posAsOf, totalValueChf: value, createdAt: created, updatedAt: updated)
+                    let item = PortfolioThemeUpdate(id: id, themeId: themeId, title: title, bodyMarkdown: body, type: type, author: author, pinned: pinned, positionsAsOf: posAsOf, totalValueChf: value, createdAt: created, updatedAt: updated)
                     items.append(item)
                 } else {
                     LoggingService.shared.log("Invalid update type '\(typeStr)' for theme update id \(id). Skipping row.", type: .warning, logger: .database)
@@ -59,12 +75,13 @@ extension DatabaseManager {
         return items
     }
 
-    func createThemeUpdate(themeId: Int, title: String, bodyText: String, type: PortfolioThemeUpdate.UpdateType, author: String, positionsAsOf: String?, totalValueChf: Double?) -> PortfolioThemeUpdate? {
-        guard PortfolioThemeUpdate.isValidTitle(title), PortfolioThemeUpdate.isValidBody(bodyText) else {
+    func createThemeUpdate(themeId: Int, title: String, bodyMarkdown: String, type: PortfolioThemeUpdate.UpdateType, pinned: Bool, author: String, positionsAsOf: String?, totalValueChf: Double?, source: String? = nil) -> PortfolioThemeUpdate? {
+        guard PortfolioThemeUpdate.isValidTitle(title), PortfolioThemeUpdate.isValidBody(bodyMarkdown) else {
             LoggingService.shared.log("Invalid title/body for theme update", type: .info, logger: .database)
             return nil
         }
-        let sql = "INSERT INTO PortfolioThemeUpdate (theme_id, title, body_text, type, author, positions_asof, total_value_chf) VALUES (?,?,?,?,?,?,?)"
+        // body_text is kept for backward compatibility with 6A clients and mirrors body_markdown
+        let sql = "INSERT INTO PortfolioThemeUpdate (theme_id, title, body_text, body_markdown, type, author, pinned, positions_asof, total_value_chf) VALUES (?,?,?,?,?,?,?,?,?)"
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
             LoggingService.shared.log("prepare createThemeUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
@@ -74,30 +91,42 @@ extension DatabaseManager {
         let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
         sqlite3_bind_int(stmt, 1, Int32(themeId))
         sqlite3_bind_text(stmt, 2, title, -1, SQLITE_TRANSIENT)
-        sqlite3_bind_text(stmt, 3, bodyText, -1, SQLITE_TRANSIENT)
-        sqlite3_bind_text(stmt, 4, type.rawValue, -1, SQLITE_TRANSIENT)
-        sqlite3_bind_text(stmt, 5, author, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 3, bodyMarkdown, -1, SQLITE_TRANSIENT) // legacy body_text
+        sqlite3_bind_text(stmt, 4, bodyMarkdown, -1, SQLITE_TRANSIENT) // new body_markdown
+        sqlite3_bind_text(stmt, 5, type.rawValue, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 6, author, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_int(stmt, 7, pinned ? 1 : 0)
         if let pos = positionsAsOf {
-            sqlite3_bind_text(stmt, 6, pos, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_text(stmt, 8, pos, -1, SQLITE_TRANSIENT)
         } else {
-            sqlite3_bind_null(stmt, 6)
+            sqlite3_bind_null(stmt, 8)
         }
         if let val = totalValueChf {
-            sqlite3_bind_double(stmt, 7, val)
+            sqlite3_bind_double(stmt, 9, val)
         } else {
-            sqlite3_bind_null(stmt, 7)
+            sqlite3_bind_null(stmt, 9)
         }
         guard sqlite3_step(stmt) == SQLITE_DONE else {
             LoggingService.shared.log("createThemeUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
             return nil
         }
         let id = Int(sqlite3_last_insert_rowid(db))
-        LoggingService.shared.log("createThemeUpdate themeId=\(themeId) id=\(id)", logger: .database)
-        return getThemeUpdate(id: id)
+        guard let item = getThemeUpdate(id: id) else { return nil }
+        var payload: [String: Any] = [
+            "themeId": themeId,
+            "updateId": id,
+            "actor": author,
+            "op": "create",
+            "pinned": pinned ? 1 : 0,
+            "created_at": item.createdAt
+        ]
+        if let source = source { payload["source"] = source }
+        logDatabaseAction(payload)
+        return item
     }
 
     func getThemeUpdate(id: Int) -> PortfolioThemeUpdate? {
-        let sql = "SELECT id, theme_id, title, body_text, type, author, positions_asof, total_value_chf, created_at, updated_at FROM PortfolioThemeUpdate WHERE id = ?"
+        let sql = "SELECT id, theme_id, title, body_markdown, type, author, pinned, positions_asof, total_value_chf, created_at, updated_at FROM PortfolioThemeUpdate WHERE id = ?"
         var stmt: OpaquePointer?
         var item: PortfolioThemeUpdate?
         if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
@@ -109,12 +138,13 @@ extension DatabaseManager {
                 let body = String(cString: sqlite3_column_text(stmt, 3))
                 let typeStr = String(cString: sqlite3_column_text(stmt, 4))
                 let author = String(cString: sqlite3_column_text(stmt, 5))
-                let posAsOf = sqlite3_column_text(stmt, 6).map { String(cString: $0) }
-                let value = sqlite3_column_type(stmt, 7) == SQLITE_NULL ? nil : sqlite3_column_double(stmt, 7)
-                let created = String(cString: sqlite3_column_text(stmt, 8))
-                let updated = String(cString: sqlite3_column_text(stmt, 9))
+                let pinned = sqlite3_column_int(stmt, 6) == 1
+                let posAsOf = sqlite3_column_text(stmt, 7).map { String(cString: $0) }
+                let value = sqlite3_column_type(stmt, 8) == SQLITE_NULL ? nil : sqlite3_column_double(stmt, 8)
+                let created = String(cString: sqlite3_column_text(stmt, 9))
+                let updated = String(cString: sqlite3_column_text(stmt, 10))
                 if let type = PortfolioThemeUpdate.UpdateType(rawValue: typeStr) {
-                    item = PortfolioThemeUpdate(id: id, themeId: themeId, title: title, bodyText: body, type: type, author: author, positionsAsOf: posAsOf, totalValueChf: value, createdAt: created, updatedAt: updated)
+                    item = PortfolioThemeUpdate(id: id, themeId: themeId, title: title, bodyMarkdown: body, type: type, author: author, pinned: pinned, positionsAsOf: posAsOf, totalValueChf: value, createdAt: created, updatedAt: updated)
                 } else {
                     LoggingService.shared.log("Invalid update type '\(typeStr)' for theme update id \(id).", type: .warning, logger: .database)
                 }
@@ -126,12 +156,38 @@ extension DatabaseManager {
         return item
     }
 
-    func updateThemeUpdate(id: Int, title: String, bodyText: String, type: PortfolioThemeUpdate.UpdateType, expectedUpdatedAt: String) -> PortfolioThemeUpdate? {
-        guard PortfolioThemeUpdate.isValidTitle(title), PortfolioThemeUpdate.isValidBody(bodyText) else {
-            LoggingService.shared.log("Invalid title/body for updateThemeUpdate", type: .info, logger: .database)
-            return nil
+    func updateThemeUpdate(id: Int, title: String?, bodyMarkdown: String?, type: PortfolioThemeUpdate.UpdateType?, pinned: Bool?, actor: String, expectedUpdatedAt: String, source: String? = nil) -> PortfolioThemeUpdate? {
+        var sets: [String] = []
+        var bind: [Any] = []
+        if let title = title {
+            guard PortfolioThemeUpdate.isValidTitle(title) else {
+                LoggingService.shared.log("Invalid title for updateThemeUpdate id=\(id)", type: .info, logger: .database)
+                return nil
+            }
+            sets.append("title = ?")
+            bind.append(title)
         }
-        let sql = "UPDATE PortfolioThemeUpdate SET title = ?, body_text = ?, type = ?, updated_at = STRFTIME('%Y-%m-%dT%H:%M:%fZ','now') WHERE id = ? AND updated_at = ?"
+        if let body = bodyMarkdown {
+            guard PortfolioThemeUpdate.isValidBody(body) else {
+                LoggingService.shared.log("Invalid body for updateThemeUpdate id=\(id)", type: .info, logger: .database)
+                return nil
+            }
+            // keep body_text in sync for legacy 6A clients
+            sets.append("body_text = ?")
+            bind.append(body)
+            sets.append("body_markdown = ?")
+            bind.append(body)
+        }
+        if let type = type {
+            sets.append("type = ?")
+            bind.append(type.rawValue)
+        }
+        if let p = pinned {
+            sets.append("pinned = ?")
+            bind.append(p ? 1 : 0)
+        }
+        sets.append("updated_at = STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')")
+        let sql = "UPDATE PortfolioThemeUpdate SET \(sets.joined(separator: ", ")) WHERE id = ? AND updated_at = ?"
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
             LoggingService.shared.log("prepare updateThemeUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
@@ -139,11 +195,20 @@ extension DatabaseManager {
         }
         defer { sqlite3_finalize(stmt) }
         let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
-        sqlite3_bind_text(stmt, 1, title, -1, SQLITE_TRANSIENT)
-        sqlite3_bind_text(stmt, 2, bodyText, -1, SQLITE_TRANSIENT)
-        sqlite3_bind_text(stmt, 3, type.rawValue, -1, SQLITE_TRANSIENT)
-        sqlite3_bind_int(stmt, 4, Int32(id))
-        sqlite3_bind_text(stmt, 5, expectedUpdatedAt, -1, SQLITE_TRANSIENT)
+        var index: Int32 = 1
+        for value in bind {
+            switch value {
+            case let s as String:
+                sqlite3_bind_text(stmt, index, s, -1, SQLITE_TRANSIENT)
+            case let i as Int:
+                sqlite3_bind_int(stmt, index, Int32(i))
+            default:
+                LoggingService.shared.log("Unsupported bind type in updateThemeUpdate: \(type(of: value))", type: .error, logger: .database)
+            }
+            index += 1
+        }
+        sqlite3_bind_int(stmt, index, Int32(id)); index += 1
+        sqlite3_bind_text(stmt, index, expectedUpdatedAt, -1, SQLITE_TRANSIENT)
         guard sqlite3_step(stmt) == SQLITE_DONE else {
             LoggingService.shared.log("updateThemeUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
             return nil
@@ -152,11 +217,27 @@ extension DatabaseManager {
             LoggingService.shared.log("updateThemeUpdate concurrency conflict id=\(id)", type: .info, logger: .database)
             return nil
         }
-        LoggingService.shared.log("updateThemeUpdate id=\(id)", logger: .database)
-        return getThemeUpdate(id: id)
+        guard let item = getThemeUpdate(id: id) else { return nil }
+        let op: String
+        if let p = pinned {
+            op = p ? "pin" : "unpin"
+        } else {
+            op = "update"
+        }
+        var payload: [String: Any] = [
+            "themeId": item.themeId,
+            "updateId": id,
+            "actor": actor,
+            "op": op,
+            "pinned": item.pinned ? 1 : 0,
+            "updated_at": item.updatedAt
+        ]
+        if let source = source { payload["source"] = source }
+        logDatabaseAction(payload)
+        return item
     }
 
-    func deleteThemeUpdate(id: Int) -> Bool {
+    func deleteThemeUpdate(id: Int, themeId: Int, actor: String, source: String? = nil) -> Bool {
         let sql = "DELETE FROM PortfolioThemeUpdate WHERE id = ?"
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
@@ -169,7 +250,16 @@ extension DatabaseManager {
             LoggingService.shared.log("deleteThemeUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
             return false
         }
-        LoggingService.shared.log("deleteThemeUpdate id=\(id)", logger: .database)
+        var payload: [String: Any] = [
+            "themeId": themeId,
+            "updateId": id,
+            "actor": actor,
+            "op": "delete",
+            "pinned": 0,
+            "updated_at": Self.isoDateFormatter.string(from: Date())
+        ]
+        if let source = source { payload["source"] = source }
+        logDatabaseAction(payload)
         return true
     }
 }

--- a/DragonShield/Models/PortfolioThemeUpdate.swift
+++ b/DragonShield/Models/PortfolioThemeUpdate.swift
@@ -1,7 +1,7 @@
 // DragonShield/Models/PortfolioThemeUpdate.swift
-// MARK: - Version 1.0
+// MARK: - Version 1.1
 // MARK: - History
-// - Initial creation: Represents plain text update entries for a portfolio theme with breadcrumb support.
+// - 1.0 -> 1.1: Add Markdown body and pin flag for Phase 6B updates.
 
 import Foundation
 
@@ -16,9 +16,10 @@ struct PortfolioThemeUpdate: Identifiable, Codable {
     let id: Int
     let themeId: Int
     var title: String
-    var bodyText: String
+    var bodyMarkdown: String
     var type: UpdateType
     let author: String
+    var pinned: Bool
     var positionsAsOf: String?
     var totalValueChf: Double?
     let createdAt: String

--- a/DragonShield/Views/PortfolioThemeUpdatesView.swift
+++ b/DragonShield/Views/PortfolioThemeUpdatesView.swift
@@ -1,7 +1,7 @@
 // DragonShield/Views/PortfolioThemeUpdatesView.swift
-// MARK: - Version 1.0
+// MARK: - Version 1.1
 // MARK: - History
-// - Initial creation: Lists and manages theme updates with fast-path creation.
+// - 1.0 -> 1.1: Support Markdown rendering, pinning, and ordering toggle.
 
 import SwiftUI
 
@@ -14,9 +14,14 @@ struct PortfolioThemeUpdatesView: View {
     @State private var editingUpdate: PortfolioThemeUpdate?
     @State private var themeName: String = ""
     @State private var isArchived: Bool = false
+    @State private var pinnedFirst: Bool = true
+    @State private var selectedId: Int?
+    @State private var showDeleteConfirm = false
+    @State private var editingFromFooter = false
+    @State private var errorMessage: String?
 
     var body: some View {
-        VStack(alignment: .leading) {
+        VStack(alignment: .leading, spacing: 0) {
             if isArchived {
                 Text("Theme archived — composition locked; updates permitted")
                     .frame(maxWidth: .infinity)
@@ -26,27 +31,59 @@ struct PortfolioThemeUpdatesView: View {
             HStack {
                 Button("+ New Update") { showEditor = true }
                 Spacer()
+                Toggle("Pinned first", isOn: $pinnedFirst)
+                    .toggleStyle(.checkbox)
+                    .onChange(of: pinnedFirst) { _ in load() }
             }
-            List {
+            List(selection: $selectedId) {
                 ForEach(updates) { update in
                     VStack(alignment: .leading, spacing: 4) {
-                        Text("\(update.createdAt) • \(update.author) • \(update.type.rawValue)")
+                        Text("\(DateFormatting.userFriendly(update.createdAt))  •  \(update.author)  •  \(update.type.rawValue)\(update.updatedAt > update.createdAt ? "  •  edited" : "")")
                             .font(.subheadline)
-                        Text("Title: \(update.title)").fontWeight(.semibold)
-                        Text(update.bodyText)
-                        Text("Breadcrumb: Positions \(update.positionsAsOf ?? "—") • Total CHF \(formatted(update.totalValueChf))")
+                        HStack {
+                            Text("Title: \(update.title)").fontWeight(.semibold)
+                            if update.pinned { Image(systemName: "star.fill") }
+                        }
+                        Text(MarkdownRenderer.attributedString(from: update.bodyMarkdown))
+                            .lineLimit(3)
+                        Text("Breadcrumb: Positions \(DateFormatting.userFriendly(update.positionsAsOf)) • Total CHF \(formatted(update.totalValueChf))")
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }
+                    .tag(update.id)
+                    .onTapGesture(count: 2) { editingUpdate = update; editingFromFooter = false }
                     .contextMenu {
-                        Button("Edit") { editingUpdate = update }
-                        Button("Delete", role: .destructive) {
-                            _ = dbManager.deleteThemeUpdate(id: update.id)
-                            load()
+                        Button("Edit") { editingUpdate = update; editingFromFooter = false }
+                        if update.pinned {
+                            Button("Unpin") { togglePin(for: update) }
+                        } else {
+                            Button("Pin") { togglePin(for: update) }
                         }
+                        Button("Delete", role: .destructive) { delete(update) }
                     }
                 }
             }
+            Divider()
+            HStack {
+                Button("Edit") { if let u = selectedUpdate { editingUpdate = u; editingFromFooter = true } }
+                    .disabled(selectedUpdate == nil)
+                Button("Delete") { showDeleteConfirm = true }
+                    .disabled(selectedUpdate == nil)
+                Button(selectedUpdate?.pinned == true ? "Unpin" : "Pin") {
+                    if let u = selectedUpdate { togglePin(for: u, source: "footer") }
+                }
+                    .disabled(selectedUpdate == nil)
+            }
+            .padding(8)
+            .confirmationDialog("Delete this update? This action can't be undone.", isPresented: $showDeleteConfirm) {
+                Button("Delete", role: .destructive) { deleteSelected() }
+            }
+            Button(action: { if let u = selectedUpdate { editingUpdate = u; editingFromFooter = true } }) { EmptyView() }
+                .keyboardShortcut(.return, modifiers: [])
+                .hidden()
+            Button(action: { if selectedUpdate != nil { showDeleteConfirm = true } }) { EmptyView() }
+                .keyboardShortcut(.delete, modifiers: [])
+                .hidden()
         }
         .onAppear { load() }
         .sheet(isPresented: $showEditor) {
@@ -64,21 +101,60 @@ struct PortfolioThemeUpdatesView: View {
                 load()
             }, onCancel: {
                 editingUpdate = nil
-            })
+            }, logSource: editingFromFooter ? "footer" : nil)
             .environmentObject(dbManager)
+        }
+        .alert("Error", isPresented: Binding(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(errorMessage ?? "")
         }
     }
 
     private func load() {
-        updates = dbManager.listThemeUpdates(themeId: themeId)
+        updates = dbManager.listThemeUpdates(themeId: themeId, pinnedFirst: pinnedFirst)
         if let theme = dbManager.getPortfolioTheme(id: themeId) {
             themeName = theme.name
             isArchived = theme.archivedAt != nil
         }
     }
 
+    private var selectedUpdate: PortfolioThemeUpdate? {
+        updates.first { $0.id == selectedId }
+    }
+
     private func formatted(_ value: Double?) -> String {
         guard let v = value else { return "—" }
         return v.formatted(.currency(code: dbManager.baseCurrency).precision(.fractionLength(2)))
+    }
+
+    private func deleteSelected() {
+        if let u = selectedUpdate { delete(u, source: "footer") }
+    }
+
+    private func togglePin(for update: PortfolioThemeUpdate, source: String? = nil) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            if let result = dbManager.updateThemeUpdate(id: update.id, title: nil, bodyMarkdown: nil, type: nil, pinned: !update.pinned, actor: NSFullUserName(), expectedUpdatedAt: update.updatedAt, source: source) {
+                DispatchQueue.main.async {
+                    load()
+                    if source == "footer" { selectedId = result.id }
+                }
+            } else {
+                DispatchQueue.main.async { errorMessage = "Failed to update. Please try again." }
+            }
+        }
+    }
+
+    private func delete(_ update: PortfolioThemeUpdate, source: String? = nil) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            if dbManager.deleteThemeUpdate(id: update.id, themeId: themeId, actor: NSFullUserName(), source: source) {
+                DispatchQueue.main.async {
+                    load()
+                    if selectedId == update.id { selectedId = nil }
+                }
+            } else {
+                DispatchQueue.main.async { errorMessage = "Failed to delete update." }
+            }
+        }
     }
 }

--- a/DragonShield/db/migrations/014_portfolio_theme_update_enrich.sql
+++ b/DragonShield/db/migrations/014_portfolio_theme_update_enrich.sql
@@ -1,0 +1,46 @@
+-- migrate:up
+-- Purpose: Add Markdown body and pin flag with NOT NULL constraint, backfilling existing text.
+-- Assumptions: PortfolioThemeUpdate from 6A with body_text column and idx_ptu_theme_order index.
+-- Idempotency: use IF NOT EXISTS and temp table recreation.
+CREATE TABLE IF NOT EXISTS PortfolioThemeUpdate_new (
+  id INTEGER PRIMARY KEY,
+  theme_id INTEGER NOT NULL REFERENCES PortfolioTheme(id) ON DELETE CASCADE,
+  title TEXT NOT NULL CHECK (LENGTH(title) BETWEEN 1 AND 120),
+  body_text TEXT NOT NULL CHECK (LENGTH(body_text) BETWEEN 1 AND 5000),
+  body_markdown TEXT NOT NULL CHECK (LENGTH(body_markdown) BETWEEN 1 AND 5000),
+  type TEXT NOT NULL CHECK (type IN ('General','Research','Rebalance','Risk')),
+  author TEXT NOT NULL,
+  pinned INTEGER NOT NULL DEFAULT 0 CHECK (pinned IN (0,1)),
+  positions_asof TEXT NULL,
+  total_value_chf REAL NULL,
+  created_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
+  updated_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+INSERT INTO PortfolioThemeUpdate_new (id, theme_id, title, body_text, body_markdown, type, author, pinned, positions_asof, total_value_chf, created_at, updated_at)
+  SELECT id, theme_id, title, body_text, COALESCE(body_text, ''), type, author, 0, positions_asof, total_value_chf, created_at, updated_at
+  FROM PortfolioThemeUpdate;
+DROP TABLE PortfolioThemeUpdate;
+ALTER TABLE PortfolioThemeUpdate_new RENAME TO PortfolioThemeUpdate;
+CREATE INDEX IF NOT EXISTS idx_ptu_theme_order ON PortfolioThemeUpdate(theme_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_ptu_theme_pinned_order ON PortfolioThemeUpdate(theme_id, pinned DESC, created_at DESC);
+
+-- migrate:down
+-- Revert to 6A schema without Markdown or pinned flag.
+CREATE TABLE IF NOT EXISTS PortfolioThemeUpdate_old (
+  id INTEGER PRIMARY KEY,
+  theme_id INTEGER NOT NULL REFERENCES PortfolioTheme(id) ON DELETE CASCADE,
+  title TEXT NOT NULL CHECK (LENGTH(title) BETWEEN 1 AND 120),
+  body_text TEXT NOT NULL CHECK (LENGTH(body_text) BETWEEN 1 AND 5000),
+  type TEXT NOT NULL CHECK (type IN ('General','Research','Rebalance','Risk')),
+  author TEXT NOT NULL,
+  positions_asof TEXT NULL,
+  total_value_chf REAL NULL,
+  created_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
+  updated_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+INSERT INTO PortfolioThemeUpdate_old (id, theme_id, title, body_text, type, author, positions_asof, total_value_chf, created_at, updated_at)
+  SELECT id, theme_id, title, body_markdown, type, author, positions_asof, total_value_chf, created_at, updated_at
+  FROM PortfolioThemeUpdate;
+DROP TABLE PortfolioThemeUpdate;
+ALTER TABLE PortfolioThemeUpdate_old RENAME TO PortfolioThemeUpdate;
+CREATE INDEX IF NOT EXISTS idx_ptu_theme_order ON PortfolioThemeUpdate(theme_id, created_at DESC);

--- a/DragonShieldTests/DateFormattingTests.swift
+++ b/DragonShieldTests/DateFormattingTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+@testable import DragonShield
+
+final class DateFormattingTests: XCTestCase {
+    func testUserFriendly() {
+        let prev = NSTimeZone.default
+        NSTimeZone.default = TimeZone(secondsFromGMT: 0)!
+        defer { NSTimeZone.default = prev }
+        let iso = "2025-08-22T15:39:00Z"
+        XCTAssertEqual(DateFormatting.userFriendly(iso), "2025-08-22 15:39")
+        XCTAssertEqual(DateFormatting.userFriendly(nil), "—")
+    }
+}

--- a/DragonShieldTests/PortfolioThemeUpdateTests.swift
+++ b/DragonShieldTests/PortfolioThemeUpdateTests.swift
@@ -24,22 +24,42 @@ final class PortfolioThemeUpdateTests: XCTestCase {
         super.tearDown()
     }
 
-    func testCreateUpdateDeleteFlow() {
-        let created = manager.createThemeUpdate(themeId: 1, title: "Raised cash", bodyText: "Trimmed VOO", type: .Rebalance, author: "Alice", positionsAsOf: "2025-09-02T09:30:00Z", totalValueChf: 2104500)
+    func testCreateUpdateDeleteFlowAndPinning() {
+        let created = manager.createThemeUpdate(themeId: 1, title: "Raised cash", bodyMarkdown: "Trimmed VOO", type: .Rebalance, pinned: true, author: "Alice", positionsAsOf: "2025-09-02T09:30:00Z", totalValueChf: 2104500)
         XCTAssertNotNil(created)
         var list = manager.listThemeUpdates(themeId: 1)
         XCTAssertEqual(list.count, 1)
         let first = list[0]
-        XCTAssertEqual(first.author, "Alice")
+        XCTAssertTrue(first.pinned)
 
-        let updated = manager.updateThemeUpdate(id: first.id, title: "Raise cash to 15%", bodyText: "Adjust further", type: .Rebalance, expectedUpdatedAt: first.updatedAt)
+        let second = manager.createThemeUpdate(themeId: 1, title: "Unpinned", bodyMarkdown: "body", type: .General, pinned: false, author: "Bob", positionsAsOf: nil, totalValueChf: nil)
+        XCTAssertNotNil(second)
+
+        list = manager.listThemeUpdates(themeId: 1)
+        XCTAssertEqual(list.first?.title, "Raised cash")
+
+        list = manager.listThemeUpdates(themeId: 1, pinnedFirst: false)
+        XCTAssertEqual(list.first?.title, "Unpinned")
+
+        let updated = manager.updateThemeUpdate(id: first.id, title: "Raise cash to 15%", bodyMarkdown: "Adjust further", type: .Rebalance, pinned: false, actor: "Alice", expectedUpdatedAt: first.updatedAt)
         XCTAssertNotNil(updated)
-        let stale = manager.updateThemeUpdate(id: first.id, title: "Stale", bodyText: "Stale", type: .General, expectedUpdatedAt: first.updatedAt)
+        let stale = manager.updateThemeUpdate(id: first.id, title: "Stale", bodyMarkdown: nil, type: nil, pinned: nil, actor: "Alice", expectedUpdatedAt: first.updatedAt)
         XCTAssertNil(stale)
 
-        let deleteOk = manager.deleteThemeUpdate(id: first.id)
+        let deleteOk = manager.deleteThemeUpdate(id: first.id, themeId: 1, actor: "Alice")
         XCTAssertTrue(deleteOk)
         list = manager.listThemeUpdates(themeId: 1)
-        XCTAssertTrue(list.isEmpty)
+        XCTAssertEqual(list.count, 1)
+    }
+
+    func testUpdateValidation() {
+        let created = manager.createThemeUpdate(themeId: 1, title: "Valid", bodyMarkdown: "Body", type: .General, pinned: false, author: "Alice", positionsAsOf: nil, totalValueChf: nil)
+        XCTAssertNotNil(created)
+        if let u = created {
+            let badTitle = manager.updateThemeUpdate(id: u.id, title: "", bodyMarkdown: nil, type: nil, pinned: nil, actor: "Bob", expectedUpdatedAt: u.updatedAt)
+            XCTAssertNil(badTitle)
+            let badBody = manager.updateThemeUpdate(id: u.id, title: nil, bodyMarkdown: "", type: nil, pinned: nil, actor: "Bob", expectedUpdatedAt: u.updatedAt)
+            XCTAssertNil(badBody)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- allow theme updates to store markdown bodies and pinned state
- let users pin/unpin updates and view pinned-first ordering
- add migration 014 to backfill markdown and track pins
- format update timestamps locally and add footer actions with markdown help
- validate update edits and surface failures during pin or delete

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `sqlite3 /tmp/test.sqlite ".schema PortfolioThemeUpdate"`
- `sqlite3 /tmp/test.sqlite "PRAGMA index_list('PortfolioThemeUpdate');"`


------
https://chatgpt.com/codex/tasks/task_e_68a89ab430148323ac26ec053d567179