### PR TITLE
feat: add searchable asset subclass picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -567,6 +567,7 @@ All notable changes to this project will be documented in this file.
 - Place Actions column first in Positions table for quicker edits
 
 - Sort instrument Type and Currency filter menus alphabetically
+- Introduce searchable, alphabetically sorted Asset SubClass picker for instruments
 - Replace blue Top 10 Positions tile with modern white card showing all positions
 - Reduce list row spacing in Top Positions card for denser display
 - Refine Asset Class card with captioned display toggle and color-coded deviation bars

--- a/DragonShield/Core/AssetSubClassLookup.swift
+++ b/DragonShield/Core/AssetSubClassLookup.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+struct AssetSubClassLookup {
+    static func sort(_ groups: [(id: Int, name: String)], locale: Locale = .current) -> [(id: Int, name: String)] {
+        groups.sorted { lhs, rhs in
+            lhs.name.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: locale)
+                < rhs.name.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: locale)
+        }
+    }
+
+    static func filter(_ groups: [(id: Int, name: String)], query: String, locale: Locale = .current) -> [(id: Int, name: String)] {
+        guard !query.isEmpty else { return sort(groups, locale: locale) }
+        let foldedQuery = query.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: locale)
+        return groups.filter { group in
+            group.name.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: locale)
+                .contains(foldedQuery)
+        }.sorted { lhs, rhs in
+            lhs.name.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: locale)
+                < rhs.name.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: locale)
+        }
+    }
+}

--- a/DragonShield/Views/AddInstrumentView.swift
+++ b/DragonShield/Views/AddInstrumentView.swift
@@ -463,43 +463,15 @@ struct AddInstrumentView: View {
                 Image(systemName: "folder.circle.fill")
                     .font(.system(size: 14))
                     .foregroundColor(.gray)
-                
+
                 Text("Asset SubClass*")
                     .font(.system(size: 14, weight: .medium))
                     .foregroundColor(.black.opacity(0.7))
-                
+
                 Spacer()
             }
-            
-            Menu {
-                ForEach(instrumentGroups, id: \.id) { group in
-                    Button(group.name) {
-                        selectedGroupId = group.id
-                    }
-                }
-            } label: {
-                HStack {
-                    Text(instrumentGroups.first(where: { $0.id == selectedGroupId })?.name ?? "Select Asset SubClass")
-                        .foregroundColor(.black)
-                        .font(.system(size: 16))
-                    
-                    Spacer()
-                    
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(.gray)
-                }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 12)
-                .background(Color.white.opacity(0.8))
-                .clipShape(RoundedRectangle(cornerRadius: 10))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(Color.gray.opacity(0.3), lineWidth: 1)
-                )
-                .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
-            }
-            .buttonStyle(PlainButtonStyle())
+
+            AssetSubClassPicker(groups: instrumentGroups, selectedGroupId: $selectedGroupId)
         }
     }
     
