### PR TITLE
feat: add searchable asset subclass picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Replace Asset SubClass dropdown with searchable, alphabetically sorted picker for instruments
 - Replace Theme Status editor pop-up with professional sheet layout and inline validation
 - Introduce preset color picker with custom hex option for Theme Statuses
 - Allow deleting Theme Statuses only when unused and surface detailed database errors

--- a/DragonShield/Core/AssetSubClassFiltering.swift
+++ b/DragonShield/Core/AssetSubClassFiltering.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+struct AssetSubClassFilter {
+    static func sort(_ items: [(id: Int, name: String)]) -> [(id: Int, name: String)] {
+        items.sorted {
+            $0.name.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current) <
+            $1.name.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+        }
+    }
+
+    static func filter(_ items: [(id: Int, name: String)], query: String) -> [(id: Int, name: String)] {
+        guard !query.isEmpty else { return sort(items) }
+        let normalizedQuery = query.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+        return sort(items).filter { item in
+            item.name.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+                .contains(normalizedQuery)
+        }
+    }
+}
+

--- a/DragonShield/Views/AddInstrumentView.swift
+++ b/DragonShield/Views/AddInstrumentView.swift
@@ -471,35 +471,7 @@ struct AddInstrumentView: View {
                 Spacer()
             }
             
-            Menu {
-                ForEach(instrumentGroups, id: \.id) { group in
-                    Button(group.name) {
-                        selectedGroupId = group.id
-                    }
-                }
-            } label: {
-                HStack {
-                    Text(instrumentGroups.first(where: { $0.id == selectedGroupId })?.name ?? "Select Asset SubClass")
-                        .foregroundColor(.black)
-                        .font(.system(size: 16))
-                    
-                    Spacer()
-                    
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(.gray)
-                }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 12)
-                .background(Color.white.opacity(0.8))
-                .clipShape(RoundedRectangle(cornerRadius: 10))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(Color.gray.opacity(0.3), lineWidth: 1)
-                )
-                .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
-            }
-            .buttonStyle(PlainButtonStyle())
+            AssetSubClassPicker(groups: instrumentGroups, selection: $selectedGroupId)
         }
     }
     
