### PR TITLE
Add search and type filter for theme updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Add search, type filter, and soft-delete with restore for Portfolio Theme updates with migration 015
 - Support Markdown bodies and pinning for Portfolio Theme updates with migration 014
 - Render theme update timestamps in local time and expose footer action bar with Markdown help
 - Harden update logging and enforce non-null Markdown schema

--- a/DragonShield/Models/PortfolioThemeUpdate.swift
+++ b/DragonShield/Models/PortfolioThemeUpdate.swift
@@ -1,7 +1,8 @@
 // DragonShield/Models/PortfolioThemeUpdate.swift
-// MARK: - Version 1.1
+// MARK: - Version 1.2
 // MARK: - History
 // - 1.0 -> 1.1: Add Markdown body and pin flag for Phase 6B updates.
+// - 1.1 -> 1.2: Track soft deletion metadata for Phase 6C.
 
 import Foundation
 
@@ -24,6 +25,9 @@ struct PortfolioThemeUpdate: Identifiable, Codable {
     var totalValueChf: Double?
     let createdAt: String
     var updatedAt: String
+    var softDelete: Bool
+    var deletedAt: String?
+    var deletedBy: String?
 
     static func isValidTitle(_ title: String) -> Bool {
         let count = title.trimmingCharacters(in: .whitespacesAndNewlines).count

--- a/DragonShield/db/migrations/015_portfolio_theme_update_softdelete_search.sql
+++ b/DragonShield/db/migrations/015_portfolio_theme_update_softdelete_search.sql
@@ -1,0 +1,23 @@
+-- migrate:up
+-- Purpose: Add soft delete columns and search indexes for portfolio theme updates
+-- Assumptions: PortfolioThemeUpdate exists without soft delete columns; data kept intact
+-- Idempotency: use IF NOT EXISTS and check constraints
+
+ALTER TABLE PortfolioThemeUpdate
+  ADD COLUMN soft_delete INTEGER NOT NULL DEFAULT 0 CHECK (soft_delete IN (0,1));
+ALTER TABLE PortfolioThemeUpdate
+  ADD COLUMN deleted_at  TEXT NULL;
+ALTER TABLE PortfolioThemeUpdate
+  ADD COLUMN deleted_by  TEXT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_ptu_theme_active_order
+  ON PortfolioThemeUpdate(theme_id, soft_delete, pinned, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_ptu_theme_deleted_order
+  ON PortfolioThemeUpdate(theme_id, soft_delete, deleted_at DESC);
+
+-- migrate:down
+DROP INDEX IF EXISTS idx_ptu_theme_deleted_order;
+DROP INDEX IF EXISTS idx_ptu_theme_active_order;
+ALTER TABLE PortfolioThemeUpdate DROP COLUMN deleted_by;
+ALTER TABLE PortfolioThemeUpdate DROP COLUMN deleted_at;
+ALTER TABLE PortfolioThemeUpdate DROP COLUMN soft_delete;


### PR DESCRIPTION
## Summary
- add search box and type picker to updates view
- filter updates list by text and type with debounce

## Testing
- `make setup` (fails: No rule to make target 'setup')
- `make fmt && make lint` (fails: No rule to make target 'fmt')
- `make migrate` (fails: No rule to make target 'migrate')
- `make build` (fails: No rule to make target 'build')
- `make test` (fails: No rule to make target 'test')
- `swift test` (fails: Could not find Package.swift)


------
https://chatgpt.com/codex/tasks/task_e_68a8ab8b949483238851c3b884ebe079