### PR TITLE
feat: searchable asset subclass picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Replace Asset SubClass menu with searchable, alphabetically sorted picker in Add and Edit Instrument views
 - Replace Theme Status editor pop-up with professional sheet layout and inline validation
 - Introduce preset color picker with custom hex option for Theme Statuses
 - Allow deleting Theme Statuses only when unused and surface detailed database errors

--- a/DragonShield/Views/AddInstrumentView.swift
+++ b/DragonShield/Views/AddInstrumentView.swift
@@ -267,8 +267,10 @@ struct AddInstrumentView: View {
                     icon: "building.2.crop.circle.fill",
                     isRequired: true
                 )
-                
-                modernAssetTypePicker()
+                AssetSubClassPickerView(
+                    instrumentGroups: instrumentGroups,
+                    selectedGroupId: $selectedGroupId
+                )
                 
                 modernCurrencyField()
             }
@@ -456,53 +458,7 @@ struct AddInstrumentView: View {
             }
         }
     }
-    
-    private func modernAssetTypePicker() -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Image(systemName: "folder.circle.fill")
-                    .font(.system(size: 14))
-                    .foregroundColor(.gray)
-                
-                Text("Asset SubClass*")
-                    .font(.system(size: 14, weight: .medium))
-                    .foregroundColor(.black.opacity(0.7))
-                
-                Spacer()
-            }
-            
-            Menu {
-                ForEach(instrumentGroups, id: \.id) { group in
-                    Button(group.name) {
-                        selectedGroupId = group.id
-                    }
-                }
-            } label: {
-                HStack {
-                    Text(instrumentGroups.first(where: { $0.id == selectedGroupId })?.name ?? "Select Asset SubClass")
-                        .foregroundColor(.black)
-                        .font(.system(size: 16))
-                    
-                    Spacer()
-                    
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(.gray)
-                }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 12)
-                .background(Color.white.opacity(0.8))
-                .clipShape(RoundedRectangle(cornerRadius: 10))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(Color.gray.opacity(0.3), lineWidth: 1)
-                )
-                .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
-            }
-            .buttonStyle(PlainButtonStyle())
-        }
-    }
-    
+        
     private func modernCurrencyField() -> some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack {
@@ -616,10 +572,10 @@ struct AddInstrumentView: View {
     // MARK: - Functions
     func loadInstrumentGroups() {
         let dbManager = DatabaseManager()
-        let groups = dbManager.fetchAssetTypes()
+        let groups = AssetSubClassPickerModel.sort(dbManager.fetchAssetTypes())
         self.instrumentGroups = groups
-        if !groups.isEmpty {
-            selectedGroupId = groups[0].id
+        if let first = groups.first {
+            selectedGroupId = first.id
         }
     }
     

--- a/DragonShield/Views/AssetSubClassPicker.swift
+++ b/DragonShield/Views/AssetSubClassPicker.swift
@@ -1,0 +1,183 @@
+import SwiftUI
+
+struct AssetSubClassPickerModel {
+    static func sort(_ groups: [(id: Int, name: String)]) -> [(id: Int, name: String)] {
+        groups.sorted {
+            $0.name
+                .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+                .localizedCompare(
+                    $1.name.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+                ) == .orderedAscending
+        }
+    }
+
+    static func filter(_ groups: [(id: Int, name: String)], query: String) -> [(id: Int, name: String)] {
+        let sortedGroups = sort(groups)
+        guard !query.isEmpty else { return sortedGroups }
+        let q = query.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+        return sortedGroups.filter {
+            $0.name
+                .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+                .contains(q)
+        }
+    }
+}
+
+struct AssetSubClassPickerView: View {
+    let instrumentGroups: [(id: Int, name: String)]
+    @Binding var selectedGroupId: Int
+    var onSelect: (() -> Void)?
+
+    @State private var isPresented = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Image(systemName: "folder.circle.fill")
+                    .font(.system(size: 14))
+                    .foregroundColor(.gray)
+                Text("Asset SubClass*")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundColor(.black.opacity(0.7))
+                Spacer()
+            }
+
+            Button {
+                isPresented = true
+            } label: {
+                HStack {
+                    Text(instrumentGroups.first { $0.id == selectedGroupId }?.name ?? "Select Asset SubClass")
+                        .foregroundColor(.black)
+                        .font(.system(size: 16))
+                    Spacer()
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(.gray)
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+                .background(Color.white.opacity(0.8))
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+                )
+                .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
+            }
+            .buttonStyle(PlainButtonStyle())
+            .sheet(isPresented: $isPresented) {
+                AssetSubClassPickerSheet(
+                    groups: instrumentGroups,
+                    selectedId: $selectedGroupId,
+                    onSelection: {
+                        onSelect?()
+                        isPresented = false
+                    },
+                    onCancel: { isPresented = false }
+                )
+            }
+        }
+    }
+}
+
+private struct AssetSubClassPickerSheet: View {
+    let groups: [(id: Int, name: String)]
+    @Binding var selectedId: Int
+    var onSelection: () -> Void
+    var onCancel: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var searchText = ""
+    @State private var debounceTask: DispatchWorkItem?
+    @State private var filtered: [(id: Int, name: String)] = []
+    @State private var highlighted: Int?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Image(systemName: "magnifyingglass")
+                TextField("Search…", text: $searchText)
+                    .textFieldStyle(PlainTextFieldStyle())
+                    .onChange(of: searchText) { _, _ in
+                        debounceTask?.cancel()
+                        let task = DispatchWorkItem {
+                            filtered = AssetSubClassPickerModel.filter(groups, query: searchText)
+                            highlighted = filtered.first?.id
+                        }
+                        debounceTask = task
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15, execute: task)
+                    }
+                if !searchText.isEmpty {
+                    Button {
+                        searchText = ""
+                        filtered = AssetSubClassPickerModel.filter(groups, query: "")
+                        highlighted = filtered.first?.id
+                    } label: {
+                        Image(systemName: "xmark.circle.fill").foregroundColor(.gray)
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                }
+            }
+            .padding()
+            Divider()
+            ScrollViewReader { proxy in
+                List(selection: $highlighted) {
+                    ForEach(filtered, id: \.id) { group in
+                        Text(group.name)
+                            .tag(group.id)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .contentShape(Rectangle())
+                            .onTapGesture {
+                                selectedId = group.id
+                                onSelection()
+                                dismiss()
+                            }
+                            .help(group.name)
+                    }
+                    if filtered.isEmpty {
+                        Text("No matches found. Clear the search to see all.")
+                            .foregroundColor(.gray)
+                            .tag(-1)
+                            .listRowBackground(Color.clear)
+                    }
+                }
+                .listStyle(PlainListStyle())
+                .frame(maxHeight: 360)
+                .onAppear {
+                    filtered = AssetSubClassPickerModel.filter(groups, query: "")
+                    highlighted = selectedId
+                    DispatchQueue.main.async {
+                        proxy.scrollTo(selectedId, anchor: .center)
+                    }
+                }
+                .onChange(of: highlighted) { _, newValue in
+                    if let id = newValue {
+                        proxy.scrollTo(id, anchor: .center)
+                    }
+                }
+            }
+        }
+        .onExitCommand {
+            if searchText.isEmpty {
+                onCancel()
+                dismiss()
+            } else {
+                searchText = ""
+                filtered = AssetSubClassPickerModel.filter(groups, query: "")
+                highlighted = filtered.first?.id
+            }
+        }
+        .onSubmit {
+            if let id = highlighted, let match = filtered.first(where: { $0.id == id }) {
+                selectedId = match.id
+                onSelection()
+                dismiss()
+            } else if let first = filtered.first {
+                selectedId = first.id
+                onSelection()
+                dismiss()
+            }
+        }
+        .accessibilityLabel("\(filtered.count) results")
+    }
+}

