### PR TITLE
feat: add searchable asset subclass picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Replace Asset SubClass dropdown with searchable, alphabetically sorted picker in instrument forms
 - Replace Theme Status editor pop-up with professional sheet layout and inline validation
 - Introduce preset color picker with custom hex option for Theme Statuses
 - Allow deleting Theme Statuses only when unused and surface detailed database errors

--- a/DragonShield/ViewModels/AssetSubClassPickerViewModel.swift
+++ b/DragonShield/ViewModels/AssetSubClassPickerViewModel.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+import Combine
+
+@MainActor
+final class AssetSubClassPickerViewModel: ObservableObject {
+    @Published var searchText: String = ""
+    @Published private(set) var results: [(id: Int, name: String)]
+    private(set) var allGroups: [(id: Int, name: String)]
+    private var cancellables: Set<AnyCancellable> = []
+
+    init(groups: [(id: Int, name: String)]) {
+        allGroups = Self.sort(groups)
+        results = allGroups
+        $searchText
+            .debounce(for: .milliseconds(150), scheduler: DispatchQueue.main)
+            .sink { [weak self] term in
+                guard let self = self else { return }
+                self.results = Self.filter(self.allGroups, query: term)
+            }
+            .store(in: &cancellables)
+    }
+
+    func updateGroups(_ groups: [(id: Int, name: String)]) {
+        allGroups = Self.sort(groups)
+        results = Self.filter(allGroups, query: searchText)
+    }
+
+    func name(for id: Int) -> String? {
+        allGroups.first { $0.id == id }?.name
+    }
+
+    func clearSearch() {
+        searchText = ""
+    }
+
+    static func sort(_ groups: [(id: Int, name: String)]) -> [(id: Int, name: String)] {
+        groups.sorted {
+            $0.name.compare($1.name, options: [.caseInsensitive, .diacriticInsensitive]) == .orderedAscending
+        }
+    }
+
+    static func filter(_ groups: [(id: Int, name: String)], query: String) -> [(id: Int, name: String)] {
+        guard !query.isEmpty else { return groups }
+        return groups.filter {
+            $0.name.range(of: query, options: [.caseInsensitive, .diacriticInsensitive]) != nil
+        }
+    }
+}

--- a/DragonShield/Views/AddInstrumentView.swift
+++ b/DragonShield/Views/AddInstrumentView.swift
@@ -463,43 +463,15 @@ struct AddInstrumentView: View {
                 Image(systemName: "folder.circle.fill")
                     .font(.system(size: 14))
                     .foregroundColor(.gray)
-                
+
                 Text("Asset SubClass*")
                     .font(.system(size: 14, weight: .medium))
                     .foregroundColor(.black.opacity(0.7))
-                
+
                 Spacer()
             }
-            
-            Menu {
-                ForEach(instrumentGroups, id: \.id) { group in
-                    Button(group.name) {
-                        selectedGroupId = group.id
-                    }
-                }
-            } label: {
-                HStack {
-                    Text(instrumentGroups.first(where: { $0.id == selectedGroupId })?.name ?? "Select Asset SubClass")
-                        .foregroundColor(.black)
-                        .font(.system(size: 16))
-                    
-                    Spacer()
-                    
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(.gray)
-                }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 12)
-                .background(Color.white.opacity(0.8))
-                .clipShape(RoundedRectangle(cornerRadius: 10))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(Color.gray.opacity(0.3), lineWidth: 1)
-                )
-                .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
-            }
-            .buttonStyle(PlainButtonStyle())
+
+            AssetSubClassPicker(selectedId: $selectedGroupId, groups: instrumentGroups)
         }
     }
     