@@ -617,9 +589,9 @@ struct AddInstrumentView: View {
     func loadInstrumentGroups() {
         let dbManager = DatabaseManager()
         let groups = dbManager.fetchAssetTypes()
-        self.instrumentGroups = groups
-        if !groups.isEmpty {
-            selectedGroupId = groups[0].id
+        self.instrumentGroups = AssetSubClassFilter.sort(groups)
+        if let first = instrumentGroups.first {
+            selectedGroupId = first.id
         }
     }
     

--- a/DragonShield/Views/AssetSubClassPicker.swift
+++ b/DragonShield/Views/AssetSubClassPicker.swift
@@ -1,0 +1,149 @@
+import SwiftUI
+import Combine
+
+struct AssetSubClassPicker: View {
+    let groups: [(id: Int, name: String)]
+    @Binding var selection: Int
+
+    @State private var isPresented = false
+    @State private var searchText = ""
+    @State private var debouncedSearch = ""
+    @State private var highlightedId: Int?
+
+    private let debounceInterval = 0.15
+
+    private var filteredGroups: [(id: Int, name: String)] {
+        AssetSubClassFilter.filter(groups, query: debouncedSearch)
+    }
+
+    var body: some View {
+        Button {
+            isPresented.toggle()
+        } label: {
+            HStack {
+                Text(groups.first(where: { $0.id == selection })?.name ?? "Select Asset SubClass")
+                    .foregroundColor(.black)
+                    .font(.system(size: 16))
+                Spacer()
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(.gray)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(Color.white.opacity(0.8))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+            )
+            .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
+        }
+        .buttonStyle(PlainButtonStyle())
+        .popover(isPresented: $isPresented, arrowEdge: .bottom) {
+            VStack(spacing: 0) {
+                HStack {
+                    Image(systemName: "magnifyingglass")
+                        .foregroundColor(.gray)
+                    TextField("Search…", text: $searchText)
+                        .textFieldStyle(PlainTextFieldStyle())
+                        .onSubmit { selectHighlighted() }
+                    if !searchText.isEmpty {
+                        Button {
+                            searchText = ""
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundColor(.gray)
+                        }
+                        .buttonStyle(BorderlessButtonStyle())
+                    }
+                }
+                .padding(8)
+                Divider()
+                ScrollViewReader { proxy in
+                    List {
+                        ForEach(filteredGroups, id: \.id) { group in
+                            Text(group.name)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.vertical, 4)
+                                .background(highlightedId == group.id ? Color.accentColor.opacity(0.2) : Color.clear)
+                                .id(group.id)
+                                .onTapGesture {
+                                    selection = group.id
+                                    isPresented = false
+                                }
+                        }
+                    }
+                    .listStyle(PlainListStyle())
+                    .frame(maxHeight: 360)
+                    .onAppear {
+                        highlightedId = selection
+                        DispatchQueue.main.async {
+                            proxy.scrollTo(selection, anchor: .center)
+                        }
+                    }
+                    .onChange(of: filteredGroups) { _ in
+                        highlightedId = filteredGroups.first?.id
+                    }
+                    .onMoveCommand { direction in
+                        guard !filteredGroups.isEmpty else { return }
+                        switch direction {
+                        case .down:
+                            moveHighlight(by: 1)
+                        case .up:
+                            moveHighlight(by: -1)
+                        case .pageDown:
+                            moveHighlight(by: 5)
+                        case .pageUp:
+                            moveHighlight(by: -5)
+                        default:
+                            break
+                        }
+                        if let id = highlightedId {
+                            withAnimation { proxy.scrollTo(id, anchor: .center) }
+                        }
+                    }
+                }
+                if filteredGroups.isEmpty {
+                    Text("No matches found. Clear the search to see all.")
+                        .foregroundColor(.gray)
+                        .padding(8)
+                } else {
+                    Text("\(filteredGroups.count) results")
+                        .font(.caption)
+                        .foregroundColor(.gray)
+                        .accessibilityLabel("\(filteredGroups.count) results")
+                        .padding(4)
+                }
+            }
+            .frame(width: 300)
+            .onExitCommand {
+                if !searchText.isEmpty {
+                    searchText = ""
+                } else {
+                    isPresented = false
+                }
+            }
+        }
+        .onReceive(Just(searchText).debounce(for: .milliseconds(Int(debounceInterval * 1000)), scheduler: RunLoop.main)) { value in
+            debouncedSearch = value
+        }
+    }
+
+    private func moveHighlight(by offset: Int) {
+        guard let current = highlightedId, let currentIndex = filteredGroups.firstIndex(where: { $0.id == current }) else {
+            highlightedId = filteredGroups.first?.id
+            return
+        }
+        let newIndex = max(0, min(filteredGroups.count - 1, currentIndex + offset))
+        highlightedId = filteredGroups[newIndex].id
+    }
+
+    private func selectHighlighted() {
+        if let id = highlightedId {
+            selection = id
+            isPresented = false
+        }
+    }
+}
+

--- a/DragonShield/Views/InstrumentEditView.swift
+++ b/DragonShield/Views/InstrumentEditView.swift
@@ -576,36 +576,10 @@ struct InstrumentEditView: View {
                 Spacer()
             }
             
-            Menu {
-                ForEach(instrumentGroups, id: \.id) { group in
-                    Button(group.name) {
-                        selectedGroupId = group.id
-                        detectChanges()
-                    }
+            AssetSubClassPicker(groups: instrumentGroups, selection: $selectedGroupId)
+                .onChange(of: selectedGroupId) { _ in
+                    detectChanges()
                 }
-            } label: {
-                HStack {
-                    Text(instrumentGroups.first(where: { $0.id == selectedGroupId })?.name ?? "Select Asset SubClass")
-                        .foregroundColor(.black)
-                        .font(.system(size: 16))
-                    
-                    Spacer()
-                    
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(.gray)
-                }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 12)
-                .background(Color.white.opacity(0.8))
-                .clipShape(RoundedRectangle(cornerRadius: 10))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(Color.gray.opacity(0.3), lineWidth: 1)
-                )
-                .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
-            }
-            .buttonStyle(PlainButtonStyle())
         }
     }
     
@@ -721,7 +695,7 @@ struct InstrumentEditView: View {
     // MARK: - Functions
     func loadInstrumentGroups() {
         let dbManager = DatabaseManager()
-        instrumentGroups = dbManager.fetchAssetTypes()
+        instrumentGroups = AssetSubClassFilter.sort(dbManager.fetchAssetTypes())
     }
     
     func loadAvailableCurrencies() {

--- a/DragonShieldTests/AssetSubClassFilterTests.swift
+++ b/DragonShieldTests/AssetSubClassFilterTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import DragonShield
+
+final class AssetSubClassFilterTests: XCTestCase {
+    func testSortCaseAndDiacriticInsensitive() {
+        let items = [(id: 1, name: "éclair"), (id: 2, name: "Banana"), (id: 3, name: "apple")]
+        let sorted = AssetSubClassFilter.sort(items)
+        XCTAssertEqual(sorted.map { $0.name }, ["apple", "Banana", "éclair"])
+    }
+
+    func testFilterContainsCaseAndDiacriticInsensitive() {
+        let items = [(id: 1, name: "Équity ETF"), (id: 2, name: "Crypto Fund"), (id: 3, name: "Government Bond")]
+        let filtered = AssetSubClassFilter.filter(items, query: "equity")
+        XCTAssertEqual(filtered.map { $0.name }, ["Équity ETF"])
+        let filteredAccent = AssetSubClassFilter.filter(items, query: "éQuItY")
+        XCTAssertEqual(filteredAccent.map { $0.name }, ["Équity ETF"])
+    }
+}


### PR DESCRIPTION
## Summary
- add AssetSubClassPicker for searchable, sorted selection
- integrate picker into Add and Edit instrument views
- sort asset sub-classes and add unit tests

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68aabe4ae0908323a593e50ebd819407