### PR TITLE
feat: add searchable asset subclass picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Replace Theme Status editor pop-up with professional sheet layout and inline validation
+- Replace Asset SubClass dropdown with searchable, alphabetically sorted picker
 - Introduce preset color picker with custom hex option for Theme Statuses
 - Allow deleting Theme Statuses only when unused and surface detailed database errors
 - Refine Overview update rows with inline toggle, right-aligned actions, and date filter including today

--- a/DragonShield/ViewModels/AssetSubClassPickerViewModel.swift
+++ b/DragonShield/ViewModels/AssetSubClassPickerViewModel.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+import Combine
+
+@MainActor
+final class AssetSubClassPickerViewModel: ObservableObject {
+    struct SubClass: Identifiable, Equatable {
+        let id: Int
+        let name: String
+    }
+
+    @Published var searchText: String = ""
+    @Published private(set) var filtered: [SubClass] = []
+    @Published var highlightedIndex: Int = 0
+
+    private let all: [SubClass]
+    private var cancellables: Set<AnyCancellable> = []
+
+    init(subClasses: [SubClass]) {
+        self.all = subClasses
+        filtered = Self.sort(subClasses)
+        $searchText
+            .removeDuplicates()
+            .debounce(for: .milliseconds(150), scheduler: DispatchQueue.main)
+            .sink { [weak self] term in
+                self?.applyFilter(term: term)
+            }
+            .store(in: &cancellables)
+    }
+
+    func displayName(for id: Int) -> String? {
+        all.first { $0.id == id }?.name
+    }
+
+    func indexOf(id: Int) -> Int? {
+        filtered.firstIndex { $0.id == id }
+    }
+
+    func ensureHighlightWithinBounds() {
+        if highlightedIndex >= filtered.count {
+            highlightedIndex = max(filtered.count - 1, 0)
+        }
+    }
+
+    private func applyFilter(term: String) {
+        if term.isEmpty {
+            filtered = Self.sort(all)
+        } else {
+            let folded = term.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+            filtered = Self.sort(
+                all.filter {
+                    $0.name.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+                        .contains(folded)
+                }
+            )
+        }
+        highlightedIndex = 0
+    }
+
+    private static func sort(_ list: [SubClass]) -> [SubClass] {
+        list.sorted {
+            $0.name.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+                < $1.name.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+        }
+    }
+}
+

--- a/DragonShield/Views/AddInstrumentView.swift
+++ b/DragonShield/Views/AddInstrumentView.swift
@@ -463,43 +463,15 @@ struct AddInstrumentView: View {
                 Image(systemName: "folder.circle.fill")
                     .font(.system(size: 14))
                     .foregroundColor(.gray)
-                
+
                 Text("Asset SubClass*")
                     .font(.system(size: 14, weight: .medium))
                     .foregroundColor(.black.opacity(0.7))
-                
+
                 Spacer()
             }
-            
-            Menu {
-                ForEach(instrumentGroups, id: \.id) { group in
-                    Button(group.name) {
-                        selectedGroupId = group.id
-                    }
-                }
-            } label: {
-                HStack {
-                    Text(instrumentGroups.first(where: { $0.id == selectedGroupId })?.name ?? "Select Asset SubClass")
-                        .foregroundColor(.black)
-                        .font(.system(size: 16))
-                    
-                    Spacer()
-                    
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(.gray)
-                }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 12)
-                .background(Color.white.opacity(0.8))
-                .clipShape(RoundedRectangle(cornerRadius: 10))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(Color.gray.opacity(0.3), lineWidth: 1)
-                )
-                .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
-            }
-            .buttonStyle(PlainButtonStyle())
+
+            AssetSubClassPicker(selectedId: $selectedGroupId, subClasses: instrumentGroups)
         }
     }
     