@@ -616,10 +588,10 @@ struct AddInstrumentView: View {
     // MARK: - Functions
     func loadInstrumentGroups() {
         let dbManager = DatabaseManager()
-        let groups = dbManager.fetchAssetTypes()
+        let groups = AssetSubClassLookup.sort(dbManager.fetchAssetTypes())
         self.instrumentGroups = groups
-        if !groups.isEmpty {
-            selectedGroupId = groups[0].id
+        if let first = groups.first {
+            selectedGroupId = first.id
         }
     }
     

--- a/DragonShield/Views/AssetSubClassPicker.swift
+++ b/DragonShield/Views/AssetSubClassPicker.swift
@@ -1,0 +1,164 @@
+import SwiftUI
+import Combine
+import AppKit
+
+struct AssetSubClassPicker: View {
+    let groups: [(id: Int, name: String)]
+    @Binding var selectedGroupId: Int
+
+    @State private var isPresented = false
+    @State private var searchText = ""
+    @State private var debouncedText = ""
+    @State private var highlightedIndex: Int = 0
+    @FocusState private var isSearchFocused: Bool
+    private let searchSubject = PassthroughSubject<String, Never>()
+
+    private var sortedGroups: [(id: Int, name: String)] {
+        AssetSubClassLookup.sort(groups)
+    }
+
+    private var filteredGroups: [(id: Int, name: String)] {
+        AssetSubClassLookup.filter(sortedGroups, query: debouncedText)
+    }
+
+    var body: some View {
+        Button {
+            highlightedIndex = indexOfSelected()
+            isPresented = true
+        } label: {
+            HStack {
+                Text(selectedName)
+                    .foregroundColor(.black)
+                    .font(.system(size: 16))
+                Spacer()
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(.gray)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(Color.white.opacity(0.8))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+            )
+            .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
+        }
+        .buttonStyle(PlainButtonStyle())
+        .popover(isPresented: $isPresented, arrowEdge: .bottom) {
+            VStack(spacing: 0) {
+                HStack {
+                    Image(systemName: "magnifyingglass")
+                    TextField("Search…", text: $searchText)
+                        .textFieldStyle(PlainTextFieldStyle())
+                        .focused($isSearchFocused)
+                        .onSubmit { selectHighlighted() }
+                    if !searchText.isEmpty {
+                        Button {
+                            searchText = ""
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundColor(.secondary)
+                        }
+                        .buttonStyle(BorderlessButtonStyle())
+                    }
+                }
+                .padding(8)
+                Divider()
+                ScrollViewReader { proxy in
+                    List(selection: Binding(get: { highlightedIndex }, set: { highlightedIndex = $0 })) {
+                        if filteredGroups.isEmpty {
+                            Text("No matches found. Clear the search to see all.")
+                                .foregroundColor(.secondary)
+                        } else {
+                            ForEach(0..<filteredGroups.count, id: \.self) { idx in
+                                let group = filteredGroups[idx]
+                                Text(group.name)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .background(highlightedIndex == idx ? Color.accentColor.opacity(0.2) : Color.clear)
+                                    .tag(idx)
+                                    .onTapGesture {
+                                        select(group: group)
+                                    }
+                            }
+                        }
+                    }
+                    .frame(maxHeight: 360)
+                    .onAppear {
+                        isSearchFocused = true
+                        proxy.scrollTo(highlightedIndex, anchor: .center)
+                        announceResultsCount()
+                    }
+                    .onChange(of: filteredGroups.count) { _, _ in
+                        announceResultsCount()
+                    }
+                    .onChange(of: debouncedText) { _, _ in
+                        if highlightedIndex >= filteredGroups.count {
+                            highlightedIndex = 0
+                        }
+                    }
+                }
+            }
+            .frame(width: 260)
+            .onReceive(searchSubject.debounce(for: .milliseconds(150), scheduler: DispatchQueue.main)) { value in
+                debouncedText = value
+            }
+            .onExitCommand {
+                if !searchText.isEmpty {
+                    searchText = ""
+                } else {
+                    isPresented = false
+                }
+            }
+            .onMoveCommand { direction in
+                switch direction {
+                case .up:
+                    moveHighlight(-1)
+                case .down:
+                    moveHighlight(1)
+                case .pageUp:
+                    moveHighlight(-5)
+                case .pageDown:
+                    moveHighlight(5)
+                default:
+                    break
+                }
+            }
+        }
+        .onChange(of: searchText) { _, value in
+            searchSubject.send(value)
+        }
+    }
+
+    private var selectedName: String {
+        groups.first { $0.id == selectedGroupId }?.name ?? "Select Asset SubClass"
+    }
+
+    private func indexOfSelected() -> Int {
+        sortedGroups.firstIndex { $0.id == selectedGroupId } ?? 0
+    }
+
+    private func selectHighlighted() {
+        guard !filteredGroups.isEmpty else { return }
+        let group = filteredGroups[highlightedIndex]
+        select(group: group)
+    }
+
+    private func select(group: (id: Int, name: String)) {
+        selectedGroupId = group.id
+        isPresented = false
+    }
+
+    private func moveHighlight(_ delta: Int) {
+        guard !filteredGroups.isEmpty else { return }
+        highlightedIndex = max(0, min(filteredGroups.count - 1, highlightedIndex + delta))
+    }
+
+    private func announceResultsCount() {
+        let count = filteredGroups.count
+        NSAccessibility.post(element: NSApp, notification: .announcementRequested, userInfo: [
+            NSAccessibility.NotificationUserInfoKey.announcement: "\(count) results"
+        ])
+    }
+}

--- a/DragonShield/Views/InstrumentEditView.swift
+++ b/DragonShield/Views/InstrumentEditView.swift
@@ -568,44 +568,18 @@ struct InstrumentEditView: View {
                 Image(systemName: "folder.circle.fill")
                     .font(.system(size: 14))
                     .foregroundColor(.gray)
-                
+
                 Text("Asset SubClass*")
                     .font(.system(size: 14, weight: .medium))
                     .foregroundColor(.black.opacity(0.7))
-                
+
                 Spacer()
             }
-            
-            Menu {
-                ForEach(instrumentGroups, id: \.id) { group in
-                    Button(group.name) {
-                        selectedGroupId = group.id
-                        detectChanges()
-                    }
+
+            AssetSubClassPicker(groups: instrumentGroups, selectedGroupId: $selectedGroupId)
+                .onChange(of: selectedGroupId) { _, _ in
+                    detectChanges()
                 }
-            } label: {
-                HStack {
-                    Text(instrumentGroups.first(where: { $0.id == selectedGroupId })?.name ?? "Select Asset SubClass")
-                        .foregroundColor(.black)
-                        .font(.system(size: 16))
-                    
-                    Spacer()
-                    
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(.gray)
-                }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 12)
-                .background(Color.white.opacity(0.8))
-                .clipShape(RoundedRectangle(cornerRadius: 10))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(Color.gray.opacity(0.3), lineWidth: 1)
-                )
-                .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
-            }
-            .buttonStyle(PlainButtonStyle())
         }
     }
     
