### PR TITLE
feat: add markdown and pinning to instrument updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Enrich instrument updates with Markdown bodies, pin/unpin, and pinned-first ordering with migration 017
 - Introduce PortfolioThemeAssetUpdate table and CRUD helpers for instrument-level update timelines with migration 016
 - Surface Instrument Updates button and sheet in Portfolio Theme composition under feature flag
 - Add search, type filter, and soft-delete with restore for Portfolio Theme updates with migration 015

--- a/DragonShield/DatabaseManager+PortfolioThemeAssetUpdates.swift
+++ b/DragonShield/DatabaseManager+PortfolioThemeAssetUpdates.swift
@@ -10,8 +10,10 @@ extension DatabaseManager {
             instrument_id INTEGER NOT NULL REFERENCES Instruments(instrument_id) ON DELETE SET NULL,
             title TEXT NOT NULL CHECK (LENGTH(title) BETWEEN 1 AND 120),
             body_text TEXT NOT NULL CHECK (LENGTH(body_text) BETWEEN 1 AND 5000),
+            body_markdown TEXT NOT NULL CHECK (LENGTH(body_markdown) BETWEEN 1 AND 5000),
             type TEXT NOT NULL CHECK (type IN ('General','Research','Rebalance','Risk')),
             author TEXT NOT NULL,
+            pinned INTEGER NOT NULL DEFAULT 0 CHECK (pinned IN (0,1)),
             positions_asof TEXT NULL,
             value_chf REAL NULL,
             actual_percent REAL NULL,
@@ -19,15 +21,17 @@ extension DatabaseManager {
             updated_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now'))
         );
         CREATE INDEX IF NOT EXISTS idx_ptau_theme_instr_order ON PortfolioThemeAssetUpdate(theme_id, instrument_id, created_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_ptau_theme_instr_pinned_order ON PortfolioThemeAssetUpdate(theme_id, instrument_id, pinned DESC, created_at DESC);
         """
         if sqlite3_exec(db, sql, nil, nil, nil) != SQLITE_OK {
             LoggingService.shared.log("ensurePortfolioThemeAssetUpdateTable failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
         }
     }
 
-    func listInstrumentUpdates(themeId: Int, instrumentId: Int) -> [PortfolioThemeAssetUpdate] {
+    func listInstrumentUpdates(themeId: Int, instrumentId: Int, pinnedFirst: Bool = true) -> [PortfolioThemeAssetUpdate] {
         var items: [PortfolioThemeAssetUpdate] = []
-        let sql = "SELECT id, theme_id, instrument_id, title, body_text, type, author, positions_asof, value_chf, actual_percent, created_at, updated_at FROM PortfolioThemeAssetUpdate WHERE theme_id = ? AND instrument_id = ? ORDER BY created_at DESC"
+        let order = pinnedFirst ? "pinned DESC, created_at DESC" : "created_at DESC"
+        let sql = "SELECT id, theme_id, instrument_id, title, body_markdown, type, author, pinned, positions_asof, value_chf, actual_percent, created_at, updated_at FROM PortfolioThemeAssetUpdate WHERE theme_id = ? AND instrument_id = ? ORDER BY \(order)"
         var stmt: OpaquePointer?
         if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
             sqlite3_bind_int(stmt, 1, Int32(themeId))
@@ -40,15 +44,16 @@ extension DatabaseManager {
                 let body = String(cString: sqlite3_column_text(stmt, 4))
                 let typeStr = String(cString: sqlite3_column_text(stmt, 5))
                 let author = String(cString: sqlite3_column_text(stmt, 6))
-                let positionsAsOf = sqlite3_column_text(stmt, 7).map { String(cString: $0) }
-                let value = sqlite3_column_type(stmt, 8) != SQLITE_NULL ? sqlite3_column_double(stmt, 8) : nil
-                let actual = sqlite3_column_type(stmt, 9) != SQLITE_NULL ? sqlite3_column_double(stmt, 9) : nil
-                let created = String(cString: sqlite3_column_text(stmt, 10))
-                let updated = String(cString: sqlite3_column_text(stmt, 11))
+                let pinned = sqlite3_column_int(stmt, 7) == 1
+                let positionsAsOf = sqlite3_column_text(stmt, 8).map { String(cString: $0) }
+                let value = sqlite3_column_type(stmt, 9) != SQLITE_NULL ? sqlite3_column_double(stmt, 9) : nil
+                let actual = sqlite3_column_type(stmt, 10) != SQLITE_NULL ? sqlite3_column_double(stmt, 10) : nil
+                let created = String(cString: sqlite3_column_text(stmt, 11))
+                let updated = String(cString: sqlite3_column_text(stmt, 12))
                 if let type = PortfolioThemeAssetUpdate.UpdateType(rawValue: typeStr) {
-                    items.append(PortfolioThemeAssetUpdate(id: id, themeId: themeId, instrumentId: instrumentId, title: title, bodyText: body, type: type, author: author, positionsAsOf: positionsAsOf, valueChf: value, actualPercent: actual, createdAt: created, updatedAt: updated))
+                    items.append(PortfolioThemeAssetUpdate(id: id, themeId: themeId, instrumentId: instrumentId, title: title, bodyMarkdown: body, type: type, author: author, pinned: pinned, positionsAsOf: positionsAsOf, valueChf: value, actualPercent: actual, createdAt: created, updatedAt: updated))
                 } else {
-                    LoggingService.shared.log("Invalid update type '\(typeStr)' for instrument update id \(id). Skipping row.", type: .warning, logger: .database)
+                    LoggingService.shared.log("Invalid update type '\\(typeStr)' for instrument update id \\(id). Skipping row.", type: .warning, logger: .database)
                 }
             }
         } else {
@@ -59,7 +64,7 @@ extension DatabaseManager {
     }
 
     func getInstrumentUpdate(id: Int) -> PortfolioThemeAssetUpdate? {
-        let sql = "SELECT id, theme_id, instrument_id, title, body_text, type, author, positions_asof, value_chf, actual_percent, created_at, updated_at FROM PortfolioThemeAssetUpdate WHERE id = ?"
+        let sql = "SELECT id, theme_id, instrument_id, title, body_markdown, type, author, pinned, positions_asof, value_chf, actual_percent, created_at, updated_at FROM PortfolioThemeAssetUpdate WHERE id = ?"
         var stmt: OpaquePointer?
         var item: PortfolioThemeAssetUpdate?
         if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
@@ -72,15 +77,16 @@ extension DatabaseManager {
                 let body = String(cString: sqlite3_column_text(stmt, 4))
                 let typeStr = String(cString: sqlite3_column_text(stmt, 5))
                 let author = String(cString: sqlite3_column_text(stmt, 6))
-                let positionsAsOf = sqlite3_column_text(stmt, 7).map { String(cString: $0) }
-                let value = sqlite3_column_type(stmt, 8) != SQLITE_NULL ? sqlite3_column_double(stmt, 8) : nil
-                let actual = sqlite3_column_type(stmt, 9) != SQLITE_NULL ? sqlite3_column_double(stmt, 9) : nil
-                let created = String(cString: sqlite3_column_text(stmt, 10))
-                let updated = String(cString: sqlite3_column_text(stmt, 11))
+                let pinned = sqlite3_column_int(stmt, 7) == 1
+                let positionsAsOf = sqlite3_column_text(stmt, 8).map { String(cString: $0) }
+                let value = sqlite3_column_type(stmt, 9) != SQLITE_NULL ? sqlite3_column_double(stmt, 9) : nil
+                let actual = sqlite3_column_type(stmt, 10) != SQLITE_NULL ? sqlite3_column_double(stmt, 10) : nil
+                let created = String(cString: sqlite3_column_text(stmt, 11))
+                let updated = String(cString: sqlite3_column_text(stmt, 12))
                 if let type = PortfolioThemeAssetUpdate.UpdateType(rawValue: typeStr) {
-                    item = PortfolioThemeAssetUpdate(id: id, themeId: themeId, instrumentId: instrumentId, title: title, bodyText: body, type: type, author: author, positionsAsOf: positionsAsOf, valueChf: value, actualPercent: actual, createdAt: created, updatedAt: updated)
+                    item = PortfolioThemeAssetUpdate(id: id, themeId: themeId, instrumentId: instrumentId, title: title, bodyMarkdown: body, type: type, author: author, pinned: pinned, positionsAsOf: positionsAsOf, valueChf: value, actualPercent: actual, createdAt: created, updatedAt: updated)
                 } else {
-                    LoggingService.shared.log("Invalid update type '\(typeStr)' for instrument update id \(id).", type: .warning, logger: .database)
+                    LoggingService.shared.log("Invalid update type '\\(typeStr)' for instrument update id \\(id).", type: .warning, logger: .database)
                 }
             }
         } else {
@@ -90,12 +96,12 @@ extension DatabaseManager {
         return item
     }
 
-    func createInstrumentUpdate(themeId: Int, instrumentId: Int, title: String, bodyText: String, type: PortfolioThemeAssetUpdate.UpdateType, author: String, breadcrumb: (positionsAsOf: String?, valueChf: Double?, actualPercent: Double?)? = nil, source: String? = nil) -> PortfolioThemeAssetUpdate? {
-        guard PortfolioThemeAssetUpdate.isValidTitle(title), PortfolioThemeAssetUpdate.isValidBody(bodyText) else {
+    func createInstrumentUpdate(themeId: Int, instrumentId: Int, title: String, bodyMarkdown: String, type: PortfolioThemeAssetUpdate.UpdateType, pinned: Bool, author: String, breadcrumb: (positionsAsOf: String?, valueChf: Double?, actualPercent: Double?)? = nil, source: String? = nil) -> PortfolioThemeAssetUpdate? {
+        guard PortfolioThemeAssetUpdate.isValidTitle(title), PortfolioThemeAssetUpdate.isValidBody(bodyMarkdown) else {
             LoggingService.shared.log("Invalid title/body for instrument update", type: .info, logger: .database)
             return nil
         }
-        let sql = "INSERT INTO PortfolioThemeAssetUpdate (theme_id, instrument_id, title, body_text, type, author, positions_asof, value_chf, actual_percent) VALUES (?,?,?,?,?,?,?,?,?)"
+        let sql = "INSERT INTO PortfolioThemeAssetUpdate (theme_id, instrument_id, title, body_text, body_markdown, type, author, pinned, positions_asof, value_chf, actual_percent) VALUES (?,?,?,?,?,?,?,?,?,?,?)"
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
             LoggingService.shared.log("prepare createInstrumentUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
@@ -105,39 +111,33 @@ extension DatabaseManager {
         sqlite3_bind_int(stmt, 2, Int32(instrumentId))
         let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
         sqlite3_bind_text(stmt, 3, title, -1, SQLITE_TRANSIENT)
-        sqlite3_bind_text(stmt, 4, bodyText, -1, SQLITE_TRANSIENT)
-        sqlite3_bind_text(stmt, 5, type.rawValue, -1, SQLITE_TRANSIENT)
-        sqlite3_bind_text(stmt, 6, author, -1, SQLITE_TRANSIENT)
-        if let pos = breadcrumb?.positionsAsOf {
-            sqlite3_bind_text(stmt, 7, pos, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 4, bodyMarkdown, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 5, bodyMarkdown, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 6, type.rawValue, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 7, author, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_int(stmt, 8, pinned ? 1 : 0)
+        if let bc = breadcrumb {
+            if let s = bc.positionsAsOf { sqlite3_bind_text(stmt, 9, s, -1, SQLITE_TRANSIENT) } else { sqlite3_bind_null(stmt, 9) }
+            if let v = bc.valueChf { sqlite3_bind_double(stmt, 10, v) } else { sqlite3_bind_null(stmt, 10) }
+            if let a = bc.actualPercent { sqlite3_bind_double(stmt, 11, a) } else { sqlite3_bind_null(stmt, 11) }
         } else {
-            sqlite3_bind_null(stmt, 7)
-        }
-        if let val = breadcrumb?.valueChf {
-            sqlite3_bind_double(stmt, 8, val)
-        } else {
-            sqlite3_bind_null(stmt, 8)
-        }
-        if let act = breadcrumb?.actualPercent {
-            sqlite3_bind_double(stmt, 9, act)
-        } else {
-            sqlite3_bind_null(stmt, 9)
+            sqlite3_bind_null(stmt, 9); sqlite3_bind_null(stmt, 10); sqlite3_bind_null(stmt, 11)
         }
         guard sqlite3_step(stmt) == SQLITE_DONE else {
             LoggingService.shared.log("createInstrumentUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
             sqlite3_finalize(stmt)
             return nil
         }
-        let id = Int(sqlite3_last_insert_rowid(db))
+        let newId = Int(sqlite3_last_insert_rowid(db))
         sqlite3_finalize(stmt)
-        guard let item = getInstrumentUpdate(id: id) else { return nil }
+        guard let item = getInstrumentUpdate(id: newId) else { return nil }
         var payload: [String: Any] = [
             "themeId": themeId,
             "instrumentId": instrumentId,
-            "updateId": id,
+            "updateId": newId,
             "actor": author,
             "op": "create",
-            "type": type.rawValue,
+            "pinned": pinned ? 1 : 0,
             "created_at": item.createdAt
         ]
         if let source = source { payload["source"] = source }
@@ -147,18 +147,22 @@ extension DatabaseManager {
         return item
     }
 
-    func updateInstrumentUpdate(id: Int, title: String?, bodyText: String?, type: PortfolioThemeAssetUpdate.UpdateType?, actor: String, expectedUpdatedAt: String, source: String? = nil) -> PortfolioThemeAssetUpdate? {
+    func updateInstrumentUpdate(id: Int, title: String?, bodyMarkdown: String?, type: PortfolioThemeAssetUpdate.UpdateType?, pinned: Bool?, actor: String, expectedUpdatedAt: String, source: String? = nil) -> PortfolioThemeAssetUpdate? {
         var sets: [String] = []
         if let title = title {
             guard PortfolioThemeAssetUpdate.isValidTitle(title) else { return nil }
             sets.append("title = ?")
         }
-        if let bodyText = bodyText {
-            guard PortfolioThemeAssetUpdate.isValidBody(bodyText) else { return nil }
+        if let bodyMarkdown = bodyMarkdown {
+            guard PortfolioThemeAssetUpdate.isValidBody(bodyMarkdown) else { return nil }
             sets.append("body_text = ?")
+            sets.append("body_markdown = ?")
         }
         if let _ = type {
             sets.append("type = ?")
+        }
+        if let _ = pinned {
+            sets.append("pinned = ?")
         }
         sets.append("updated_at = STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')")
         let sql = "UPDATE PortfolioThemeAssetUpdate SET \(sets.joined(separator: ", ")) WHERE id = ? AND updated_at = ?"
@@ -172,11 +176,15 @@ extension DatabaseManager {
         if let title = title {
             sqlite3_bind_text(stmt, idx, title, -1, SQLITE_TRANSIENT); idx += 1
         }
-        if let bodyText = bodyText {
-            sqlite3_bind_text(stmt, idx, bodyText, -1, SQLITE_TRANSIENT); idx += 1
+        if let bodyMarkdown = bodyMarkdown {
+            sqlite3_bind_text(stmt, idx, bodyMarkdown, -1, SQLITE_TRANSIENT); idx += 1
+            sqlite3_bind_text(stmt, idx, bodyMarkdown, -1, SQLITE_TRANSIENT); idx += 1
         }
         if let type = type {
             sqlite3_bind_text(stmt, idx, type.rawValue, -1, SQLITE_TRANSIENT); idx += 1
+        }
+        if let pinned = pinned {
+            sqlite3_bind_int(stmt, idx, pinned ? 1 : 0); idx += 1
         }
         sqlite3_bind_int(stmt, idx, Int32(id)); idx += 1
         sqlite3_bind_text(stmt, idx, expectedUpdatedAt, -1, SQLITE_TRANSIENT)
@@ -192,13 +200,17 @@ extension DatabaseManager {
         }
         sqlite3_finalize(stmt)
         guard let item = getInstrumentUpdate(id: id) else { return nil }
+        var op = "update"
+        if let pinned = pinned, title == nil && bodyMarkdown == nil && type == nil {
+            op = pinned ? "pin" : "unpin"
+        }
         var payload: [String: Any] = [
             "themeId": item.themeId,
             "instrumentId": item.instrumentId,
             "updateId": id,
             "actor": actor,
-            "op": "update",
-            "type": item.type.rawValue,
+            "op": op,
+            "pinned": item.pinned ? 1 : 0,
             "updated_at": item.updatedAt
         ]
         if let source = source { payload["source"] = source }
@@ -211,12 +223,16 @@ extension DatabaseManager {
     func deleteInstrumentUpdate(id: Int, actor: String, source: String? = nil) -> Bool {
         var themeId: Int = 0
         var instrumentId: Int = 0
+        var pinned: Int32 = 0
+        var updatedAt: String = ""
         var stmt: OpaquePointer?
-        if sqlite3_prepare_v2(db, "SELECT theme_id, instrument_id FROM PortfolioThemeAssetUpdate WHERE id = ?", -1, &stmt, nil) == SQLITE_OK {
+        if sqlite3_prepare_v2(db, "SELECT theme_id, instrument_id, pinned, updated_at FROM PortfolioThemeAssetUpdate WHERE id = ?", -1, &stmt, nil) == SQLITE_OK {
             sqlite3_bind_int(stmt, 1, Int32(id))
             if sqlite3_step(stmt) == SQLITE_ROW {
                 themeId = Int(sqlite3_column_int(stmt, 0))
                 instrumentId = Int(sqlite3_column_int(stmt, 1))
+                pinned = sqlite3_column_int(stmt, 2)
+                updatedAt = String(cString: sqlite3_column_text(stmt, 3))
             }
         }
         sqlite3_finalize(stmt)
@@ -237,7 +253,9 @@ extension DatabaseManager {
             "instrumentId": instrumentId,
             "updateId": id,
             "actor": actor,
-            "op": "delete"
+            "op": "delete",
+            "pinned": Int(pinned),
+            "updated_at": updatedAt
         ]
         if let source = source { payload["source"] = source }
         if let data = try? JSONSerialization.data(withJSONObject: payload), let log = String(data: data, encoding: .utf8) {
@@ -263,4 +281,3 @@ extension DatabaseManager {
         return count
     }
 }
-

--- a/DragonShield/Models/PortfolioThemeAssetUpdate.swift
+++ b/DragonShield/Models/PortfolioThemeAssetUpdate.swift
@@ -1,7 +1,8 @@
 // DragonShield/Models/PortfolioThemeAssetUpdate.swift
-// MARK: - Version 1.0
+// MARK: - Version 1.1
 // MARK: - History
 // - 1.0: Initial instrument-level update model for Step 7A.
+// - 1.0 -> 1.1: Add Markdown body and pin flag for Phase 7B.
 
 import Foundation
 
@@ -17,9 +18,10 @@ struct PortfolioThemeAssetUpdate: Identifiable, Codable {
     let themeId: Int
     let instrumentId: Int
     var title: String
-    var bodyText: String
+    var bodyMarkdown: String
     var type: UpdateType
     let author: String
+    var pinned: Bool
     var positionsAsOf: String?
     var valueChf: Double?
     var actualPercent: Double?

--- a/DragonShield/Views/InstrumentUpdatesView.swift
+++ b/DragonShield/Views/InstrumentUpdatesView.swift
@@ -1,7 +1,8 @@
 // DragonShield/Views/InstrumentUpdatesView.swift
-// MARK: - Version 1.0
+// MARK: - Version 1.1
 // MARK: - History
 // - 1.0: Initial instrument updates list for Step 7A.
+// - 1.0 -> 1.1: Support Markdown rendering, pinning, and ordering toggle for Phase 7B.
 
 import SwiftUI
 
@@ -20,6 +21,7 @@ struct InstrumentUpdatesView: View {
     @State private var isArchived = false
     @State private var instrumentExists = true
     @State private var showDeleteConfirm = false
+    @State private var pinnedFirst = true
     @State private var selectedId: Int?
 
     @Environment(\.dismiss) private var dismiss
@@ -45,31 +47,66 @@ struct InstrumentUpdatesView: View {
                 Button("+ New Update") { showEditor = true }
                     .disabled(!instrumentExists)
                 Spacer()
+                Toggle("Pinned first", isOn: $pinnedFirst)
+                    .toggleStyle(.checkbox)
+                    .onChange(of: pinnedFirst) { _ in load() }
             }
             .padding(.horizontal, 16)
             List(selection: $selectedId) {
                 ForEach(updates) { update in
                     VStack(alignment: .leading, spacing: 4) {
-                        Text("\(DateFormatting.userFriendly(update.createdAt))  •  \(update.author)  •  \(update.type.rawValue)\(update.updatedAt > update.createdAt ? "  •  edited" : "")")
-                            .font(.subheadline)
+                        HStack {
+                            Text("\(DateFormatting.userFriendly(update.createdAt)) • \(update.author) • \(update.type.rawValue)\(update.updatedAt > update.createdAt ? " • edited" : "")")
+                                .font(.subheadline)
+                            Spacer()
+                            Text(update.pinned ? "★ Pinned" : "☆")
+                        }
                         Text("Title: \(update.title)").fontWeight(.semibold)
-                        Text(update.bodyText)
+                        Text(MarkdownRenderer.attributedString(from: update.bodyMarkdown))
+                            .lineLimit(3)
                         Text("Breadcrumb: Positions \(DateFormatting.userFriendly(update.positionsAsOf)) • Value CHF \(formatted(update.valueChf)) • Actual \(formattedPct(update.actualPercent))")
                             .font(.caption)
                             .foregroundColor(.secondary)
+                        HStack {
+                            Button("Edit") { editingUpdate = update }
+                            Button(update.pinned ? "Unpin" : "Pin") {
+                                DispatchQueue.global(qos: .userInitiated).async {
+                                    _ = dbManager.updateInstrumentUpdate(id: update.id, title: nil, bodyMarkdown: nil, type: nil, pinned: !update.pinned, actor: NSFullUserName(), expectedUpdatedAt: update.updatedAt)
+                                    DispatchQueue.main.async {
+                                        load()
+                                        selectedId = update.id
+                                    }
+                                }
+                            }
+                            Button("Delete", role: .destructive) {
+                                selectedId = update.id
+                                showDeleteConfirm = true
+                            }
+                        }
+                        .font(.caption)
                     }
                     .tag(update.id)
-                    .contextMenu {
-                        Button("Edit") { editingUpdate = update }
-                        Button("Delete", role: .destructive) { selectedId = update.id; showDeleteConfirm = true }
-                    }
                 }
             }
             Divider()
             HStack {
                 Button("Edit") { if let u = selectedUpdate { editingUpdate = u } }
                     .disabled(selectedUpdate == nil)
-                Button("Delete") { showDeleteConfirm = true }
+                Button(selectedUpdate?.pinned == true ? "Unpin" : "Pin") {
+                    if let u = selectedUpdate {
+                        DispatchQueue.global(qos: .userInitiated).async {
+                            _ = dbManager.updateInstrumentUpdate(id: u.id, title: nil, bodyMarkdown: nil, type: nil, pinned: !(u.pinned), actor: NSFullUserName(), expectedUpdatedAt: u.updatedAt)
+                            DispatchQueue.main.async {
+                                load()
+                                selectedId = u.id
+                            }
+                        }
+                    }
+                }
+                    .disabled(selectedUpdate == nil)
+                Button("Delete") {
+                    showDeleteConfirm = true
+                }
                     .disabled(selectedUpdate == nil)
                 Spacer()
                 Button("Close") { onClose(); dismiss() }
@@ -99,7 +136,7 @@ struct InstrumentUpdatesView: View {
     }
 
     private func load() {
-        updates = dbManager.listInstrumentUpdates(themeId: themeId, instrumentId: instrumentId)
+        updates = dbManager.listInstrumentUpdates(themeId: themeId, instrumentId: instrumentId, pinnedFirst: pinnedFirst)
         isArchived = dbManager.getPortfolioTheme(id: themeId)?.archivedAt != nil
         instrumentExists = dbManager.listThemeAssets(themeId: themeId).contains { $0.instrumentId == instrumentId }
     }
@@ -112,6 +149,7 @@ struct InstrumentUpdatesView: View {
         guard let id = selectedUpdate?.id else { return }
         if dbManager.deleteInstrumentUpdate(id: id, actor: NSFullUserName()) {
             load()
+            selectedId = nil
         }
         showDeleteConfirm = false
     }

--- a/DragonShield/db/migrations/017_portfolio_theme_asset_update_enrich.sql
+++ b/DragonShield/db/migrations/017_portfolio_theme_asset_update_enrich.sql
@@ -1,0 +1,16 @@
+-- migrate:up
+-- Purpose: Add Markdown body and pin flag to instrument updates for richer formatting and prioritization.
+-- Assumptions: PortfolioThemeAssetUpdate table exists from migration 016 with body_text column.
+-- Idempotency: use IF NOT EXISTS and content checks where possible
+ALTER TABLE PortfolioThemeAssetUpdate
+  ADD COLUMN body_markdown TEXT NULL;
+ALTER TABLE PortfolioThemeAssetUpdate
+  ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0 CHECK (pinned IN (0,1));
+UPDATE PortfolioThemeAssetUpdate
+  SET body_markdown = COALESCE(body_text, '');
+CREATE INDEX IF NOT EXISTS idx_ptau_theme_instr_pinned_order
+  ON PortfolioThemeAssetUpdate(theme_id, instrument_id, pinned DESC, created_at DESC);
+
+-- migrate:down
+DROP INDEX IF EXISTS idx_ptau_theme_instr_pinned_order;
+-- SQLite lacks DROP COLUMN; rollback requires restoring backup taken before migration 017.

--- a/DragonShieldTests/PortfolioThemeAssetUpdateTests.swift
+++ b/DragonShieldTests/PortfolioThemeAssetUpdateTests.swift
@@ -27,17 +27,24 @@ final class PortfolioThemeAssetUpdateTests: XCTestCase {
     }
 
     func testCreateEditDeleteFlow() {
-        let first = manager.createInstrumentUpdate(themeId: 1, instrumentId: 42, title: "Init", bodyText: "Start", type: .General, author: "Alice", breadcrumb: nil)
+        let first = manager.createInstrumentUpdate(themeId: 1, instrumentId: 42, title: "Init", bodyMarkdown: "Start", type: .General, pinned: false, author: "Alice", breadcrumb: nil)
         XCTAssertNotNil(first)
-        let second = manager.createInstrumentUpdate(themeId: 1, instrumentId: 42, title: "Second", bodyText: "More", type: .Research, author: "Bob", breadcrumb: nil)
+        let second = manager.createInstrumentUpdate(themeId: 1, instrumentId: 42, title: "Second", bodyMarkdown: "More", type: .Research, pinned: false, author: "Bob", breadcrumb: nil)
         XCTAssertNotNil(second)
         var list = manager.listInstrumentUpdates(themeId: 1, instrumentId: 42)
         XCTAssertEqual(list.count, 2)
         XCTAssertEqual(list.first?.id, second!.id)
-        let updated = manager.updateInstrumentUpdate(id: first!.id, title: "Changed", bodyText: nil, type: .Risk, actor: "Alice", expectedUpdatedAt: first!.updatedAt)
+        // Pin first update and ensure it bubbles to top
+        let pinned = manager.updateInstrumentUpdate(id: first!.id, title: nil, bodyMarkdown: nil, type: nil, pinned: true, actor: "Alice", expectedUpdatedAt: first!.updatedAt)
+        XCTAssertTrue(pinned?.pinned == true)
+        list = manager.listInstrumentUpdates(themeId: 1, instrumentId: 42)
+        XCTAssertEqual(list.first?.id, first!.id)
+        // Unpin and update title
+        let updated = manager.updateInstrumentUpdate(id: first!.id, title: "Changed", bodyMarkdown: nil, type: .Risk, pinned: false, actor: "Alice", expectedUpdatedAt: pinned!.updatedAt)
         XCTAssertEqual(updated?.title, "Changed")
         XCTAssertEqual(updated?.type, .Risk)
-        let conflict = manager.updateInstrumentUpdate(id: first!.id, title: "Bad", bodyText: nil, type: nil, actor: "Bob", expectedUpdatedAt: "bogus")
+        XCTAssertTrue(updated?.pinned == false)
+        let conflict = manager.updateInstrumentUpdate(id: first!.id, title: "Bad", bodyMarkdown: nil, type: nil, pinned: nil, actor: "Bob", expectedUpdatedAt: "bogus")
         XCTAssertNil(conflict)
         XCTAssertTrue(manager.deleteInstrumentUpdate(id: first!.id, actor: "Alice"))
         XCTAssertEqual(manager.countInstrumentUpdates(themeId: 1, instrumentId: 42), 1)


### PR DESCRIPTION
## Summary
- support Markdown bodies and pin/unpin for instrument updates
- enable pinned-first ordering with session toggle and preserve selection on pin
- add migration for body_markdown and pinned fields

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `sqlite3 :memory: <<'SQL' ... SQL`
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a8caaa07e48323aaa23604592d05e0