### PR TITLE
feat: add searchable asset subclass picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Replace Asset SubClass dropdowns with searchable, alphabetized pickers in Add/Edit Instrument sheets
 - Refine Overview update rows with inline toggle, right-aligned actions, and date filter including today
 - Add Overview tab with read-only Update Reader for Portfolio Theme details
 - Flesh out Portfolio Theme Overview with KPIs, filters, and update actions

--- a/DragonShield/Views/AddInstrumentView.swift
+++ b/DragonShield/Views/AddInstrumentView.swift
@@ -463,43 +463,18 @@ struct AddInstrumentView: View {
                 Image(systemName: "folder.circle.fill")
                     .font(.system(size: 14))
                     .foregroundColor(.gray)
-                
+
                 Text("Asset SubClass*")
                     .font(.system(size: 14, weight: .medium))
                     .foregroundColor(.black.opacity(0.7))
-                
+
                 Spacer()
             }
-            
-            Menu {
-                ForEach(instrumentGroups, id: \.id) { group in
-                    Button(group.name) {
-                        selectedGroupId = group.id
-                    }
-                }
-            } label: {
-                HStack {
-                    Text(instrumentGroups.first(where: { $0.id == selectedGroupId })?.name ?? "Select Asset SubClass")
-                        .foregroundColor(.black)
-                        .font(.system(size: 16))
-                    
-                    Spacer()
-                    
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(.gray)
-                }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 12)
-                .background(Color.white.opacity(0.8))
-                .clipShape(RoundedRectangle(cornerRadius: 10))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(Color.gray.opacity(0.3), lineWidth: 1)
-                )
-                .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
-            }
-            .buttonStyle(PlainButtonStyle())
+
+            SearchableAssetSubClassPicker(
+                options: instrumentGroups.map { AssetSubClassOption(id: $0.id, name: $0.name) },
+                selection: $selectedGroupId
+            )
         }
     }
     