--- a/DragonShield/Views/InstrumentEditView.swift
+++ b/DragonShield/Views/InstrumentEditView.swift
@@ -336,7 +336,11 @@ struct InstrumentEditView: View {
                 
                 // Asset SubClass and Currency side by side
                 HStack(spacing: 16) {
-                    modernAssetTypePicker()
+                    AssetSubClassPickerView(
+                        instrumentGroups: instrumentGroups,
+                        selectedGroupId: $selectedGroupId,
+                        onSelect: { detectChanges() }
+                    )
                         .frame(maxWidth: .infinity)
                     
                     modernCurrencyField()
@@ -561,54 +565,7 @@ struct InstrumentEditView: View {
             }
         }
     }
-    
-    private func modernAssetTypePicker() -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Image(systemName: "folder.circle.fill")
-                    .font(.system(size: 14))
-                    .foregroundColor(.gray)
-                
-                Text("Asset SubClass*")
-                    .font(.system(size: 14, weight: .medium))
-                    .foregroundColor(.black.opacity(0.7))
-                
-                Spacer()
-            }
-            
-            Menu {
-                ForEach(instrumentGroups, id: \.id) { group in
-                    Button(group.name) {
-                        selectedGroupId = group.id
-                        detectChanges()
-                    }
-                }
-            } label: {
-                HStack {
-                    Text(instrumentGroups.first(where: { $0.id == selectedGroupId })?.name ?? "Select Asset SubClass")
-                        .foregroundColor(.black)
-                        .font(.system(size: 16))
-                    
-                    Spacer()
-                    
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(.gray)
-                }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 12)
-                .background(Color.white.opacity(0.8))
-                .clipShape(RoundedRectangle(cornerRadius: 10))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(Color.gray.opacity(0.3), lineWidth: 1)
-                )
-                .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
-            }
-            .buttonStyle(PlainButtonStyle())
-        }
-    }
-    
+        
     private func modernCurrencyField() -> some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack {
@@ -721,7 +678,8 @@ struct InstrumentEditView: View {
     // MARK: - Functions
     func loadInstrumentGroups() {
         let dbManager = DatabaseManager()
-        instrumentGroups = dbManager.fetchAssetTypes()
+        let groups = AssetSubClassPickerModel.sort(dbManager.fetchAssetTypes())
+        instrumentGroups = groups
     }
     
     func loadAvailableCurrencies() {

--- a/DragonShieldTests/AssetSubClassPickerTests.swift
+++ b/DragonShieldTests/AssetSubClassPickerTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import DragonShield
+
+final class AssetSubClassPickerTests: XCTestCase {
+    func testSortAlphabeticalCaseDiacriticInsensitive() {
+        let groups: [(id: Int, name: String)] = [
+            (1, "Équity"),
+            (2, "crypto Fund"),
+            (3, "Corporate Bond")
+        ]
+        let sorted = AssetSubClassPickerModel.sort(groups)
+        XCTAssertEqual(sorted.map { $0.name }, ["Corporate Bond", "crypto Fund", "Équity"])
+    }
+
+    func testFilterContainsCaseDiacriticInsensitive() {
+        let groups: [(id: Int, name: String)] = [
+            (1, "Équity ETF"),
+            (2, "Corporate Bond"),
+            (3, "Crypto Fund")
+        ]
+        let filtered = AssetSubClassPickerModel.filter(groups, query: "equity")
+        XCTAssertEqual(filtered.map { $0.name }, ["Équity ETF"])
+    }
+}


### PR DESCRIPTION
## Summary
- replace asset subclass dropdown with searchable sorted picker in instrument add/edit views
- ensure asset sub classes loaded alphabetically
- test diacritic-insensitive sort and filter logic

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift)*


------
https://chatgpt.com/codex/tasks/task_e_68aac20427708323b2e941c63c94dca5