@@ -617,9 +589,10 @@ struct AddInstrumentView: View {
     func loadInstrumentGroups() {
         let dbManager = DatabaseManager()
         let groups = dbManager.fetchAssetTypes()
-        self.instrumentGroups = groups
-        if !groups.isEmpty {
-            selectedGroupId = groups[0].id
+        let sorted = AssetSubClassPickerViewModel.sort(groups)
+        self.instrumentGroups = sorted
+        if let first = sorted.first {
+            selectedGroupId = first.id
         }
     }
     

--- a/DragonShield/Views/AssetSubClassPicker.swift
+++ b/DragonShield/Views/AssetSubClassPicker.swift
@@ -1,0 +1,114 @@
+import SwiftUI
+
+struct AssetSubClassPicker: View {
+    @Binding var selectedId: Int
+    let groups: [(id: Int, name: String)]
+
+    @StateObject private var viewModel: AssetSubClassPickerViewModel
+    @State private var isPresented = false
+    @State private var highlightedId: Int?
+    @FocusState private var searchFocused: Bool
+
+    init(selectedId: Binding<Int>, groups: [(id: Int, name: String)]) {
+        self._selectedId = selectedId
+        self.groups = groups
+        _viewModel = StateObject(wrappedValue: AssetSubClassPickerViewModel(groups: groups))
+    }
+
+    var body: some View {
+        Button(action: { isPresented = true }) {
+            HStack {
+                Text(viewModel.name(for: selectedId) ?? "Select Asset SubClass")
+                    .foregroundColor(.black)
+                    .font(.system(size: 16))
+                Spacer()
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(.gray)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(Color.white.opacity(0.8))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+            )
+            .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
+        }
+        .buttonStyle(PlainButtonStyle())
+        .popover(isPresented: $isPresented, arrowEdge: .bottom) {
+            VStack(spacing: 0) {
+                HStack {
+                    TextField("Search…", text: $viewModel.searchText)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .focused($searchFocused)
+                    if !viewModel.searchText.isEmpty {
+                        Button(action: { viewModel.clearSearch() }) {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundColor(.gray)
+                        }
+                        .buttonStyle(BorderlessButtonStyle())
+                    }
+                }
+                .padding()
+
+                Divider()
+
+                if viewModel.results.isEmpty {
+                    Text("No matches found. Clear the search to see all.")
+                        .foregroundColor(.secondary)
+                        .padding()
+                } else {
+                    ScrollViewReader { proxy in
+                        List(selection: $highlightedId) {
+                            ForEach(viewModel.results, id: \.id) { group in
+                                Text(group.name)
+                                    .tag(group.id)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .contentShape(Rectangle())
+                                    .onTapGesture {
+                                        selectedId = group.id
+                                        isPresented = false
+                                    }
+                            }
+                        }
+                        .listStyle(.plain)
+                        .frame(maxHeight: 360)
+                        .onAppear {
+                            highlightedId = selectedId
+                            searchFocused = true
+                            proxy.scrollTo(selectedId, anchor: .center)
+                        }
+                        .onChange(of: highlightedId) { newId in
+                            if let newId = newId {
+                                proxy.scrollTo(newId, anchor: .center)
+                            }
+                        }
+                        .onChange(of: viewModel.results) { _ in
+                            if !viewModel.results.contains(where: { $0.id == highlightedId }) {
+                                highlightedId = viewModel.results.first?.id
+                            }
+                        }
+                    }
+                }
+            }
+            .onSubmit {
+                if let id = highlightedId ?? viewModel.results.first?.id {
+                    selectedId = id
+                    isPresented = false
+                }
+            }
+            .onExitCommand {
+                if !viewModel.searchText.isEmpty {
+                    viewModel.clearSearch()
+                } else {
+                    isPresented = false
+                }
+            }
+        }
+        .onChange(of: groups) { newGroups in
+            viewModel.updateGroups(newGroups)
+        }
+    }
+}

--- a/DragonShield/Views/InstrumentEditView.swift
+++ b/DragonShield/Views/InstrumentEditView.swift
@@ -576,36 +576,10 @@ struct InstrumentEditView: View {
                 Spacer()
             }
             
-            Menu {
-                ForEach(instrumentGroups, id: \.id) { group in
-                    Button(group.name) {
-                        selectedGroupId = group.id
-                        detectChanges()
-                    }
+            AssetSubClassPicker(selectedId: $selectedGroupId, groups: instrumentGroups)
+                .onChange(of: selectedGroupId) { _ in
+                    detectChanges()
                 }
-            } label: {
-                HStack {
-                    Text(instrumentGroups.first(where: { $0.id == selectedGroupId })?.name ?? "Select Asset SubClass")
-                        .foregroundColor(.black)
-                        .font(.system(size: 16))
-                    
-                    Spacer()
-                    
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(.gray)
-                }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 12)
-                .background(Color.white.opacity(0.8))
-                .clipShape(RoundedRectangle(cornerRadius: 10))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(Color.gray.opacity(0.3), lineWidth: 1)
-                )
-                .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
-            }
-            .buttonStyle(PlainButtonStyle())
         }
     }
     
@@ -721,7 +695,8 @@ struct InstrumentEditView: View {
     // MARK: - Functions
     func loadInstrumentGroups() {
         let dbManager = DatabaseManager()
-        instrumentGroups = dbManager.fetchAssetTypes()
+        let groups = dbManager.fetchAssetTypes()
+        instrumentGroups = AssetSubClassPickerViewModel.sort(groups)
     }
     
     func loadAvailableCurrencies() {

--- a/DragonShieldTests/AssetSubClassPickerViewModelTests.swift
+++ b/DragonShieldTests/AssetSubClassPickerViewModelTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import DragonShield
+
+final class AssetSubClassPickerViewModelTests: XCTestCase {
+    func testSortCaseAndDiacriticInsensitive() {
+        let groups = [
+            (id: 1, name: "Équity REIT"),
+            (id: 2, name: "equity etf"),
+            (id: 3, name: "Crypto Fund")
+        ]
+        let sorted = AssetSubClassPickerViewModel.sort(groups)
+        XCTAssertEqual(sorted.map { $0.name }, ["Crypto Fund", "equity etf", "Équity REIT"])
+    }
+
+    func testFilterContainsCaseAndDiacriticInsensitive() {
+        let groups = [
+            (id: 1, name: "Crypto Fund"),
+            (id: 2, name: "Equity ETF"),
+            (id: 3, name: "Équity REIT")
+        ]
+        let filtered = AssetSubClassPickerViewModel.filter(groups, query: "equity")
+        XCTAssertEqual(filtered.map { $0.name }, ["Equity ETF", "Équity REIT"])
+    }
+}


### PR DESCRIPTION
## Summary
- replace Asset SubClass dropdown with searchable, alphabetized picker
- sort AssetSubClasses case/diacritic-insensitively and enable live filtering
- cover picker sorting and filtering logic with unit tests

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68aabe4ae0908323a593e50ebd819407