### PR TITLE
feat: enrich instrument updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Add Markdown body and pin flag to instrument-level updates with migration 017
 - Introduce PortfolioThemeAssetUpdate table and CRUD helpers for instrument-level update timelines with migration 016
 - Surface Instrument Updates button and sheet in Portfolio Theme composition under feature flag
 - Add search, type filter, and soft-delete with restore for Portfolio Theme updates with migration 015

--- a/DragonShield/DatabaseManager+PortfolioThemeAssetUpdates.swift
+++ b/DragonShield/DatabaseManager+PortfolioThemeAssetUpdates.swift
@@ -10,24 +10,28 @@ extension DatabaseManager {
             instrument_id INTEGER NOT NULL REFERENCES Instruments(instrument_id) ON DELETE SET NULL,
             title TEXT NOT NULL CHECK (LENGTH(title) BETWEEN 1 AND 120),
             body_text TEXT NOT NULL CHECK (LENGTH(body_text) BETWEEN 1 AND 5000),
+            body_markdown TEXT NULL,
             type TEXT NOT NULL CHECK (type IN ('General','Research','Rebalance','Risk')),
             author TEXT NOT NULL,
             positions_asof TEXT NULL,
             value_chf REAL NULL,
             actual_percent REAL NULL,
+            pinned INTEGER NOT NULL DEFAULT 0 CHECK (pinned IN (0,1)),
             created_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
             updated_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now'))
         );
         CREATE INDEX IF NOT EXISTS idx_ptau_theme_instr_order ON PortfolioThemeAssetUpdate(theme_id, instrument_id, created_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_ptau_theme_instr_pinned_order ON PortfolioThemeAssetUpdate(theme_id, instrument_id, pinned DESC, created_at DESC);
         """
         if sqlite3_exec(db, sql, nil, nil, nil) != SQLITE_OK {
             LoggingService.shared.log("ensurePortfolioThemeAssetUpdateTable failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
         }
     }
 
-    func listInstrumentUpdates(themeId: Int, instrumentId: Int) -> [PortfolioThemeAssetUpdate] {
+    func listInstrumentUpdates(themeId: Int, instrumentId: Int, pinnedFirst: Bool = true) -> [PortfolioThemeAssetUpdate] {
         var items: [PortfolioThemeAssetUpdate] = []
-        let sql = "SELECT id, theme_id, instrument_id, title, body_text, type, author, positions_asof, value_chf, actual_percent, created_at, updated_at FROM PortfolioThemeAssetUpdate WHERE theme_id = ? AND instrument_id = ? ORDER BY created_at DESC"
+        let order = pinnedFirst ? "pinned DESC, created_at DESC" : "created_at DESC"
+        let sql = "SELECT id, theme_id, instrument_id, title, body_markdown, type, author, positions_asof, value_chf, actual_percent, pinned, created_at, updated_at FROM PortfolioThemeAssetUpdate WHERE theme_id = ? AND instrument_id = ? ORDER BY \(order)"
         var stmt: OpaquePointer?
         if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
             sqlite3_bind_int(stmt, 1, Int32(themeId))
@@ -37,16 +41,17 @@ extension DatabaseManager {
                 let themeId = Int(sqlite3_column_int(stmt, 1))
                 let instrumentId = Int(sqlite3_column_int(stmt, 2))
                 let title = String(cString: sqlite3_column_text(stmt, 3))
-                let body = String(cString: sqlite3_column_text(stmt, 4))
+                let body = sqlite3_column_text(stmt, 4).map { String(cString: $0) } ?? ""
                 let typeStr = String(cString: sqlite3_column_text(stmt, 5))
                 let author = String(cString: sqlite3_column_text(stmt, 6))
                 let positionsAsOf = sqlite3_column_text(stmt, 7).map { String(cString: $0) }
                 let value = sqlite3_column_type(stmt, 8) != SQLITE_NULL ? sqlite3_column_double(stmt, 8) : nil
                 let actual = sqlite3_column_type(stmt, 9) != SQLITE_NULL ? sqlite3_column_double(stmt, 9) : nil
-                let created = String(cString: sqlite3_column_text(stmt, 10))
-                let updated = String(cString: sqlite3_column_text(stmt, 11))
+                let pinned = sqlite3_column_int(stmt, 10) == 1
+                let created = String(cString: sqlite3_column_text(stmt, 11))
+                let updated = String(cString: sqlite3_column_text(stmt, 12))
                 if let type = PortfolioThemeAssetUpdate.UpdateType(rawValue: typeStr) {
-                    items.append(PortfolioThemeAssetUpdate(id: id, themeId: themeId, instrumentId: instrumentId, title: title, bodyText: body, type: type, author: author, positionsAsOf: positionsAsOf, valueChf: value, actualPercent: actual, createdAt: created, updatedAt: updated))
+                    items.append(PortfolioThemeAssetUpdate(id: id, themeId: themeId, instrumentId: instrumentId, title: title, bodyMarkdown: body, type: type, author: author, positionsAsOf: positionsAsOf, valueChf: value, actualPercent: actual, pinned: pinned, createdAt: created, updatedAt: updated))
                 } else {
                     LoggingService.shared.log("Invalid update type '\(typeStr)' for instrument update id \(id). Skipping row.", type: .warning, logger: .database)
                 }
@@ -59,7 +64,7 @@ extension DatabaseManager {
     }
 
     func getInstrumentUpdate(id: Int) -> PortfolioThemeAssetUpdate? {
-        let sql = "SELECT id, theme_id, instrument_id, title, body_text, type, author, positions_asof, value_chf, actual_percent, created_at, updated_at FROM PortfolioThemeAssetUpdate WHERE id = ?"
+        let sql = "SELECT id, theme_id, instrument_id, title, body_markdown, type, author, positions_asof, value_chf, actual_percent, pinned, created_at, updated_at FROM PortfolioThemeAssetUpdate WHERE id = ?"
         var stmt: OpaquePointer?
         var item: PortfolioThemeAssetUpdate?
         if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
@@ -69,16 +74,17 @@ extension DatabaseManager {
                 let themeId = Int(sqlite3_column_int(stmt, 1))
                 let instrumentId = Int(sqlite3_column_int(stmt, 2))
                 let title = String(cString: sqlite3_column_text(stmt, 3))
-                let body = String(cString: sqlite3_column_text(stmt, 4))
+                let body = sqlite3_column_text(stmt, 4).map { String(cString: $0) } ?? ""
                 let typeStr = String(cString: sqlite3_column_text(stmt, 5))
                 let author = String(cString: sqlite3_column_text(stmt, 6))
                 let positionsAsOf = sqlite3_column_text(stmt, 7).map { String(cString: $0) }
                 let value = sqlite3_column_type(stmt, 8) != SQLITE_NULL ? sqlite3_column_double(stmt, 8) : nil
                 let actual = sqlite3_column_type(stmt, 9) != SQLITE_NULL ? sqlite3_column_double(stmt, 9) : nil
-                let created = String(cString: sqlite3_column_text(stmt, 10))
-                let updated = String(cString: sqlite3_column_text(stmt, 11))
+                let pinned = sqlite3_column_int(stmt, 10) == 1
+                let created = String(cString: sqlite3_column_text(stmt, 11))
+                let updated = String(cString: sqlite3_column_text(stmt, 12))
                 if let type = PortfolioThemeAssetUpdate.UpdateType(rawValue: typeStr) {
-                    item = PortfolioThemeAssetUpdate(id: id, themeId: themeId, instrumentId: instrumentId, title: title, bodyText: body, type: type, author: author, positionsAsOf: positionsAsOf, valueChf: value, actualPercent: actual, createdAt: created, updatedAt: updated)
+                    item = PortfolioThemeAssetUpdate(id: id, themeId: themeId, instrumentId: instrumentId, title: title, bodyMarkdown: body, type: type, author: author, positionsAsOf: positionsAsOf, valueChf: value, actualPercent: actual, pinned: pinned, createdAt: created, updatedAt: updated)
                 } else {
                     LoggingService.shared.log("Invalid update type '\(typeStr)' for instrument update id \(id).", type: .warning, logger: .database)
                 }
@@ -90,12 +96,12 @@ extension DatabaseManager {
         return item
     }
 
-    func createInstrumentUpdate(themeId: Int, instrumentId: Int, title: String, bodyText: String, type: PortfolioThemeAssetUpdate.UpdateType, author: String, breadcrumb: (positionsAsOf: String?, valueChf: Double?, actualPercent: Double?)? = nil, source: String? = nil) -> PortfolioThemeAssetUpdate? {
-        guard PortfolioThemeAssetUpdate.isValidTitle(title), PortfolioThemeAssetUpdate.isValidBody(bodyText) else {
+    func createInstrumentUpdate(themeId: Int, instrumentId: Int, title: String, bodyMarkdown: String, type: PortfolioThemeAssetUpdate.UpdateType, pinned: Bool, author: String, breadcrumb: (positionsAsOf: String?, valueChf: Double?, actualPercent: Double?)? = nil, source: String? = nil) -> PortfolioThemeAssetUpdate? {
+        guard PortfolioThemeAssetUpdate.isValidTitle(title), PortfolioThemeAssetUpdate.isValidBody(bodyMarkdown) else {
             LoggingService.shared.log("Invalid title/body for instrument update", type: .info, logger: .database)
             return nil
         }
-        let sql = "INSERT INTO PortfolioThemeAssetUpdate (theme_id, instrument_id, title, body_text, type, author, positions_asof, value_chf, actual_percent) VALUES (?,?,?,?,?,?,?,?,?)"
+        let sql = "INSERT INTO PortfolioThemeAssetUpdate (theme_id, instrument_id, title, body_markdown, body_text, type, author, positions_asof, value_chf, actual_percent, pinned) VALUES (?,?,?,?,?,?,?,?,?,?,?)"
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
             LoggingService.shared.log("prepare createInstrumentUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
@@ -105,24 +111,20 @@ extension DatabaseManager {
         sqlite3_bind_int(stmt, 2, Int32(instrumentId))
         let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
         sqlite3_bind_text(stmt, 3, title, -1, SQLITE_TRANSIENT)
-        sqlite3_bind_text(stmt, 4, bodyText, -1, SQLITE_TRANSIENT)
-        sqlite3_bind_text(stmt, 5, type.rawValue, -1, SQLITE_TRANSIENT)
-        sqlite3_bind_text(stmt, 6, author, -1, SQLITE_TRANSIENT)
-        if let pos = breadcrumb?.positionsAsOf {
-            sqlite3_bind_text(stmt, 7, pos, -1, SQLITE_TRANSIENT)
-        } else {
-            sqlite3_bind_null(stmt, 7)
-        }
-        if let val = breadcrumb?.valueChf {
-            sqlite3_bind_double(stmt, 8, val)
+        sqlite3_bind_text(stmt, 4, bodyMarkdown, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 5, bodyMarkdown, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 6, type.rawValue, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 7, author, -1, SQLITE_TRANSIENT)
+        if let bc = breadcrumb {
+            bc.positionsAsOf.map { sqlite3_bind_text(stmt, 8, $0, -1, SQLITE_TRANSIENT) } ?? sqlite3_bind_null(stmt, 8)
+            if let v = bc.valueChf { sqlite3_bind_double(stmt, 9, v) } else { sqlite3_bind_null(stmt, 9) }
+            if let a = bc.actualPercent { sqlite3_bind_double(stmt, 10, a) } else { sqlite3_bind_null(stmt, 10) }
         } else {
             sqlite3_bind_null(stmt, 8)
-        }
-        if let act = breadcrumb?.actualPercent {
-            sqlite3_bind_double(stmt, 9, act)
-        } else {
             sqlite3_bind_null(stmt, 9)
+            sqlite3_bind_null(stmt, 10)
         }
+        sqlite3_bind_int(stmt, 11, pinned ? 1 : 0)
         guard sqlite3_step(stmt) == SQLITE_DONE else {
             LoggingService.shared.log("createInstrumentUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
             sqlite3_finalize(stmt)
@@ -137,6 +139,7 @@ extension DatabaseManager {
             "updateId": id,
             "actor": author,
             "op": "create",
+            "pinned": pinned,
             "type": type.rawValue,
             "created_at": item.createdAt
         ]
@@ -147,18 +150,22 @@ extension DatabaseManager {
         return item
     }
 
-    func updateInstrumentUpdate(id: Int, title: String?, bodyText: String?, type: PortfolioThemeAssetUpdate.UpdateType?, actor: String, expectedUpdatedAt: String, source: String? = nil) -> PortfolioThemeAssetUpdate? {
+    func updateInstrumentUpdate(id: Int, title: String?, bodyMarkdown: String?, type: PortfolioThemeAssetUpdate.UpdateType?, pinned: Bool?, actor: String, expectedUpdatedAt: String, source: String? = nil) -> PortfolioThemeAssetUpdate? {
         var sets: [String] = []
         if let title = title {
             guard PortfolioThemeAssetUpdate.isValidTitle(title) else { return nil }
             sets.append("title = ?")
         }
-        if let bodyText = bodyText {
-            guard PortfolioThemeAssetUpdate.isValidBody(bodyText) else { return nil }
+        if let bodyMarkdown = bodyMarkdown {
+            guard PortfolioThemeAssetUpdate.isValidBody(bodyMarkdown) else { return nil }
+            sets.append("body_markdown = ?")
             sets.append("body_text = ?")
         }
         if let _ = type {
             sets.append("type = ?")
+        }
+        if let _ = pinned {
+            sets.append("pinned = ?")
         }
         sets.append("updated_at = STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')")
         let sql = "UPDATE PortfolioThemeAssetUpdate SET \(sets.joined(separator: ", ")) WHERE id = ? AND updated_at = ?"
@@ -172,11 +179,15 @@ extension DatabaseManager {
         if let title = title {
             sqlite3_bind_text(stmt, idx, title, -1, SQLITE_TRANSIENT); idx += 1
         }
-        if let bodyText = bodyText {
-            sqlite3_bind_text(stmt, idx, bodyText, -1, SQLITE_TRANSIENT); idx += 1
+        if let bodyMarkdown = bodyMarkdown {
+            sqlite3_bind_text(stmt, idx, bodyMarkdown, -1, SQLITE_TRANSIENT); idx += 1
+            sqlite3_bind_text(stmt, idx, bodyMarkdown, -1, SQLITE_TRANSIENT); idx += 1
         }
         if let type = type {
             sqlite3_bind_text(stmt, idx, type.rawValue, -1, SQLITE_TRANSIENT); idx += 1
+        }
+        if let pinned = pinned {
+            sqlite3_bind_int(stmt, idx, pinned ? 1 : 0); idx += 1
         }
         sqlite3_bind_int(stmt, idx, Int32(id)); idx += 1
         sqlite3_bind_text(stmt, idx, expectedUpdatedAt, -1, SQLITE_TRANSIENT)
@@ -192,12 +203,15 @@ extension DatabaseManager {
         }
         sqlite3_finalize(stmt)
         guard let item = getInstrumentUpdate(id: id) else { return nil }
+        var op = "update"
+        if let pinned = pinned { op = pinned ? "pin" : "unpin" }
         var payload: [String: Any] = [
             "themeId": item.themeId,
             "instrumentId": item.instrumentId,
             "updateId": id,
             "actor": actor,
-            "op": "update",
+            "op": op,
+            "pinned": item.pinned,
             "type": item.type.rawValue,
             "updated_at": item.updatedAt
         ]
@@ -211,12 +225,14 @@ extension DatabaseManager {
     func deleteInstrumentUpdate(id: Int, actor: String, source: String? = nil) -> Bool {
         var themeId: Int = 0
         var instrumentId: Int = 0
+        var pinned: Bool = false
         var stmt: OpaquePointer?
-        if sqlite3_prepare_v2(db, "SELECT theme_id, instrument_id FROM PortfolioThemeAssetUpdate WHERE id = ?", -1, &stmt, nil) == SQLITE_OK {
+        if sqlite3_prepare_v2(db, "SELECT theme_id, instrument_id, pinned FROM PortfolioThemeAssetUpdate WHERE id = ?", -1, &stmt, nil) == SQLITE_OK {
             sqlite3_bind_int(stmt, 1, Int32(id))
             if sqlite3_step(stmt) == SQLITE_ROW {
                 themeId = Int(sqlite3_column_int(stmt, 0))
                 instrumentId = Int(sqlite3_column_int(stmt, 1))
+                pinned = sqlite3_column_int(stmt, 2) == 1
             }
         }
         sqlite3_finalize(stmt)
@@ -237,7 +253,8 @@ extension DatabaseManager {
             "instrumentId": instrumentId,
             "updateId": id,
             "actor": actor,
-            "op": "delete"
+            "op": "delete",
+            "pinned": pinned
         ]
         if let source = source { payload["source"] = source }
         if let data = try? JSONSerialization.data(withJSONObject: payload), let log = String(data: data, encoding: .utf8) {
@@ -263,4 +280,3 @@ extension DatabaseManager {
         return count
     }
 }
-

--- a/DragonShield/Models/PortfolioThemeAssetUpdate.swift
+++ b/DragonShield/Models/PortfolioThemeAssetUpdate.swift
@@ -1,6 +1,7 @@
 // DragonShield/Models/PortfolioThemeAssetUpdate.swift
-// MARK: - Version 1.0
+// MARK: - Version 1.1
 // MARK: - History
+// - 1.1: Add Markdown body and pin flag for Step 7B.
 // - 1.0: Initial instrument-level update model for Step 7A.
 
 import Foundation
@@ -17,12 +18,13 @@ struct PortfolioThemeAssetUpdate: Identifiable, Codable {
     let themeId: Int
     let instrumentId: Int
     var title: String
-    var bodyText: String
+    var bodyMarkdown: String
     var type: UpdateType
     let author: String
     var positionsAsOf: String?
     var valueChf: Double?
     var actualPercent: Double?
+    var pinned: Bool
     let createdAt: String
     var updatedAt: String
 
@@ -36,4 +38,3 @@ struct PortfolioThemeAssetUpdate: Identifiable, Codable {
         return count >= 1 && count <= 5000
     }
 }
-

--- a/DragonShield/Views/InstrumentUpdatesView.swift
+++ b/DragonShield/Views/InstrumentUpdatesView.swift
@@ -1,6 +1,7 @@
 // DragonShield/Views/InstrumentUpdatesView.swift
-// MARK: - Version 1.0
+// MARK: - Version 1.1
 // MARK: - History
+// - 1.1: Display Markdown body and pinned state for Step 7B.
 // - 1.0: Initial instrument updates list for Step 7A.
 
 import SwiftUI
@@ -50,10 +51,10 @@ struct InstrumentUpdatesView: View {
             List(selection: $selectedId) {
                 ForEach(updates) { update in
                     VStack(alignment: .leading, spacing: 4) {
-                        Text("\(DateFormatting.userFriendly(update.createdAt))  •  \(update.author)  •  \(update.type.rawValue)\(update.updatedAt > update.createdAt ? "  •  edited" : "")")
+                        Text("\(DateFormatting.userFriendly(update.createdAt))  •  \(update.author)  •  \(update.type.rawValue)  \(update.pinned ? "★ Pinned" : "☆")\(update.updatedAt > update.createdAt ? "  •  edited" : "")")
                             .font(.subheadline)
                         Text("Title: \(update.title)").fontWeight(.semibold)
-                        Text(update.bodyText)
+                        Text(update.bodyMarkdown)
                         Text("Breadcrumb: Positions \(DateFormatting.userFriendly(update.positionsAsOf)) • Value CHF \(formatted(update.valueChf)) • Actual \(formattedPct(update.actualPercent))")
                             .font(.caption)
                             .foregroundColor(.secondary)

--- a/DragonShield/db/migrations/017_portfolio_theme_asset_update_enrich.sql
+++ b/DragonShield/db/migrations/017_portfolio_theme_asset_update_enrich.sql
@@ -1,0 +1,19 @@
+-- migrate:up
+-- Purpose: Add Markdown body and pin flag to instrument-level updates.
+-- Assumptions: PortfolioThemeAssetUpdate table exists with body_text column.
+-- Idempotency: use IF NOT EXISTS and content checks where possible.
+ALTER TABLE PortfolioThemeAssetUpdate
+  ADD COLUMN body_markdown TEXT NULL;
+
+ALTER TABLE PortfolioThemeAssetUpdate
+  ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0 CHECK (pinned IN (0,1));
+
+UPDATE PortfolioThemeAssetUpdate
+  SET body_markdown = COALESCE(body_text, '');
+
+CREATE INDEX IF NOT EXISTS idx_ptau_theme_instr_pinned_order
+  ON PortfolioThemeAssetUpdate(theme_id, instrument_id, pinned DESC, created_at DESC);
+
+-- migrate:down
+-- Purpose: Roll back pin and Markdown fields. SQLite cannot drop columns; restore from backup.
+DROP INDEX IF EXISTS idx_ptau_theme_instr_pinned_order;

--- a/DragonShieldTests/PortfolioThemeAssetUpdateTests.swift
+++ b/DragonShieldTests/PortfolioThemeAssetUpdateTests.swift
@@ -27,17 +27,23 @@ final class PortfolioThemeAssetUpdateTests: XCTestCase {
     }
 
     func testCreateEditDeleteFlow() {
-        let first = manager.createInstrumentUpdate(themeId: 1, instrumentId: 42, title: "Init", bodyText: "Start", type: .General, author: "Alice", breadcrumb: nil)
+        let first = manager.createInstrumentUpdate(themeId: 1, instrumentId: 42, title: "Init", bodyMarkdown: "Start", type: .General, pinned: false, author: "Alice", breadcrumb: nil)
         XCTAssertNotNil(first)
-        let second = manager.createInstrumentUpdate(themeId: 1, instrumentId: 42, title: "Second", bodyText: "More", type: .Research, author: "Bob", breadcrumb: nil)
+        let second = manager.createInstrumentUpdate(themeId: 1, instrumentId: 42, title: "Second", bodyMarkdown: "More", type: .Research, pinned: false, author: "Bob", breadcrumb: nil)
         XCTAssertNotNil(second)
         var list = manager.listInstrumentUpdates(themeId: 1, instrumentId: 42)
         XCTAssertEqual(list.count, 2)
         XCTAssertEqual(list.first?.id, second!.id)
-        let updated = manager.updateInstrumentUpdate(id: first!.id, title: "Changed", bodyText: nil, type: .Risk, actor: "Alice", expectedUpdatedAt: first!.updatedAt)
-        XCTAssertEqual(updated?.title, "Changed")
-        XCTAssertEqual(updated?.type, .Risk)
-        let conflict = manager.updateInstrumentUpdate(id: first!.id, title: "Bad", bodyText: nil, type: nil, actor: "Bob", expectedUpdatedAt: "bogus")
+        let pinned = manager.updateInstrumentUpdate(id: first!.id, title: nil, bodyMarkdown: nil, type: nil, pinned: true, actor: "Alice", expectedUpdatedAt: first!.updatedAt)
+        XCTAssertTrue(pinned?.pinned ?? false)
+        list = manager.listInstrumentUpdates(themeId: 1, instrumentId: 42)
+        XCTAssertEqual(list.first?.id, first!.id)
+        list = manager.listInstrumentUpdates(themeId: 1, instrumentId: 42, pinnedFirst: false)
+        XCTAssertEqual(list.first?.id, second!.id)
+        let edited = manager.updateInstrumentUpdate(id: first!.id, title: "Changed", bodyMarkdown: nil, type: .Risk, pinned: nil, actor: "Alice", expectedUpdatedAt: pinned!.updatedAt)
+        XCTAssertEqual(edited?.title, "Changed")
+        XCTAssertEqual(edited?.type, .Risk)
+        let conflict = manager.updateInstrumentUpdate(id: first!.id, title: "Bad", bodyMarkdown: nil, type: nil, pinned: nil, actor: "Bob", expectedUpdatedAt: "bogus")
         XCTAssertNil(conflict)
         XCTAssertTrue(manager.deleteInstrumentUpdate(id: first!.id, actor: "Alice"))
         XCTAssertEqual(manager.countInstrumentUpdates(themeId: 1, instrumentId: 42), 1)
@@ -47,4 +53,3 @@ final class PortfolioThemeAssetUpdateTests: XCTestCase {
         XCTAssertEqual(list.count, 0)
     }
 }
-


### PR DESCRIPTION
## Summary
- support markdown and pin flag for instrument-level updates
- track pinned updates with optional ordering
- add migration for body_markdown and pinned columns

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `dbmate --migrations-dir "$DRAGONSHIELD_HOME/DragonShield/db/migrations" --url "$DATABASE_URL" status` *(fails: command not found: dbmate)*
- `dbmate --migrations-dir "$DRAGONSHIELD_HOME/DragonShield/db/migrations" --url "$DATABASE_URL" up` *(fails: command not found: dbmate)*
- `sqlite3 "$DBFILE" "SELECT version FROM schema_migrations ORDER BY version;"` *(fails: no such table: schema_migrations)*


------
https://chatgpt.com/codex/tasks/task_e_68a8caaa07e48323aaa23604592d05e0