### PR TITLE
Add instrument update timeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Introduce PortfolioThemeAssetUpdate table and CRUD helpers for instrument-level update timelines with migration 016
 - Add search, type filter, and soft-delete with restore for Portfolio Theme updates with migration 015
 - Support Markdown bodies and pinning for Portfolio Theme updates with migration 014
 - Render theme update timestamps in local time and expose footer action bar with Markdown help

--- a/DragonShield/DatabaseManager+PortfolioThemeAssetUpdates.swift
+++ b/DragonShield/DatabaseManager+PortfolioThemeAssetUpdates.swift
@@ -1,0 +1,266 @@
+import Foundation
+import SQLite3
+
+extension DatabaseManager {
+    func ensurePortfolioThemeAssetUpdateTable() {
+        let sql = """
+        CREATE TABLE IF NOT EXISTS PortfolioThemeAssetUpdate (
+            id INTEGER PRIMARY KEY,
+            theme_id INTEGER NOT NULL REFERENCES PortfolioTheme(id) ON DELETE CASCADE,
+            instrument_id INTEGER NOT NULL REFERENCES Instruments(instrument_id) ON DELETE SET NULL,
+            title TEXT NOT NULL CHECK (LENGTH(title) BETWEEN 1 AND 120),
+            body_text TEXT NOT NULL CHECK (LENGTH(body_text) BETWEEN 1 AND 5000),
+            type TEXT NOT NULL CHECK (type IN ('General','Research','Rebalance','Risk')),
+            author TEXT NOT NULL,
+            positions_asof TEXT NULL,
+            value_chf REAL NULL,
+            actual_percent REAL NULL,
+            created_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
+            updated_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now'))
+        );
+        CREATE INDEX IF NOT EXISTS idx_ptau_theme_instr_order ON PortfolioThemeAssetUpdate(theme_id, instrument_id, created_at DESC);
+        """
+        if sqlite3_exec(db, sql, nil, nil, nil) != SQLITE_OK {
+            LoggingService.shared.log("ensurePortfolioThemeAssetUpdateTable failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+    }
+
+    func listInstrumentUpdates(themeId: Int, instrumentId: Int) -> [PortfolioThemeAssetUpdate] {
+        var items: [PortfolioThemeAssetUpdate] = []
+        let sql = "SELECT id, theme_id, instrument_id, title, body_text, type, author, positions_asof, value_chf, actual_percent, created_at, updated_at FROM PortfolioThemeAssetUpdate WHERE theme_id = ? AND instrument_id = ? ORDER BY created_at DESC"
+        var stmt: OpaquePointer?
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            sqlite3_bind_int(stmt, 1, Int32(themeId))
+            sqlite3_bind_int(stmt, 2, Int32(instrumentId))
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                let id = Int(sqlite3_column_int(stmt, 0))
+                let themeId = Int(sqlite3_column_int(stmt, 1))
+                let instrumentId = Int(sqlite3_column_int(stmt, 2))
+                let title = String(cString: sqlite3_column_text(stmt, 3))
+                let body = String(cString: sqlite3_column_text(stmt, 4))
+                let typeStr = String(cString: sqlite3_column_text(stmt, 5))
+                let author = String(cString: sqlite3_column_text(stmt, 6))
+                let positionsAsOf = sqlite3_column_text(stmt, 7).map { String(cString: $0) }
+                let value = sqlite3_column_type(stmt, 8) != SQLITE_NULL ? sqlite3_column_double(stmt, 8) : nil
+                let actual = sqlite3_column_type(stmt, 9) != SQLITE_NULL ? sqlite3_column_double(stmt, 9) : nil
+                let created = String(cString: sqlite3_column_text(stmt, 10))
+                let updated = String(cString: sqlite3_column_text(stmt, 11))
+                if let type = PortfolioThemeAssetUpdate.UpdateType(rawValue: typeStr) {
+                    items.append(PortfolioThemeAssetUpdate(id: id, themeId: themeId, instrumentId: instrumentId, title: title, bodyText: body, type: type, author: author, positionsAsOf: positionsAsOf, valueChf: value, actualPercent: actual, createdAt: created, updatedAt: updated))
+                } else {
+                    LoggingService.shared.log("Invalid update type '\(typeStr)' for instrument update id \(id). Skipping row.", type: .warning, logger: .database)
+                }
+            }
+        } else {
+            LoggingService.shared.log("Failed to prepare listInstrumentUpdates: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+        sqlite3_finalize(stmt)
+        return items
+    }
+
+    func getInstrumentUpdate(id: Int) -> PortfolioThemeAssetUpdate? {
+        let sql = "SELECT id, theme_id, instrument_id, title, body_text, type, author, positions_asof, value_chf, actual_percent, created_at, updated_at FROM PortfolioThemeAssetUpdate WHERE id = ?"
+        var stmt: OpaquePointer?
+        var item: PortfolioThemeAssetUpdate?
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            sqlite3_bind_int(stmt, 1, Int32(id))
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                let id = Int(sqlite3_column_int(stmt, 0))
+                let themeId = Int(sqlite3_column_int(stmt, 1))
+                let instrumentId = Int(sqlite3_column_int(stmt, 2))
+                let title = String(cString: sqlite3_column_text(stmt, 3))
+                let body = String(cString: sqlite3_column_text(stmt, 4))
+                let typeStr = String(cString: sqlite3_column_text(stmt, 5))
+                let author = String(cString: sqlite3_column_text(stmt, 6))
+                let positionsAsOf = sqlite3_column_text(stmt, 7).map { String(cString: $0) }
+                let value = sqlite3_column_type(stmt, 8) != SQLITE_NULL ? sqlite3_column_double(stmt, 8) : nil
+                let actual = sqlite3_column_type(stmt, 9) != SQLITE_NULL ? sqlite3_column_double(stmt, 9) : nil
+                let created = String(cString: sqlite3_column_text(stmt, 10))
+                let updated = String(cString: sqlite3_column_text(stmt, 11))
+                if let type = PortfolioThemeAssetUpdate.UpdateType(rawValue: typeStr) {
+                    item = PortfolioThemeAssetUpdate(id: id, themeId: themeId, instrumentId: instrumentId, title: title, bodyText: body, type: type, author: author, positionsAsOf: positionsAsOf, valueChf: value, actualPercent: actual, createdAt: created, updatedAt: updated)
+                } else {
+                    LoggingService.shared.log("Invalid update type '\(typeStr)' for instrument update id \(id).", type: .warning, logger: .database)
+                }
+            }
+        } else {
+            LoggingService.shared.log("Failed to prepare getInstrumentUpdate: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+        sqlite3_finalize(stmt)
+        return item
+    }
+
+    func createInstrumentUpdate(themeId: Int, instrumentId: Int, title: String, bodyText: String, type: PortfolioThemeAssetUpdate.UpdateType, author: String, breadcrumb: (positionsAsOf: String?, valueChf: Double?, actualPercent: Double?)? = nil, source: String? = nil) -> PortfolioThemeAssetUpdate? {
+        guard PortfolioThemeAssetUpdate.isValidTitle(title), PortfolioThemeAssetUpdate.isValidBody(bodyText) else {
+            LoggingService.shared.log("Invalid title/body for instrument update", type: .info, logger: .database)
+            return nil
+        }
+        let sql = "INSERT INTO PortfolioThemeAssetUpdate (theme_id, instrument_id, title, body_text, type, author, positions_asof, value_chf, actual_percent) VALUES (?,?,?,?,?,?,?,?,?)"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            LoggingService.shared.log("prepare createInstrumentUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            return nil
+        }
+        sqlite3_bind_int(stmt, 1, Int32(themeId))
+        sqlite3_bind_int(stmt, 2, Int32(instrumentId))
+        let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        sqlite3_bind_text(stmt, 3, title, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 4, bodyText, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 5, type.rawValue, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 6, author, -1, SQLITE_TRANSIENT)
+        if let pos = breadcrumb?.positionsAsOf {
+            sqlite3_bind_text(stmt, 7, pos, -1, SQLITE_TRANSIENT)
+        } else {
+            sqlite3_bind_null(stmt, 7)
+        }
+        if let val = breadcrumb?.valueChf {
+            sqlite3_bind_double(stmt, 8, val)
+        } else {
+            sqlite3_bind_null(stmt, 8)
+        }
+        if let act = breadcrumb?.actualPercent {
+            sqlite3_bind_double(stmt, 9, act)
+        } else {
+            sqlite3_bind_null(stmt, 9)
+        }
+        guard sqlite3_step(stmt) == SQLITE_DONE else {
+            LoggingService.shared.log("createInstrumentUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            sqlite3_finalize(stmt)
+            return nil
+        }
+        let id = Int(sqlite3_last_insert_rowid(db))
+        sqlite3_finalize(stmt)
+        guard let item = getInstrumentUpdate(id: id) else { return nil }
+        var payload: [String: Any] = [
+            "themeId": themeId,
+            "instrumentId": instrumentId,
+            "updateId": id,
+            "actor": author,
+            "op": "create",
+            "type": type.rawValue,
+            "created_at": item.createdAt
+        ]
+        if let source = source { payload["source"] = source }
+        if let data = try? JSONSerialization.data(withJSONObject: payload), let log = String(data: data, encoding: .utf8) {
+            LoggingService.shared.log(log, logger: .database)
+        }
+        return item
+    }
+
+    func updateInstrumentUpdate(id: Int, title: String?, bodyText: String?, type: PortfolioThemeAssetUpdate.UpdateType?, actor: String, expectedUpdatedAt: String, source: String? = nil) -> PortfolioThemeAssetUpdate? {
+        var sets: [String] = []
+        if let title = title {
+            guard PortfolioThemeAssetUpdate.isValidTitle(title) else { return nil }
+            sets.append("title = ?")
+        }
+        if let bodyText = bodyText {
+            guard PortfolioThemeAssetUpdate.isValidBody(bodyText) else { return nil }
+            sets.append("body_text = ?")
+        }
+        if let _ = type {
+            sets.append("type = ?")
+        }
+        sets.append("updated_at = STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')")
+        let sql = "UPDATE PortfolioThemeAssetUpdate SET \(sets.joined(separator: ", ")) WHERE id = ? AND updated_at = ?"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            LoggingService.shared.log("prepare updateInstrumentUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            return nil
+        }
+        let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        var idx: Int32 = 1
+        if let title = title {
+            sqlite3_bind_text(stmt, idx, title, -1, SQLITE_TRANSIENT); idx += 1
+        }
+        if let bodyText = bodyText {
+            sqlite3_bind_text(stmt, idx, bodyText, -1, SQLITE_TRANSIENT); idx += 1
+        }
+        if let type = type {
+            sqlite3_bind_text(stmt, idx, type.rawValue, -1, SQLITE_TRANSIENT); idx += 1
+        }
+        sqlite3_bind_int(stmt, idx, Int32(id)); idx += 1
+        sqlite3_bind_text(stmt, idx, expectedUpdatedAt, -1, SQLITE_TRANSIENT)
+        guard sqlite3_step(stmt) == SQLITE_DONE else {
+            LoggingService.shared.log("updateInstrumentUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            sqlite3_finalize(stmt)
+            return nil
+        }
+        if sqlite3_changes(db) == 0 {
+            LoggingService.shared.log("updateInstrumentUpdate concurrency conflict id=\(id)", type: .info, logger: .database)
+            sqlite3_finalize(stmt)
+            return nil
+        }
+        sqlite3_finalize(stmt)
+        guard let item = getInstrumentUpdate(id: id) else { return nil }
+        var payload: [String: Any] = [
+            "themeId": item.themeId,
+            "instrumentId": item.instrumentId,
+            "updateId": id,
+            "actor": actor,
+            "op": "update",
+            "type": item.type.rawValue,
+            "updated_at": item.updatedAt
+        ]
+        if let source = source { payload["source"] = source }
+        if let data = try? JSONSerialization.data(withJSONObject: payload), let log = String(data: data, encoding: .utf8) {
+            LoggingService.shared.log(log, logger: .database)
+        }
+        return item
+    }
+
+    func deleteInstrumentUpdate(id: Int, actor: String, source: String? = nil) -> Bool {
+        var themeId: Int = 0
+        var instrumentId: Int = 0
+        var stmt: OpaquePointer?
+        if sqlite3_prepare_v2(db, "SELECT theme_id, instrument_id FROM PortfolioThemeAssetUpdate WHERE id = ?", -1, &stmt, nil) == SQLITE_OK {
+            sqlite3_bind_int(stmt, 1, Int32(id))
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                themeId = Int(sqlite3_column_int(stmt, 0))
+                instrumentId = Int(sqlite3_column_int(stmt, 1))
+            }
+        }
+        sqlite3_finalize(stmt)
+        guard themeId != 0 else { return false }
+        if sqlite3_prepare_v2(db, "DELETE FROM PortfolioThemeAssetUpdate WHERE id = ?", -1, &stmt, nil) != SQLITE_OK {
+            LoggingService.shared.log("prepare deleteInstrumentUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            return false
+        }
+        sqlite3_bind_int(stmt, 1, Int32(id))
+        guard sqlite3_step(stmt) == SQLITE_DONE else {
+            LoggingService.shared.log("deleteInstrumentUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            sqlite3_finalize(stmt)
+            return false
+        }
+        sqlite3_finalize(stmt)
+        var payload: [String: Any] = [
+            "themeId": themeId,
+            "instrumentId": instrumentId,
+            "updateId": id,
+            "actor": actor,
+            "op": "delete"
+        ]
+        if let source = source { payload["source"] = source }
+        if let data = try? JSONSerialization.data(withJSONObject: payload), let log = String(data: data, encoding: .utf8) {
+            LoggingService.shared.log(log, logger: .database)
+        }
+        return true
+    }
+
+    func countInstrumentUpdates(themeId: Int, instrumentId: Int) -> Int {
+        let sql = "SELECT COUNT(*) FROM PortfolioThemeAssetUpdate WHERE theme_id = ? AND instrument_id = ?"
+        var stmt: OpaquePointer?
+        var count = 0
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            sqlite3_bind_int(stmt, 1, Int32(themeId))
+            sqlite3_bind_int(stmt, 2, Int32(instrumentId))
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                count = Int(sqlite3_column_int(stmt, 0))
+            }
+        } else {
+            LoggingService.shared.log("Failed to prepare countInstrumentUpdates: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+        sqlite3_finalize(stmt)
+        return count
+    }
+}
+

--- a/DragonShield/DatabaseManager.swift
+++ b/DragonShield/DatabaseManager.swift
@@ -91,6 +91,7 @@ class DatabaseManager: ObservableObject {
         ensurePortfolioThemeTable()
         ensurePortfolioThemeAssetTable()
         ensurePortfolioThemeUpdateTable()
+        ensurePortfolioThemeAssetUpdateTable()
         let version = loadConfiguration()
         self.dbVersion = version
         DispatchQueue.main.async { self.dbVersion = version }

--- a/DragonShield/FeatureFlags.swift
+++ b/DragonShield/FeatureFlags.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+enum FeatureFlags {
+    static func portfolioInstrumentUpdatesEnabled(
+        args: [String] = CommandLine.arguments,
+        env: [String: String] = ProcessInfo.processInfo.environment,
+        defaults: UserDefaults = .standard
+    ) -> Bool {
+        if let idx = args.firstIndex(of: "--portfolioInstrumentUpdatesEnabled"),
+           let value = args.dropFirst(idx + 1).first {
+            return value.lowercased() != "false"
+        }
+        if let value = env["PORTFOLIO_INSTRUMENT_UPDATES_ENABLED"] {
+            return value.lowercased() != "false"
+        }
+        if defaults.object(forKey: "portfolioInstrumentUpdatesEnabled") != nil {
+            return defaults.bool(forKey: "portfolioInstrumentUpdatesEnabled")
+        }
+        #if DEBUG
+        return true
+        #else
+        return false
+        #endif
+    }
+}
+

--- a/DragonShield/Models/PortfolioThemeAssetUpdate.swift
+++ b/DragonShield/Models/PortfolioThemeAssetUpdate.swift
@@ -1,0 +1,39 @@
+// DragonShield/Models/PortfolioThemeAssetUpdate.swift
+// MARK: - Version 1.0
+// MARK: - History
+// - 1.0: Initial instrument-level update model for Step 7A.
+
+import Foundation
+
+struct PortfolioThemeAssetUpdate: Identifiable, Codable {
+    enum UpdateType: String, CaseIterable, Codable {
+        case General
+        case Research
+        case Rebalance
+        case Risk
+    }
+
+    let id: Int
+    let themeId: Int
+    let instrumentId: Int
+    var title: String
+    var bodyText: String
+    var type: UpdateType
+    let author: String
+    var positionsAsOf: String?
+    var valueChf: Double?
+    var actualPercent: Double?
+    let createdAt: String
+    var updatedAt: String
+
+    static func isValidTitle(_ title: String) -> Bool {
+        let count = title.trimmingCharacters(in: .whitespacesAndNewlines).count
+        return count >= 1 && count <= 120
+    }
+
+    static func isValidBody(_ body: String) -> Bool {
+        let count = body.trimmingCharacters(in: .whitespacesAndNewlines).count
+        return count >= 1 && count <= 5000
+    }
+}
+

--- a/DragonShield/db/migrations/016_portfolio_theme_asset_update.sql
+++ b/DragonShield/db/migrations/016_portfolio_theme_asset_update.sql
@@ -1,0 +1,27 @@
+-- migrate:up
+-- Purpose: Introduce PortfolioThemeAssetUpdate table for instrument-level update timelines.
+-- Assumptions: PortfolioTheme and Instruments tables exist with integer primary keys.
+-- Idempotency: use IF NOT EXISTS and CHECK constraints to enforce domain values.
+CREATE TABLE IF NOT EXISTS PortfolioThemeAssetUpdate (
+  id               INTEGER PRIMARY KEY,
+  theme_id         INTEGER NOT NULL
+                     REFERENCES PortfolioTheme(id) ON DELETE CASCADE,
+  instrument_id    INTEGER NOT NULL
+                     REFERENCES Instruments(instrument_id) ON DELETE SET NULL,
+  title            TEXT    NOT NULL CHECK (LENGTH(title) BETWEEN 1 AND 120),
+  body_text        TEXT    NOT NULL CHECK (LENGTH(body_text) BETWEEN 1 AND 5000),
+  type             TEXT    NOT NULL
+                     CHECK (type IN ('General','Research','Rebalance','Risk')),
+  author           TEXT    NOT NULL,
+  positions_asof   TEXT    NULL,
+  value_chf        REAL    NULL,
+  actual_percent   REAL    NULL,
+  created_at       TEXT    NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
+  updated_at       TEXT    NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+CREATE INDEX IF NOT EXISTS idx_ptau_theme_instr_order
+  ON PortfolioThemeAssetUpdate(theme_id, instrument_id, created_at DESC);
+
+-- migrate:down
+DROP INDEX IF EXISTS idx_ptau_theme_instr_order;
+DROP TABLE IF EXISTS PortfolioThemeAssetUpdate;

--- a/DragonShieldTests/PortfolioThemeAssetUpdateTests.swift
+++ b/DragonShieldTests/PortfolioThemeAssetUpdateTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+import SQLite3
+@testable import DragonShield
+
+final class PortfolioThemeAssetUpdateTests: XCTestCase {
+    var manager: DatabaseManager!
+    var memdb: OpaquePointer?
+
+    override func setUp() {
+        super.setUp()
+        manager = DatabaseManager()
+        sqlite3_open(":memory:", &memdb)
+        manager.db = memdb
+        sqlite3_exec(manager.db, "PRAGMA foreign_keys = ON;", nil, nil, nil)
+        sqlite3_exec(manager.db, "CREATE TABLE PortfolioTheme(id INTEGER PRIMARY KEY);", nil, nil, nil)
+        sqlite3_exec(manager.db, "INSERT INTO PortfolioTheme(id) VALUES (1);", nil, nil, nil)
+        sqlite3_exec(manager.db, "CREATE TABLE Instruments(instrument_id INTEGER PRIMARY KEY);", nil, nil, nil)
+        sqlite3_exec(manager.db, "INSERT INTO Instruments(instrument_id) VALUES (42);", nil, nil, nil)
+        manager.ensurePortfolioThemeAssetUpdateTable()
+    }
+
+    override func tearDown() {
+        sqlite3_close(memdb)
+        memdb = nil
+        manager = nil
+        super.tearDown()
+    }
+
+    func testCreateEditDeleteFlow() {
+        let first = manager.createInstrumentUpdate(themeId: 1, instrumentId: 42, title: "Init", bodyText: "Start", type: .General, author: "Alice", breadcrumb: nil)
+        XCTAssertNotNil(first)
+        let second = manager.createInstrumentUpdate(themeId: 1, instrumentId: 42, title: "Second", bodyText: "More", type: .Research, author: "Bob", breadcrumb: nil)
+        XCTAssertNotNil(second)
+        var list = manager.listInstrumentUpdates(themeId: 1, instrumentId: 42)
+        XCTAssertEqual(list.count, 2)
+        XCTAssertEqual(list.first?.id, second!.id)
+        let updated = manager.updateInstrumentUpdate(id: first!.id, title: "Changed", bodyText: nil, type: .Risk, actor: "Alice", expectedUpdatedAt: first!.updatedAt)
+        XCTAssertEqual(updated?.title, "Changed")
+        XCTAssertEqual(updated?.type, .Risk)
+        let conflict = manager.updateInstrumentUpdate(id: first!.id, title: "Bad", bodyText: nil, type: nil, actor: "Bob", expectedUpdatedAt: "bogus")
+        XCTAssertNil(conflict)
+        XCTAssertTrue(manager.deleteInstrumentUpdate(id: first!.id, actor: "Alice"))
+        XCTAssertEqual(manager.countInstrumentUpdates(themeId: 1, instrumentId: 42), 1)
+        XCTAssertTrue(manager.deleteInstrumentUpdate(id: second!.id, actor: "Bob"))
+        XCTAssertEqual(manager.countInstrumentUpdates(themeId: 1, instrumentId: 42), 0)
+        list = manager.listInstrumentUpdates(themeId: 1, instrumentId: 42)
+        XCTAssertEqual(list.count, 0)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `PortfolioThemeAssetUpdate` model and database helpers
- support instrument update CRUD with logging and counts
- migrate schema to create `PortfolioThemeAssetUpdate` table

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift)*


------
https://chatgpt.com/codex/tasks/task_e_68a8c2eac34c832395e84eb89cdc40d3