### PR TITLE
Remove duplicate note preview in Theme Details overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Remove duplicate note previews from Theme Details Overview rows
 - Replace Theme Status editor pop-up with professional sheet layout and inline validation
 - Introduce preset color picker with custom hex option for Theme Statuses
 - Allow deleting Theme Statuses only when unused and surface detailed database errors

--- a/DragonShield/Views/PortfolioThemeOverviewView.swift
+++ b/DragonShield/Views/PortfolioThemeOverviewView.swift
@@ -40,8 +40,7 @@ struct PortfolioThemeOverviewView: View {
                 List(updates) { update in
                     VStack(alignment: .leading, spacing: 4) {
                         headerLine(update)
-                        Text("Title: \(update.title)").fontWeight(.semibold)
-                        Text(snippet(from: update.bodyMarkdown)).lineLimit(1)
+                        titleLine(update)
                         indicatorRow(update)
                         if expandedId == update.id {
                             expandedDetails(update)
@@ -133,6 +132,21 @@ struct PortfolioThemeOverviewView: View {
                     .disabled(isArchived)
                     .keyboardShortcut(.delete)
             }
+        }
+    }
+
+    private func titleLine(_ update: PortfolioThemeUpdate) -> some View {
+        HStack(alignment: .top, spacing: 0) {
+            Text("Title: ").fontWeight(.semibold)
+            Group {
+                if update.title.isEmpty {
+                    Text("(No title)").italic().foregroundColor(.secondary)
+                } else {
+                    Text(update.title)
+                }
+            }
+            .lineLimit(1)
+            .help(PortfolioThemeOverviewView.titleOrPlaceholder(update.title))
         }
     }
 
@@ -296,10 +310,6 @@ struct PortfolioThemeOverviewView: View {
         return link.rawURL
     }
 
-    private func snippet(from markdown: String) -> AttributedString {
-        MarkdownRenderer.attributedString(from: markdown)
-    }
-
     private func formattedChf(_ value: Double) -> String {
         value.formatted(.currency(code: dbManager.baseCurrency).precision(.fractionLength(2)))
     }
@@ -360,5 +370,11 @@ struct PortfolioThemeOverviewView: View {
                 return date >= start && date <= end
             }
         }
+    }
+}
+
+extension PortfolioThemeOverviewView {
+    static func titleOrPlaceholder(_ title: String) -> String {
+        title.isEmpty ? "(No title)" : title
     }
 }

--- a/DragonShieldTests/PortfolioThemeOverviewViewTests.swift
+++ b/DragonShieldTests/PortfolioThemeOverviewViewTests.swift
@@ -17,4 +17,9 @@ final class PortfolioThemeOverviewViewTests: XCTestCase {
         let eightDaysAgo = calendar.date(byAdding: .day, value: -8, to: startToday)!
         XCTAssertFalse(PortfolioThemeOverviewView.DateFilter.last7d.contains(eightDaysAgo, timeZone: tz))
     }
+
+    func testTitleOrPlaceholder() {
+        XCTAssertEqual(PortfolioThemeOverviewView.titleOrPlaceholder(""), "(No title)")
+        XCTAssertEqual(PortfolioThemeOverviewView.titleOrPlaceholder("Alpha"), "Alpha")
+    }
 }


### PR DESCRIPTION
## Summary
- drop body text snippet from overview list to avoid duplication
- truncate title with tooltip and placeholder for empty titles
- test coverage for title placeholder

## Testing
- `make setup` (fails: No rule)
- `make fmt` (fails: No rule)
- `make lint` (fails: No rule)
- `make migrate` (fails: No rule)
- `make build` (fails: No rule)
- `make test` (fails: No rule)
- `swift build` (fails: Could not find Package.swift)
- `swift test` (fails: Could not find Package.swift)


------
https://chatgpt.com/codex/tasks/task_e_68aac1e937dc8323bfdbb998298eeaeb