### PR TITLE
feat: add searchable asset subclass picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Add searchable, alphabetically sorted Asset SubClass picker in Add/Edit Instrument forms.
 - Refine Overview update rows with inline toggle, right-aligned actions, and date filter including today
 - Add Overview tab with read-only Update Reader for Portfolio Theme details
 - Flesh out Portfolio Theme Overview with KPIs, filters, and update actions

--- a/DragonShield/Core/AssetSubClassFiltering.swift
+++ b/DragonShield/Core/AssetSubClassFiltering.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Represents an asset sub-class item used by pickers.
+struct AssetSubClassItem: Identifiable, Equatable {
+    let id: Int
+    let name: String
+}
+
+/// Provides sorting and filtering utilities for asset sub-classes.
+enum AssetSubClassFilter {
+    /// Returns items sorted alphabetically by display name using case- and diacritic-insensitive compare.
+    static func sort(_ items: [AssetSubClassItem]) -> [AssetSubClassItem] {
+        items.sorted {
+            $0.name.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+                < $1.name.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+        }
+    }
+
+    /// Filters items whose names contain the query, applying the same normalization as sorting.
+    static func filter(_ items: [AssetSubClassItem], query: String) -> [AssetSubClassItem] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return sort(items) }
+        let foldedQuery = trimmed.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+        return sort(items).filter {
+            $0.name.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+                .contains(foldedQuery)
+        }
+    }
+}
+

--- a/DragonShield/Views/AddInstrumentView.swift
+++ b/DragonShield/Views/AddInstrumentView.swift
@@ -10,7 +10,7 @@ struct AddInstrumentView: View {
     @State private var isin = ""
     @State private var valorNr = ""
     @State private var sector = ""
-    @State private var instrumentGroups: [(id: Int, name: String)] = []
+    @State private var instrumentGroups: [AssetSubClassItem] = []
     @State private var showingAlert = false
     @State private var alertMessage = ""
     @State private var isLoading = false
@@ -471,35 +471,7 @@ struct AddInstrumentView: View {
                 Spacer()
             }
             
-            Menu {
-                ForEach(instrumentGroups, id: \.id) { group in
-                    Button(group.name) {
-                        selectedGroupId = group.id
-                    }
-                }
-            } label: {
-                HStack {
-                    Text(instrumentGroups.first(where: { $0.id == selectedGroupId })?.name ?? "Select Asset SubClass")
-                        .foregroundColor(.black)
-                        .font(.system(size: 16))
-                    
-                    Spacer()
-                    
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(.gray)
-                }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 12)
-                .background(Color.white.opacity(0.8))
-                .clipShape(RoundedRectangle(cornerRadius: 10))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(Color.gray.opacity(0.3), lineWidth: 1)
-                )
-                .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
-            }
-            .buttonStyle(PlainButtonStyle())
+            AssetSubClassPicker(selectedId: $selectedGroupId, items: instrumentGroups)
         }
     }
     