@@ -721,7 +695,7 @@ struct InstrumentEditView: View {
     // MARK: - Functions
     func loadInstrumentGroups() {
         let dbManager = DatabaseManager()
-        instrumentGroups = dbManager.fetchAssetTypes()
+        instrumentGroups = AssetSubClassLookup.sort(dbManager.fetchAssetTypes())
     }
     
     func loadAvailableCurrencies() {

--- a/DragonShieldTests/AssetSubClassLookupTests.swift
+++ b/DragonShieldTests/AssetSubClassLookupTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import DragonShield
+
+final class AssetSubClassLookupTests: XCTestCase {
+    func testSortingIsCaseAndDiacriticInsensitive() {
+        let groups = [(1, "Équity"), (2, "corporate bond"), (3, "equity ETF")]
+        let sorted = AssetSubClassLookup.sort(groups)
+        XCTAssertEqual(sorted.map { $0.name }, ["corporate bond", "equity ETF", "Équity"])
+    }
+
+    func testFilterContainsCaseAndDiacriticInsensitive() {
+        let groups = [(1, "Corporate Bond"), (2, "Equity ETF"), (3, "Equity Fund")]
+        let filtered = AssetSubClassLookup.filter(groups, query: "equité")
+        XCTAssertEqual(filtered.map { $0.name }, ["Equity ETF", "Equity Fund"])
+    }
+}


### PR DESCRIPTION
## Summary
- replace static Asset SubClass dropdown with searchable picker sorted alphabetically
- centralize diacritic-insensitive sort/filter logic
- cover sort and filter behaviors with tests

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68aac20427708323b2e941c63c94dca5