### PR TITLE
feat: add theme status color presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Introduce preset color picker with custom hex option for Theme Statuses
 - Refine Overview update rows with inline toggle, right-aligned actions, and date filter including today
 - Add Overview tab with read-only Update Reader for Portfolio Theme details
 - Flesh out Portfolio Theme Overview with KPIs, filters, and update actions

--- a/DragonShield/Models/ThemeStatusColorPresets.swift
+++ b/DragonShield/Models/ThemeStatusColorPresets.swift
@@ -1,0 +1,46 @@
+// DragonShield/Models/ThemeStatusColorPresets.swift
+// MARK: - Version 1.0
+// MARK: - History
+// - Initial creation: Defines preset colors for Theme Status picker.
+
+import Foundation
+
+struct ThemeStatusColorPreset: Identifiable, Equatable {
+    let name: String
+    let hex: String
+    var id: String { hex.lowercased() }
+}
+
+let themeStatusColorPresets: [ThemeStatusColorPreset] = [
+    ThemeStatusColorPreset(name: "Red", hex: "#EF4444"),
+    ThemeStatusColorPreset(name: "Orange", hex: "#F97316"),
+    ThemeStatusColorPreset(name: "Amber", hex: "#F59E0B"),
+    ThemeStatusColorPreset(name: "Yellow", hex: "#EAB308"),
+    ThemeStatusColorPreset(name: "Lime", hex: "#84CC16"),
+    ThemeStatusColorPreset(name: "Green", hex: "#22C55E"),
+    ThemeStatusColorPreset(name: "Emerald", hex: "#10B981"),
+    ThemeStatusColorPreset(name: "Teal", hex: "#14B8A6"),
+    ThemeStatusColorPreset(name: "Cyan", hex: "#06B6D4"),
+    ThemeStatusColorPreset(name: "Sky", hex: "#0EA5E9"),
+    ThemeStatusColorPreset(name: "Blue", hex: "#3B82F6"),
+    ThemeStatusColorPreset(name: "Indigo", hex: "#6366F1"),
+    ThemeStatusColorPreset(name: "Violet", hex: "#8B5CF6"),
+    ThemeStatusColorPreset(name: "Purple", hex: "#A855F7"),
+    ThemeStatusColorPreset(name: "Fuchsia", hex: "#D946EF"),
+    ThemeStatusColorPreset(name: "Pink", hex: "#EC4899"),
+    ThemeStatusColorPreset(name: "Rose", hex: "#F43F5E"),
+    ThemeStatusColorPreset(name: "Slate", hex: "#64748B"),
+    ThemeStatusColorPreset(name: "Gray", hex: "#6B7280"),
+    ThemeStatusColorPreset(name: "Stone", hex: "#78716C")
+]
+
+extension ThemeStatusColorPreset {
+    static var `default`: ThemeStatusColorPreset {
+        themeStatusColorPresets.first { $0.name == "Emerald" }!
+    }
+
+    static func matching(hex: String) -> ThemeStatusColorPreset? {
+        themeStatusColorPresets.first { $0.hex.caseInsensitiveCompare(hex) == .orderedSame }
+    }
+}
+

--- a/DragonShield/Views/ThemeStatusSettingsView.swift
+++ b/DragonShield/Views/ThemeStatusSettingsView.swift
@@ -1,7 +1,8 @@
 // DragonShield/Views/ThemeStatusSettingsView.swift
-// MARK: - Version 1.0
+// MARK: - Version 1.1
 // MARK: - History
 // - Initial creation: Manage PortfolioThemeStatus entries.
+// - 1.1: Add preset color picker with custom hex option and contrast-aware chips.
 
 import SwiftUI
 