@@ -617,9 +589,10 @@ struct AddInstrumentView: View {
     func loadInstrumentGroups() {
         let dbManager = DatabaseManager()
         let groups = dbManager.fetchAssetTypes()
-        self.instrumentGroups = groups
-        if !groups.isEmpty {
-            selectedGroupId = groups[0].id
+            .map { AssetSubClassItem(id: $0.id, name: $0.name) }
+        instrumentGroups = AssetSubClassFilter.sort(groups)
+        if let first = instrumentGroups.first {
+            selectedGroupId = first.id
         }
     }
     
@@ -630,8 +603,8 @@ struct AddInstrumentView: View {
         isin = ""
         valorNr = ""
         sector = ""
-        if !instrumentGroups.isEmpty {
-            selectedGroupId = instrumentGroups[0].id
+        if let first = instrumentGroups.first {
+            selectedGroupId = first.id
         }
     }
     

--- a/DragonShield/Views/AssetSubClassPicker.swift
+++ b/DragonShield/Views/AssetSubClassPicker.swift
@@ -1,0 +1,123 @@
+import SwiftUI
+import Combine
+import OSLog
+
+/// Searchable picker for choosing an asset sub-class.
+struct AssetSubClassPicker: View {
+    @Binding var selectedId: Int
+    let items: [AssetSubClassItem]
+
+    @State private var isPresented = false
+    @State private var searchText = ""
+    @State private var debouncedSearch = ""
+    @State private var highlightedId: Int?
+    @FocusState private var isSearchFocused: Bool
+
+    private let logger = Logger.ui
+
+    var body: some View {
+        Button { isPresented = true } label: {
+            HStack {
+                Text(displayName(for: selectedId) ?? "Select Asset SubClass")
+                    .foregroundColor(.black)
+                    .font(.system(size: 16))
+                Spacer()
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(.gray)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(Color.white.opacity(0.8))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+            )
+            .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
+        }
+        .buttonStyle(PlainButtonStyle())
+        .popover(isPresented: $isPresented, arrowEdge: .bottom) {
+            VStack(spacing: 0) {
+                HStack {
+                    Image(systemName: "magnifyingglass")
+                        .foregroundColor(.gray)
+                    TextField("Search…", text: $searchText)
+                        .textFieldStyle(PlainTextFieldStyle())
+                        .focused($isSearchFocused)
+                        .onSubmit(selectHighlighted)
+                    if !searchText.isEmpty {
+                        Button("✕") { searchText = "" }
+                            .buttonStyle(BorderlessButtonStyle())
+                            .foregroundColor(.gray)
+                    }
+                }
+                .padding(8)
+                .background(Color.gray.opacity(0.1))
+                Divider()
+
+                if filteredItems.isEmpty {
+                    Text("No matches found. Clear the search to see all.")
+                        .foregroundColor(.gray)
+                        .padding()
+                } else {
+                    ScrollViewReader { proxy in
+                        List(filteredItems, id: \.id, selection: $highlightedId) { item in
+                            Text(item.name)
+                                .tag(item.id)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .contentShape(Rectangle())
+                                .onTapGesture { select(item) }
+                        }
+                        .listStyle(.plain)
+                        .onAppear {
+                            highlightedId = selectedId
+                            DispatchQueue.main.async {
+                                if let id = highlightedId {
+                                    proxy.scrollTo(id, anchor: .center)
+                                }
+                                isSearchFocused = true
+                            }
+                        }
+                    }
+                    .frame(maxHeight: 360)
+                }
+            }
+            .onExitCommand { handleEscape() }
+            .onReceive(Just(searchText).debounce(for: .milliseconds(150), scheduler: RunLoop.main)) { value in
+                debouncedSearch = value
+                highlightedId = filteredItems.first?.id
+            }
+            .frame(width: 300)
+        }
+    }
+
+    private var filteredItems: [AssetSubClassItem] {
+        AssetSubClassFilter.filter(items, query: debouncedSearch)
+    }
+
+    private func displayName(for id: Int) -> String? {
+        items.first(where: { $0.id == id })?.name
+    }
+
+    private func select(_ item: AssetSubClassItem) {
+        selectedId = item.id
+        logger.debug("Selected asset sub-class: \(item.name, privacy: .public)")
+        isPresented = false
+    }
+
+    private func selectHighlighted() {
+        if let id = highlightedId, let item = items.first(where: { $0.id == id }) {
+            select(item)
+        }
+    }
+
+    private func handleEscape() {
+        if !searchText.isEmpty {
+            searchText = ""
+        } else {
+            isPresented = false
+        }
+    }
+}
+

--- a/DragonShield/Views/InstrumentEditView.swift
+++ b/DragonShield/Views/InstrumentEditView.swift
@@ -11,7 +11,7 @@ struct InstrumentEditView: View {
     @State private var isin = ""
     @State private var valorNr = ""
     @State private var sector = ""
-    @State private var instrumentGroups: [(id: Int, name: String)] = []
+    @State private var instrumentGroups: [AssetSubClassItem] = []
     @State private var availableCurrencies: [(code: String, name: String, symbol: String)] = []
     @State private var showingAlert = false
     @State private var alertMessage = ""
@@ -576,36 +576,8 @@ struct InstrumentEditView: View {
                 Spacer()
             }
             
-            Menu {
-                ForEach(instrumentGroups, id: \.id) { group in
-                    Button(group.name) {
-                        selectedGroupId = group.id
-                        detectChanges()
-                    }
-                }
-            } label: {
-                HStack {
-                    Text(instrumentGroups.first(where: { $0.id == selectedGroupId })?.name ?? "Select Asset SubClass")
-                        .foregroundColor(.black)
-                        .font(.system(size: 16))
-                    
-                    Spacer()
-                    
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(.gray)
-                }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 12)
-                .background(Color.white.opacity(0.8))
-                .clipShape(RoundedRectangle(cornerRadius: 10))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(Color.gray.opacity(0.3), lineWidth: 1)
-                )
-                .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
-            }
-            .buttonStyle(PlainButtonStyle())
+            AssetSubClassPicker(selectedId: $selectedGroupId, items: instrumentGroups)
+                .onChange(of: selectedGroupId) { _ in detectChanges() }
         }
     }
     
@@ -721,7 +693,9 @@ struct InstrumentEditView: View {
     // MARK: - Functions
     func loadInstrumentGroups() {
         let dbManager = DatabaseManager()
-        instrumentGroups = dbManager.fetchAssetTypes()
+        let groups = dbManager.fetchAssetTypes()
+            .map { AssetSubClassItem(id: $0.id, name: $0.name) }
+        instrumentGroups = AssetSubClassFilter.sort(groups)
     }
     
     func loadAvailableCurrencies() {

--- a/DragonShieldTests/AssetSubClassFilteringTests.swift
+++ b/DragonShieldTests/AssetSubClassFilteringTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import DragonShield
+
+final class AssetSubClassFilteringTests: XCTestCase {
+    func testSortingAndFiltering() {
+        let items = [
+            AssetSubClassItem(id: 1, name: "Équity ETF"),
+            AssetSubClassItem(id: 2, name: "corporate bond"),
+            AssetSubClassItem(id: 3, name: "Crypto Fund")
+        ]
+        let sorted = AssetSubClassFilter.sort(items)
+        XCTAssertEqual(sorted.map(\.$name), ["corporate bond", "Crypto Fund", "Équity ETF"])
+
+        let filtered = AssetSubClassFilter.filter(items, query: "equity")
+        XCTAssertEqual(filtered.map(\.$name), ["Équity ETF"])
+    }
+}


### PR DESCRIPTION
## Summary
- add sortable & searchable Asset SubClass picker
- apply picker to Add/Edit Instrument forms
- cover sorting & filtering logic with unit tests

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -scheme DragonShield -sdk macosx build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aab990f40483238f0a6ced7d9a89dc