--- a/DragonShield/Views/Components/SearchableAssetSubClassPicker.swift
+++ b/DragonShield/Views/Components/SearchableAssetSubClassPicker.swift
@@ -1,0 +1,111 @@
+import SwiftUI
+import Combine
+
+/// Searchable picker for Asset SubClasses with alphabetical ordering and live filtering.
+struct SearchableAssetSubClassPicker: View {
+    let options: [AssetSubClassOption]
+    @Binding var selection: Int
+
+    @State private var search: String = ""
+    @State private var debouncedSearch: String = ""
+    @State private var isPresented = false
+
+    private var filteredOptions: [AssetSubClassOption] {
+        AssetSubClassPickerModel.filter(options, query: debouncedSearch)
+    }
+
+    var body: some View {
+        Button {
+            isPresented.toggle()
+        } label: {
+            HStack {
+                Text(options.first(where: { $0.id == selection })?.name ?? "Select Asset SubClass")
+                    .foregroundColor(.black)
+                    .font(.system(size: 16))
+                Spacer()
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(.gray)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(Color.white.opacity(0.8))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color.gray.opacity(0.3), lineWidth: 1))
+            .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
+        }
+        .buttonStyle(PlainButtonStyle())
+        .popover(isPresented: $isPresented, arrowEdge: .bottom) {
+            VStack(spacing: 0) {
+                HStack {
+                    Image(systemName: "magnifyingglass")
+                        .foregroundColor(.gray)
+                    TextField("Search…", text: $search)
+                        .textFieldStyle(PlainTextFieldStyle())
+                        .onSubmit(selectFirstResult)
+                        .accessibilityLabel("Search Asset SubClass")
+                    if !search.isEmpty {
+                        Button {
+                            search = ""
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundColor(.gray)
+                        }
+                        .buttonStyle(BorderlessButtonStyle())
+                    }
+                }
+                .padding(8)
+                Divider()
+                if filteredOptions.isEmpty {
+                    Text("No matches found. Clear the search to see all.")
+                        .foregroundColor(.secondary)
+                        .padding()
+                        .frame(maxWidth: .infinity)
+                } else {
+                    ScrollViewReader { proxy in
+                        List(filteredOptions, id: \.id) { option in
+                            Text(option.name)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.vertical, 4)
+                                .background(option.id == selection ? Color.accentColor.opacity(0.2) : Color.clear)
+                                .contentShape(Rectangle())
+                                .onTapGesture {
+                                    selection = option.id
+                                    isPresented = false
+                                }
+                                .id(option.id)
+                        }
+                        .listStyle(.plain)
+                        .frame(maxHeight: 360)
+                        .onAppear {
+                            if let index = filteredOptions.firstIndex(where: { $0.id == selection }) {
+                                DispatchQueue.main.async {
+                                    proxy.scrollTo(filteredOptions[index].id, anchor: .center)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .frame(width: 260)
+            .onReceive(Just(search).debounce(for: .milliseconds(150), scheduler: RunLoop.main)) { value in
+                debouncedSearch = value
+            }
+            .onExitCommand {
+                if search.isEmpty {
+                    isPresented = false
+                } else {
+                    search = ""
+                }
+            }
+        }
+    }
+
+    private func selectFirstResult() {
+        if let first = filteredOptions.first {
+            selection = first.id
+            isPresented = false
+        }
+    }
+}
+

--- a/DragonShield/Views/InstrumentEditView.swift
+++ b/DragonShield/Views/InstrumentEditView.swift
@@ -568,44 +568,21 @@ struct InstrumentEditView: View {
                 Image(systemName: "folder.circle.fill")
                     .font(.system(size: 14))
                     .foregroundColor(.gray)
-                
+
                 Text("Asset SubClass*")
                     .font(.system(size: 14, weight: .medium))
                     .foregroundColor(.black.opacity(0.7))
-                
+
                 Spacer()
             }
-            
-            Menu {
-                ForEach(instrumentGroups, id: \.id) { group in
-                    Button(group.name) {
-                        selectedGroupId = group.id
-                        detectChanges()
-                    }
-                }
-            } label: {
-                HStack {
-                    Text(instrumentGroups.first(where: { $0.id == selectedGroupId })?.name ?? "Select Asset SubClass")
-                        .foregroundColor(.black)
-                        .font(.system(size: 16))
-                    
-                    Spacer()
-                    
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(.gray)
-                }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 12)
-                .background(Color.white.opacity(0.8))
-                .clipShape(RoundedRectangle(cornerRadius: 10))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(Color.gray.opacity(0.3), lineWidth: 1)
-                )
-                .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
+
+            SearchableAssetSubClassPicker(
+                options: instrumentGroups.map { AssetSubClassOption(id: $0.id, name: $0.name) },
+                selection: $selectedGroupId
+            )
+            .onChange(of: selectedGroupId) { _ in
+                detectChanges()
             }
-            .buttonStyle(PlainButtonStyle())
         }
     }
     

--- a/DragonShieldTests/AssetSubClassPickerModelTests.swift
+++ b/DragonShieldTests/AssetSubClassPickerModelTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import DragonShield
+
+final class AssetSubClassPickerModelTests: XCTestCase {
+    func testSortAndFilter() {
+        let options: [AssetSubClassOption] = [
+            .init(id: 1, name: "Éclair"),
+            .init(id: 2, name: "beta"),
+            .init(id: 3, name: "Alpha")
+        ]
+        let sorted = AssetSubClassPickerModel.sort(options)
+        XCTAssertEqual(sorted.map { $0.name }, ["Alpha", "beta", "Éclair"])
+
+        let filtered = AssetSubClassPickerModel.filter(options, query: "écl")
+        XCTAssertEqual(filtered.map { $0.name }, ["Éclair"])
+
+        let all = AssetSubClassPickerModel.filter(options, query: "")
+        XCTAssertEqual(all.map { $0.name }, ["Alpha", "beta", "Éclair"])
+    }
+}

--- a/Model/AssetSubClassPickerModel.swift
+++ b/Model/AssetSubClassPickerModel.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Represents an Asset SubClass option in pickers.
+struct AssetSubClassOption: Equatable {
+    let id: Int
+    let name: String
+}
+
+/// Utility methods for sorting and filtering AssetSubClass options.
+enum AssetSubClassPickerModel {
+    /// Returns options sorted alphabetically by display name.
+    static func sort(_ options: [AssetSubClassOption]) -> [AssetSubClassOption] {
+        options.sorted {
+            $0.name.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+                <
+            $1.name.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+        }
+    }
+
+    /// Returns options filtered by query and sorted alphabetically.
+    /// - Parameters:
+    ///   - options: full list of options.
+    ///   - query: search term; if empty, returns the full sorted list.
+    static func filter(_ options: [AssetSubClassOption], query: String) -> [AssetSubClassOption] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        let sorted = sort(options)
+        guard !trimmed.isEmpty else { return sorted }
+        let needle = trimmed.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+        return sorted.filter {
+            $0.name.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+                .contains(needle)
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- replace Asset SubClass dropdowns with searchable, alphabetized pickers on add/edit instrument sheets
- add model helpers and unit tests for diacritic-insensitive sort and filter logic

## Testing
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68aab990f40483238f0a6ced7d9a89dc