@@ -20,7 +21,8 @@ struct ThemeStatusSettingsView: View {
                     HStack {
                         Text(status.code).frame(width: 80, alignment: .leading)
                         Text(status.name).frame(width: 120, alignment: .leading)
-                        Text(status.colorHex).frame(width: 80, alignment: .leading)
+                        ColorChip(text: status.colorHex, hex: status.colorHex)
+                            .frame(width: 100, alignment: .leading)
                         Spacer()
                         Button(action: { dbManager.setDefaultThemeStatus(id: status.id); load() }) {
                             Image(systemName: status.isDefault ? "largecircle.fill.circle" : "circle")
@@ -34,7 +36,7 @@ struct ThemeStatusSettingsView: View {
             }
             HStack {
                 Button("+ Add Status") {
-                    editing = PortfolioThemeStatus(id: 0, code: "", name: "", colorHex: "#000000", isDefault: false)
+                    editing = PortfolioThemeStatus(id: 0, code: "", name: "", colorHex: "", isDefault: false)
                     isNew = true
                 }
                 Spacer()
@@ -76,8 +78,20 @@ struct ThemeStatusEditView: View {
 
     @State private var code: String = ""
     @State private var name: String = ""
-    @State private var color: String = ""
+    @State private var selection: String = ""
+    @State private var customHex: String = ""
     @State private var isDefault: Bool = false
+
+    private var currentHex: String {
+        selection == "custom" ? customHex : selection
+    }
+
+    private var selectedName: String {
+        if selection == "custom" {
+            return "Custom"
+        }
+        return ThemeStatusColorPreset.matching(hex: selection)?.name ?? "Custom"
+    }
 
     var body: some View {
         Form {
@@ -87,18 +101,61 @@ struct ThemeStatusEditView: View {
                 Text("Code: \(status.code)")
             }
             TextField("Name", text: $name)
-            TextField("Color", text: $color)
+            Picker(selection: $selection, label: HStack {
+                Rectangle()
+                    .fill(Color(hex: currentHex))
+                    .frame(width: 16, height: 16)
+                    .cornerRadius(2)
+                Text(selectedName)
+            }) {
+                ForEach(themeStatusColorPresets) { preset in
+                    HStack {
+                        Rectangle()
+                            .fill(Color(hex: preset.hex))
+                            .frame(width: 16, height: 16)
+                            .cornerRadius(2)
+                        Text(preset.name)
+                    }
+                    .tag(preset.hex)
+                }
+                Divider()
+                Text("Custom…").tag("custom")
+            }
+            .pickerStyle(MenuPickerStyle())
+            .onChange(of: selection) { newValue in
+                if newValue != "custom" {
+                    customHex = newValue
+                }
+            }
+
+            if selection == "custom" {
+                HStack {
+                    TextField("Hex", text: $customHex)
+                    Rectangle()
+                        .fill(Color(hex: customHex))
+                        .frame(width: 24, height: 24)
+                        .cornerRadius(4)
+                        .overlay(RoundedRectangle(cornerRadius: 4).stroke(Color.secondary))
+                }
+                if !PortfolioThemeStatus.isValidColor(customHex) {
+                    Text("Use format #RRGGBB.")
+                        .foregroundColor(.red)
+                        .font(.caption)
+                }
+            }
+
             Toggle("Default", isOn: $isDefault)
             HStack {
                 Spacer()
                 Button("Save") {
+                    let hex = currentHex
                     let updatedStatus: PortfolioThemeStatus
                     if isNew {
-                        updatedStatus = PortfolioThemeStatus(id: 0, code: code.uppercased(), name: name, colorHex: color, isDefault: isDefault)
+                        updatedStatus = PortfolioThemeStatus(id: 0, code: code.uppercased(), name: name, colorHex: hex, isDefault: isDefault)
                     } else {
                         var updated = status
                         updated.name = name
-                        updated.colorHex = color
+                        updated.colorHex = hex
                         updated.isDefault = isDefault
                         updatedStatus = updated
                     }
@@ -112,14 +169,37 @@ struct ThemeStatusEditView: View {
         .onAppear {
             code = status.code
             name = status.name
-            color = status.colorHex
+            if isNew {
+                let def = ThemeStatusColorPreset.default
+                selection = def.hex
+                customHex = def.hex
+            } else if let match = ThemeStatusColorPreset.matching(hex: status.colorHex) {
+                selection = match.hex
+                customHex = match.hex
+            } else {
+                selection = "custom"
+                customHex = status.colorHex
+            }
             isDefault = status.isDefault
         }
-        .frame(minWidth: 300, minHeight: 200)
+        .frame(minWidth: 300, minHeight: 240)
     }
 
     private var valid: Bool {
         let codeOk = isNew ? PortfolioThemeStatus.isValidCode(code) : true
-        return codeOk && PortfolioThemeStatus.isValidName(name) && PortfolioThemeStatus.isValidColor(color)
+        return codeOk && PortfolioThemeStatus.isValidName(name) && PortfolioThemeStatus.isValidColor(currentHex)
+    }
+}
+
+struct ColorChip: View {
+    let text: String
+    let hex: String
+
+    var body: some View {
+        Text(text)
+            .padding(4)
+            .background(Color(hex: hex))
+            .foregroundColor(Color.textColor(forHex: hex))
+            .cornerRadius(4)
     }
 }

--- a/DragonShield/helpers/Color+Hex.swift
+++ b/DragonShield/helpers/Color+Hex.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+extension Color {
+    init(hex: String) {
+        var hex = hex
+        if hex.hasPrefix("#") {
+            hex.removeFirst()
+        }
+        guard hex.count == 6, let int = Int(hex, radix: 16) else {
+            self = .clear
+            return
+        }
+        let r = Double((int >> 16) & 0xFF) / 255.0
+        let g = Double((int >> 8) & 0xFF) / 255.0
+        let b = Double(int & 0xFF) / 255.0
+        self.init(red: r, green: g, blue: b)
+    }
+
+    static func textColor(forHex hex: String) -> Color {
+        var hex = hex
+        if hex.hasPrefix("#") {
+            hex.removeFirst()
+        }
+        guard hex.count == 6, let int = Int(hex, radix: 16) else {
+            return .black
+        }
+        let r = Double((int >> 16) & 0xFF) / 255.0
+        let g = Double((int >> 8) & 0xFF) / 255.0
+        let b = Double(int & 0xFF) / 255.0
+        let luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
+        return luminance < 0.5 ? .white : .black
+    }
+}

--- a/DragonShieldTests/ThemeStatusColorPresetsTests.swift
+++ b/DragonShieldTests/ThemeStatusColorPresetsTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+import SwiftUI
+@testable import DragonShield
+
+final class ThemeStatusColorPresetsTests: XCTestCase {
+    func testPresetCount() {
+        XCTAssertEqual(themeStatusColorPresets.count, 20)
+    }
+
+    func testContainsEmeraldDefault() {
+        XCTAssertTrue(themeStatusColorPresets.contains { $0.name == "Emerald" && $0.hex == "#10B981" })
+    }
+
+    func testTextColorContrast() {
+        #if os(macOS)
+        XCTAssertEqual(NSColor(Color.textColor(forHex: "#6366F1")), NSColor.white)
+        XCTAssertEqual(NSColor(Color.textColor(forHex: "#EAB308")), NSColor.black)
+        #else
+        XCTAssertEqual(UIColor(Color.textColor(forHex: "#6366F1")), UIColor.white)
+        XCTAssertEqual(UIColor(Color.textColor(forHex: "#EAB308")), UIColor.black)
+        #endif
+    }
+}


### PR DESCRIPTION
## Summary
- add 20 preset theme status colors with Emerald default and custom hex support
- render color chips with automatic text contrast in settings list and editor
- test preset definitions and contrast calculations

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -scheme DragonShield -destination 'platform=macOS' build` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68aa24885444832386296ee3d235abc5