@@ -617,9 +589,13 @@ struct AddInstrumentView: View {
     func loadInstrumentGroups() {
         let dbManager = DatabaseManager()
         let groups = dbManager.fetchAssetTypes()
-        self.instrumentGroups = groups
-        if !groups.isEmpty {
-            selectedGroupId = groups[0].id
+        let sorted = groups.sorted {
+            $0.name.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current) <
+            $1.name.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+        }
+        self.instrumentGroups = sorted
+        if let first = sorted.first {
+            selectedGroupId = first.id
         }
     }
     

--- a/DragonShield/Views/AssetSubClassPicker.swift
+++ b/DragonShield/Views/AssetSubClassPicker.swift
@@ -1,0 +1,114 @@
+import SwiftUI
+
+struct AssetSubClassPicker: View {
+    @Binding var selectedId: Int
+    @State private var isPresented = false
+    @StateObject private var viewModel: AssetSubClassPickerViewModel
+    private let maxHeight: CGFloat = 360
+
+    init(selectedId: Binding<Int>, subClasses: [(id: Int, name: String)]) {
+        _selectedId = selectedId
+        _viewModel = StateObject(wrappedValue: AssetSubClassPickerViewModel(subClasses: subClasses.map { .init(id: $0.id, name: $0.name) }))
+    }
+
+    var body: some View {
+        Button {
+            isPresented = true
+        } label: {
+            HStack {
+                Text(viewModel.displayName(for: selectedId) ?? "Select Asset SubClass")
+                    .foregroundColor(.black)
+                    .font(.system(size: 16))
+                Spacer()
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(.gray)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(Color.white.opacity(0.8))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+            )
+            .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
+        }
+        .buttonStyle(PlainButtonStyle())
+        .popover(isPresented: $isPresented, arrowEdge: .bottom) {
+            VStack(spacing: 0) {
+                searchRow
+                Divider()
+                if viewModel.filtered.isEmpty {
+                    Text("No matches found. Clear the search to see all.")
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                } else {
+                    ScrollViewReader { proxy in
+                        ScrollView {
+                            LazyVStack(alignment: .leading, spacing: 0) {
+                                ForEach(Array(viewModel.filtered.enumerated()), id: \.1.id) { index, item in
+                                    row(for: item, index: index)
+                                }
+                            }
+                        }
+                        .frame(maxHeight: maxHeight)
+                        .onAppear {
+                            DispatchQueue.main.async {
+                                proxy.scrollTo(selectedId, anchor: .center)
+                                viewModel.highlightedIndex = viewModel.indexOf(id: selectedId) ?? 0
+                            }
+                        }
+                    }
+                }
+                Text("\(viewModel.filtered.count) results")
+                    .font(.caption)
+                    .foregroundColor(.clear)
+                    .accessibilityHidden(false)
+                    .accessibilityLabel("\(viewModel.filtered.count) results")
+                    .accessibilityLiveRegion(.polite)
+            }
+            .frame(width: 260)
+            .padding(.bottom, 8)
+        }
+        .onChange(of: viewModel.filtered) { _, _ in
+            viewModel.ensureHighlightWithinBounds()
+        }
+    }
+
+    private var searchRow: some View {
+        HStack {
+            Image(systemName: "magnifyingglass")
+            TextField("Search…", text: $viewModel.searchText)
+                .textFieldStyle(PlainTextFieldStyle())
+            if !viewModel.searchText.isEmpty {
+                Button {
+                    viewModel.searchText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(.secondary)
+                }
+                .buttonStyle(BorderlessButtonStyle())
+            }
+        }
+        .padding(8)
+    }
+
+    private func row(for item: AssetSubClassPickerViewModel.SubClass, index: Int) -> some View {
+        Button {
+            selectedId = item.id
+            isPresented = false
+        } label: {
+            HStack {
+                Text(item.name)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 4)
+            }
+            .background(index == viewModel.highlightedIndex ? Color.accentColor.opacity(0.2) : Color.clear)
+        }
+        .buttonStyle(PlainButtonStyle())
+        .id(item.id)
+    }
+}
+

--- a/DragonShield/Views/InstrumentEditView.swift
+++ b/DragonShield/Views/InstrumentEditView.swift
@@ -568,44 +568,16 @@ struct InstrumentEditView: View {
                 Image(systemName: "folder.circle.fill")
                     .font(.system(size: 14))
                     .foregroundColor(.gray)
-                
+
                 Text("Asset SubClass*")
                     .font(.system(size: 14, weight: .medium))
                     .foregroundColor(.black.opacity(0.7))
-                
+
                 Spacer()
             }
-            
-            Menu {
-                ForEach(instrumentGroups, id: \.id) { group in
-                    Button(group.name) {
-                        selectedGroupId = group.id
-                        detectChanges()
-                    }
-                }
-            } label: {
-                HStack {
-                    Text(instrumentGroups.first(where: { $0.id == selectedGroupId })?.name ?? "Select Asset SubClass")
-                        .foregroundColor(.black)
-                        .font(.system(size: 16))
-                    
-                    Spacer()
-                    
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(.gray)
-                }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 12)
-                .background(Color.white.opacity(0.8))
-                .clipShape(RoundedRectangle(cornerRadius: 10))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(Color.gray.opacity(0.3), lineWidth: 1)
-                )
-                .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
-            }
-            .buttonStyle(PlainButtonStyle())
+
+            AssetSubClassPicker(selectedId: $selectedGroupId, subClasses: instrumentGroups)
+                .onChange(of: selectedGroupId) { _, _ in detectChanges() }
         }
     }
     
@@ -721,7 +693,11 @@ struct InstrumentEditView: View {
     // MARK: - Functions
     func loadInstrumentGroups() {
         let dbManager = DatabaseManager()
-        instrumentGroups = dbManager.fetchAssetTypes()
+        let groups = dbManager.fetchAssetTypes()
+        instrumentGroups = groups.sorted {
+            $0.name.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current) <
+            $1.name.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+        }
     }
     
     func loadAvailableCurrencies() {

--- a/DragonShieldTests/AssetSubClassPickerViewModelTests.swift
+++ b/DragonShieldTests/AssetSubClassPickerViewModelTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import DragonShield
+
+final class AssetSubClassPickerViewModelTests: XCTestCase {
+    func testSortedAlphabeticallyCaseAndDiacriticInsensitive() throws {
+        let data: [AssetSubClassPickerViewModel.SubClass] = [
+            .init(id: 1, name: "crypto Fund"),
+            .init(id: 2, name: "Équity ETF"),
+            .init(id: 3, name: "Corporate Bond")
+        ]
+        let vm = AssetSubClassPickerViewModel(subClasses: data)
+        XCTAssertEqual(vm.filtered.map(\.name), ["Corporate Bond", "crypto Fund", "Équity ETF"])
+    }
+
+    func testFilteringIsCaseAndDiacriticInsensitive() {
+        let data: [AssetSubClassPickerViewModel.SubClass] = [
+            .init(id: 1, name: "Equity ETF"),
+            .init(id: 2, name: "Equity Fund"),
+            .init(id: 3, name: "Hedge Fund")
+        ]
+        let vm = AssetSubClassPickerViewModel(subClasses: data)
+        vm.searchText = "equité"
+        let expectation = XCTestExpectation(description: "debounce")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            XCTAssertEqual(vm.filtered.map(\.name), ["Equity ETF", "Equity Fund"])
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add AssetSubClassPicker SwiftUI control with search and alphabetical sorting
- integrate searchable picker into AddInstrumentView and InstrumentEditView
- test sorting and filtering logic for AssetSubClassPickerViewModel

## Testing
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68aabe4ae0908323a593e50ebd819407