### PR TITLE
feat: redesign theme status sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Introduce preset color picker with custom hex option for Theme Statuses
+- Refine Theme Status editor sheet with aligned grid layout and inline validation
 - Refine Overview update rows with inline toggle, right-aligned actions, and date filter including today
 - Add Overview tab with read-only Update Reader for Portfolio Theme details
 - Flesh out Portfolio Theme Overview with KPIs, filters, and update actions

--- a/DragonShield/Models/PortfolioThemeStatus.swift
+++ b/DragonShield/Models/PortfolioThemeStatus.swift
@@ -14,12 +14,14 @@ struct PortfolioThemeStatus: Identifiable {
     var isDefault: Bool
 
     static func isValidCode(_ code: String) -> Bool {
-        let pattern = "^[A-Z][A-Z0-9_]{1,30}$"
-        return code.range(of: pattern, options: .regularExpression) != nil
+        let trimmed = code.trimmingCharacters(in: .whitespacesAndNewlines)
+        let pattern = "^[A-Z][A-Z0-9_]{1,9}$"
+        return trimmed.range(of: pattern, options: .regularExpression) != nil
     }
 
     static func isValidName(_ name: String) -> Bool {
-        return !name.isEmpty && name.count <= 64
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.count >= 2 && trimmed.count <= 40
     }
 
     static func isValidColor(_ hex: String) -> Bool {

--- a/DragonShield/Models/ThemeStatusColorPresets.swift
+++ b/DragonShield/Models/ThemeStatusColorPresets.swift
@@ -1,0 +1,46 @@
+// DragonShield/Models/ThemeStatusColorPresets.swift
+// MARK: - Version 1.0
+// MARK: - History
+// - Initial creation: Defines preset colors for Theme Status picker.
+
+import Foundation
+
+struct ThemeStatusColorPreset: Identifiable, Equatable {
+    let name: String
+    let hex: String
+    var id: String { hex.lowercased() }
+}
+
+let themeStatusColorPresets: [ThemeStatusColorPreset] = [
+    ThemeStatusColorPreset(name: "Red", hex: "#EF4444"),
+    ThemeStatusColorPreset(name: "Orange", hex: "#F97316"),
+    ThemeStatusColorPreset(name: "Amber", hex: "#F59E0B"),
+    ThemeStatusColorPreset(name: "Yellow", hex: "#EAB308"),
+    ThemeStatusColorPreset(name: "Lime", hex: "#84CC16"),
+    ThemeStatusColorPreset(name: "Green", hex: "#22C55E"),
+    ThemeStatusColorPreset(name: "Emerald", hex: "#10B981"),
+    ThemeStatusColorPreset(name: "Teal", hex: "#14B8A6"),
+    ThemeStatusColorPreset(name: "Cyan", hex: "#06B6D4"),
+    ThemeStatusColorPreset(name: "Sky", hex: "#0EA5E9"),
+    ThemeStatusColorPreset(name: "Blue", hex: "#3B82F6"),
+    ThemeStatusColorPreset(name: "Indigo", hex: "#6366F1"),
+    ThemeStatusColorPreset(name: "Violet", hex: "#8B5CF6"),
+    ThemeStatusColorPreset(name: "Purple", hex: "#A855F7"),
+    ThemeStatusColorPreset(name: "Fuchsia", hex: "#D946EF"),
+    ThemeStatusColorPreset(name: "Pink", hex: "#EC4899"),
+    ThemeStatusColorPreset(name: "Rose", hex: "#F43F5E"),
+    ThemeStatusColorPreset(name: "Slate", hex: "#64748B"),
+    ThemeStatusColorPreset(name: "Gray", hex: "#6B7280"),
+    ThemeStatusColorPreset(name: "Stone", hex: "#78716C")
+]
+
+extension ThemeStatusColorPreset {
+    static var `default`: ThemeStatusColorPreset {
+        themeStatusColorPresets.first { $0.name == "Emerald" }!
+    }
+
+    static func matching(hex: String) -> ThemeStatusColorPreset? {
+        themeStatusColorPresets.first { $0.hex.caseInsensitiveCompare(hex) == .orderedSame }
+    }
+}
+

--- a/DragonShield/Models/ThemeStatusSaveError.swift
+++ b/DragonShield/Models/ThemeStatusSaveError.swift
@@ -1,0 +1,14 @@
+// DragonShield/Models/ThemeStatusSaveError.swift
+// MARK: - Version 1.0
+// MARK: - History
+// - Initial creation: Represents errors when saving Theme Status.
+
+import Foundation
+
+enum ThemeStatusSaveError: Error, Equatable {
+    case codeInvalid
+    case codeExists
+    case nameExists
+    case couldNotSetDefault
+    case unknown
+}

--- a/DragonShield/Views/ThemeStatusSettingsView.swift
+++ b/DragonShield/Views/ThemeStatusSettingsView.swift
@@ -1,7 +1,9 @@
 // DragonShield/Views/ThemeStatusSettingsView.swift
-// MARK: - Version 1.0
+// MARK: - Version 1.2
 // MARK: - History
 // - Initial creation: Manage PortfolioThemeStatus entries.
+// - 1.1: Add preset color picker with custom hex option and contrast-aware chips.
+// - 1.2: Professional sheet layout with grid alignment and inline validation.
 
 import SwiftUI
 
@@ -10,8 +12,6 @@ struct ThemeStatusSettingsView: View {
     @State private var statuses: [PortfolioThemeStatus] = []
     @State private var editing: PortfolioThemeStatus?
     @State private var isNew: Bool = false
-    @State private var showErrorAlert: Bool = false
-    @State private var errorMessage: String = ""
 
     var body: some View {
         VStack {
@@ -20,7 +20,9 @@ struct ThemeStatusSettingsView: View {
                     HStack {
                         Text(status.code).frame(width: 80, alignment: .leading)
                         Text(status.name).frame(width: 120, alignment: .leading)
-                        Text(status.colorHex).frame(width: 80, alignment: .leading)
+                        ColorSwatch(hex: status.colorHex)
+                            .help(ThemeStatusColorPreset.matching(hex: status.colorHex).map { "\($0.name) (\($0.hex))" } ?? status.colorHex)
+                            .frame(width: 30, alignment: .leading)
                         Spacer()
                         Button(action: { dbManager.setDefaultThemeStatus(id: status.id); load() }) {
                             Image(systemName: status.isDefault ? "largecircle.fill.circle" : "circle")
@@ -34,7 +36,7 @@ struct ThemeStatusSettingsView: View {
             }
             HStack {
                 Button("+ Add Status") {
-                    editing = PortfolioThemeStatus(id: 0, code: "", name: "", colorHex: "#000000", isDefault: false)
+                    editing = PortfolioThemeStatus(id: 0, code: "", name: "", colorHex: "", isDefault: false)
                     isNew = true
                 }
                 Spacer()
@@ -43,23 +45,10 @@ struct ThemeStatusSettingsView: View {
         .navigationTitle("Theme Statuses")
         .onAppear(perform: load)
         .sheet(item: $editing, onDismiss: load) { status in
-            ThemeStatusEditView(status: status, isNew: isNew) { updated in
-                let ok: Bool
-                if isNew {
-                    ok = dbManager.insertPortfolioThemeStatus(code: updated.code, name: updated.name, colorHex: updated.colorHex, isDefault: updated.isDefault)
-                } else {
-                    ok = dbManager.updatePortfolioThemeStatus(id: updated.id, name: updated.name, colorHex: updated.colorHex, isDefault: updated.isDefault)
-                }
-                if !ok {
-                    errorMessage = "Failed to save theme status"
-                    showErrorAlert = true
-                }
+            ThemeStatusEditView(status: status, isNew: isNew) {
+                load()
             }
-        }
-        .alert("Database Error", isPresented: $showErrorAlert) {
-            Button("OK", role: .cancel) { }
-        } message: {
-            Text(errorMessage)
+            .environmentObject(dbManager)
         }
     }
 
@@ -69,57 +58,213 @@ struct ThemeStatusSettingsView: View {
 }
 
 struct ThemeStatusEditView: View {
+    @EnvironmentObject var dbManager: DatabaseManager
     @State var status: PortfolioThemeStatus
     let isNew: Bool
-    var onSave: (PortfolioThemeStatus) -> Void
+    var onComplete: () -> Void
     @Environment(\.dismiss) private var dismiss
 
     @State private var code: String = ""
     @State private var name: String = ""
-    @State private var color: String = ""
+    @State private var selection: String = ThemeStatusColorPreset.default.hex
+    @State private var customHex: String = ThemeStatusColorPreset.default.hex
     @State private var isDefault: Bool = false
 
+    @State private var codeError: String?
+    @State private var nameError: String?
+    @State private var customError: String?
+
+    enum Field: Hashable { case code, name, customHex }
+    @FocusState private var focus: Field?
+
+    private var currentHex: String { selection == "custom" ? customHex : selection }
+    private var selectedName: String { selection == "custom" ? "Custom" : ThemeStatusColorPreset.matching(hex: selection)?.name ?? "Custom" }
+
     var body: some View {
-        Form {
-            if isNew {
-                TextField("Code", text: $code)
-            } else {
-                Text("Code: \(status.code)")
-            }
-            TextField("Name", text: $name)
-            TextField("Color", text: $color)
-            Toggle("Default", isOn: $isDefault)
+        VStack(alignment: .leading, spacing: 16) {
             HStack {
+                Text(isNew ? "Add Theme Status" : "Edit Theme Status")
+                    .font(.title2).bold()
                 Spacer()
-                Button("Save") {
-                    let updatedStatus: PortfolioThemeStatus
-                    if isNew {
-                        updatedStatus = PortfolioThemeStatus(id: 0, code: code.uppercased(), name: name, colorHex: color, isDefault: isDefault)
-                    } else {
-                        var updated = status
-                        updated.name = name
-                        updated.colorHex = color
-                        updated.isDefault = isDefault
-                        updatedStatus = updated
-                    }
-                    onSave(updatedStatus)
-                    dismiss()
-                }
-                .disabled(!valid)
                 Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Save") { save() }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(!valid)
             }
+            Divider()
+            Grid(alignment: .leading, horizontalSpacing: 8, verticalSpacing: 12) {
+                GridRow {
+                    Text("Code").frame(width: 140, alignment: .leading)
+                    TextField("Code", text: $code)
+                        .textInputAutocapitalization(.characters)
+                        .disableAutocorrection(true)
+                        .focused($focus, equals: .code)
+                        .disabled(!isNew)
+                        .onSubmit { save() }
+                    Spacer()
+                }
+                if let codeError {
+                    GridRow {
+                        Spacer().frame(width: 140)
+                        Text(codeError).foregroundColor(.red).font(.caption)
+                        Spacer()
+                    }
+                }
+                GridRow {
+                    Text("Name").frame(width: 140, alignment: .leading)
+                    TextField("Name", text: $name)
+                        .focused($focus, equals: .name)
+                        .onSubmit { save() }
+                    Spacer()
+                }
+                if let nameError {
+                    GridRow {
+                        Spacer().frame(width: 140)
+                        Text(nameError).foregroundColor(.red).font(.caption)
+                        Spacer()
+                    }
+                }
+                GridRow {
+                    Text("Color").frame(width: 140, alignment: .leading)
+                    Picker(selection: $selection, label: HStack {
+                        Rectangle()
+                            .fill(Color(hex: currentHex))
+                            .frame(width: 16, height: 16)
+                            .cornerRadius(3)
+                            .overlay(RoundedRectangle(cornerRadius: 3).stroke(Color.secondary))
+                        Text(selectedName)
+                    }) {
+                        ForEach(themeStatusColorPresets) { preset in
+                            HStack {
+                                Rectangle()
+                                    .fill(Color(hex: preset.hex))
+                                    .frame(width: 16, height: 16)
+                                    .cornerRadius(3)
+                                    .overlay(RoundedRectangle(cornerRadius: 3).stroke(Color.secondary))
+                                Text(preset.name)
+                            }
+                            .tag(preset.hex)
+                            .accessibilityLabel("\(preset.name), \(preset.hex)")
+                        }
+                        Divider()
+                        Text("Custom…").tag("custom")
+                    }
+                    .pickerStyle(MenuPickerStyle())
+                    Spacer()
+                }
+                if selection == "custom" {
+                    GridRow {
+                        Text("Custom Hex").frame(width: 140, alignment: .leading)
+                        HStack {
+                            TextField("#RRGGBB", text: $customHex)
+                                .focused($focus, equals: .customHex)
+                                .onSubmit { save() }
+                            Rectangle()
+                                .fill(Color(hex: customHex))
+                                .frame(width: 24, height: 24)
+                                .cornerRadius(4)
+                                .overlay(RoundedRectangle(cornerRadius: 4).stroke(Color.secondary))
+                        }
+                        Spacer()
+                    }
+                    if let customError {
+                        GridRow {
+                            Spacer().frame(width: 140)
+                            Text(customError).foregroundColor(.red).font(.caption)
+                            Spacer()
+                        }
+                    }
+                }
+                GridRow {
+                    Text("Default").frame(width: 140, alignment: .leading)
+                    Toggle("Set as default", isOn: $isDefault)
+                    Spacer()
+                }
+            }
+            Spacer()
         }
-        .onAppear {
-            code = status.code
-            name = status.name
-            color = status.colorHex
-            isDefault = status.isDefault
-        }
-        .frame(minWidth: 300, minHeight: 200)
+        .padding(20)
+        .frame(minWidth: 640, minHeight: 340)
+        .onAppear { setup() }
     }
 
     private var valid: Bool {
         let codeOk = isNew ? PortfolioThemeStatus.isValidCode(code) : true
-        return codeOk && PortfolioThemeStatus.isValidName(name) && PortfolioThemeStatus.isValidColor(color)
+        let nameOk = PortfolioThemeStatus.isValidName(name)
+        let colorOk = PortfolioThemeStatus.isValidColor(currentHex)
+        return codeOk && nameOk && colorOk && codeError == nil && nameError == nil && customError == nil
+    }
+
+    private func setup() {
+        code = status.code
+        name = status.name
+        if isNew {
+            let def = ThemeStatusColorPreset.default
+            selection = def.hex
+            customHex = def.hex
+        } else if let match = ThemeStatusColorPreset.matching(hex: status.colorHex) {
+            selection = match.hex
+            customHex = match.hex
+        } else {
+            selection = "custom"
+            customHex = status.colorHex
+        }
+        isDefault = status.isDefault
+    }
+
+    private func save() {
+        codeError = nil
+        nameError = nil
+        customError = nil
+        guard valid else { return }
+        let hex = currentHex
+        let updated: PortfolioThemeStatus
+        if isNew {
+            updated = PortfolioThemeStatus(id: 0, code: code.uppercased(), name: name, colorHex: hex, isDefault: isDefault)
+        } else {
+            var u = status
+            u.name = name
+            u.colorHex = hex
+            u.isDefault = isDefault
+            updated = u
+        }
+        let result: Result<Void, ThemeStatusSaveError>
+        if isNew {
+            result = dbManager.insertPortfolioThemeStatus(code: updated.code, name: updated.name, colorHex: updated.colorHex, isDefault: updated.isDefault)
+        } else {
+            result = dbManager.updatePortfolioThemeStatus(id: updated.id, name: updated.name, colorHex: updated.colorHex, isDefault: updated.isDefault)
+        }
+        switch result {
+        case .success:
+            onComplete()
+            dismiss()
+        case .failure(let error):
+            switch error {
+            case .codeInvalid:
+                codeError = "Code must be 2–10 characters: A–Z, 0–9, _ (start with a letter)."
+            case .codeExists:
+                codeError = "A status with this Code already exists."
+            case .nameExists:
+                nameError = "A status with this Name already exists."
+            case .couldNotSetDefault:
+                nameError = "Could not set default. Please retry."
+            case .unknown:
+                customError = "Save failed. See logs for details."
+            }
+        }
+    }
+}
+
+struct ColorSwatch: View {
+    let hex: String
+
+    var body: some View {
+        Rectangle()
+            .fill(Color(hex: hex))
+            .frame(width: 14, height: 14)
+            .cornerRadius(3)
+            .overlay(RoundedRectangle(cornerRadius: 3).stroke(Color.secondary, lineWidth: 1))
+            .accessibilityLabel(hex)
     }
 }

--- a/DragonShield/helpers/Color+Hex.swift
+++ b/DragonShield/helpers/Color+Hex.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+extension Color {
+    init(hex: String) {
+        var hex = hex
+        if hex.hasPrefix("#") {
+            hex.removeFirst()
+        }
+        guard hex.count == 6, let int = Int(hex, radix: 16) else {
+            self = .clear
+            return
+        }
+        let r = Double((int >> 16) & 0xFF) / 255.0
+        let g = Double((int >> 8) & 0xFF) / 255.0
+        let b = Double(int & 0xFF) / 255.0
+        self.init(red: r, green: g, blue: b)
+    }
+
+    static func textColor(forHex hex: String) -> Color {
+        var hex = hex
+        if hex.hasPrefix("#") {
+            hex.removeFirst()
+        }
+        guard hex.count == 6, let int = Int(hex, radix: 16) else {
+            return .black
+        }
+        let r = Double((int >> 16) & 0xFF) / 255.0
+        let g = Double((int >> 8) & 0xFF) / 255.0
+        let b = Double(int & 0xFF) / 255.0
+        let luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
+        return luminance < 0.5 ? .white : .black
+    }
+}

--- a/DragonShieldTests/PortfolioThemeStatusTests.swift
+++ b/DragonShieldTests/PortfolioThemeStatusTests.swift
@@ -9,13 +9,17 @@ final class PortfolioThemeStatusTests: XCTestCase {
     }
 
     func testCodeValidation() {
-        XCTAssertTrue(PortfolioThemeStatus.isValidCode("VALID1"))
+        XCTAssertTrue(PortfolioThemeStatus.isValidCode("CODE1"))
+        XCTAssertTrue(PortfolioThemeStatus.isValidCode("CODE_1"))
+        XCTAssertFalse(PortfolioThemeStatus.isValidCode("T"))
+        XCTAssertFalse(PortfolioThemeStatus.isValidCode("TOO_LONG_CODE"))
         XCTAssertFalse(PortfolioThemeStatus.isValidCode("invalid"))
     }
 
     func testNameValidation() {
         XCTAssertTrue(PortfolioThemeStatus.isValidName("Valid Name"))
         XCTAssertFalse(PortfolioThemeStatus.isValidName(""))
-        XCTAssertFalse(PortfolioThemeStatus.isValidName(String(repeating: "a", count: 65)))
+        XCTAssertFalse(PortfolioThemeStatus.isValidName("A"))
+        XCTAssertFalse(PortfolioThemeStatus.isValidName(String(repeating: "a", count: 41)))
     }
 }

--- a/DragonShieldTests/ThemeStatusColorPresetsTests.swift
+++ b/DragonShieldTests/ThemeStatusColorPresetsTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+import SwiftUI
+@testable import DragonShield
+
+final class ThemeStatusColorPresetsTests: XCTestCase {
+    func testPresetCount() {
+        XCTAssertEqual(themeStatusColorPresets.count, 20)
+    }
+
+    func testContainsEmeraldDefault() {
+        XCTAssertTrue(themeStatusColorPresets.contains { $0.name == "Emerald" && $0.hex == "#10B981" })
+    }
+
+    func testTextColorContrast() {
+        #if os(macOS)
+        XCTAssertEqual(NSColor(Color.textColor(forHex: "#6366F1")), NSColor.white)
+        XCTAssertEqual(NSColor(Color.textColor(forHex: "#EAB308")), NSColor.black)
+        #else
+        XCTAssertEqual(UIColor(Color.textColor(forHex: "#6366F1")), UIColor.white)
+        XCTAssertEqual(UIColor(Color.textColor(forHex: "#EAB308")), UIColor.black)
+        #endif
+    }
+}

--- a/DragonShieldTests/ThemeStatusSaveErrorTests.swift
+++ b/DragonShieldTests/ThemeStatusSaveErrorTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import DragonShield
+
+final class ThemeStatusSaveErrorTests: XCTestCase {
+    func testEquality() {
+        XCTAssertEqual(ThemeStatusSaveError.codeExists, ThemeStatusSaveError.codeExists)
+    }
+}


### PR DESCRIPTION
## Summary
- add ThemeStatusSaveError to surface database constraint failures
- return detailed save errors from PortfolioThemeStatus insert/update helpers
- rebuild Theme Status Add/Edit sheet with aligned grid layout and inline field validation

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild -scheme DragonShield -destination 'platform=macOS' build` *(fails: command not found: xcodebuild)*


------
https://chatgpt.com/codex/tasks/task_e_68aa24885444832386296ee3d235abc5