### PR TITLE
feat: add searchable asset subclass picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Add searchable, alphabetically sorted Asset SubClass picker with expanded list view to Add/Edit Instrument sheets
 - Replace Theme Status editor pop-up with professional sheet layout and inline validation
 - Introduce preset color picker with custom hex option for Theme Statuses
 - Allow deleting Theme Statuses only when unused and surface detailed database errors

--- a/DragonShield/Views/AddInstrumentView.swift
+++ b/DragonShield/Views/AddInstrumentView.swift
@@ -10,7 +10,7 @@ struct AddInstrumentView: View {
     @State private var isin = ""
     @State private var valorNr = ""
     @State private var sector = ""
-    @State private var instrumentGroups: [(id: Int, name: String)] = []
+    @State private var instrumentGroups: [AssetSubClassOption] = []
     @State private var showingAlert = false
     @State private var alertMessage = ""
     @State private var isLoading = false
@@ -471,35 +471,7 @@ struct AddInstrumentView: View {
                 Spacer()
             }
             
-            Menu {
-                ForEach(instrumentGroups, id: \.id) { group in
-                    Button(group.name) {
-                        selectedGroupId = group.id
-                    }
-                }
-            } label: {
-                HStack {
-                    Text(instrumentGroups.first(where: { $0.id == selectedGroupId })?.name ?? "Select Asset SubClass")
-                        .foregroundColor(.black)
-                        .font(.system(size: 16))
-                    
-                    Spacer()
-                    
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(.gray)
-                }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 12)
-                .background(Color.white.opacity(0.8))
-                .clipShape(RoundedRectangle(cornerRadius: 10))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(Color.gray.opacity(0.3), lineWidth: 1)
-                )
-                .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
-            }
-            .buttonStyle(PlainButtonStyle())
+            AssetSubClassPicker(options: instrumentGroups, selection: $selectedGroupId)
         }
     }
     
@@ -616,10 +588,10 @@ struct AddInstrumentView: View {
     // MARK: - Functions
     func loadInstrumentGroups() {
         let dbManager = DatabaseManager()
-        let groups = dbManager.fetchAssetTypes()
-        self.instrumentGroups = groups
-        if !groups.isEmpty {
-            selectedGroupId = groups[0].id
+        let groups = dbManager.fetchAssetTypes().map { AssetSubClassOption(id: $0.id, name: $0.name) }
+        self.instrumentGroups = AssetSubClassPickerLogic.filteredOptions(from: groups, query: "")
+        if !instrumentGroups.isEmpty {
+            selectedGroupId = instrumentGroups[0].id
         }
     }
     

--- a/DragonShield/Views/AssetSubClassPicker.swift
+++ b/DragonShield/Views/AssetSubClassPicker.swift
@@ -1,0 +1,201 @@
+import SwiftUI
+
+struct AssetSubClassOption: Identifiable, Equatable {
+    let id: Int
+    let name: String
+}
+
+enum AssetSubClassPickerLogic {
+    static func filteredOptions(from options: [AssetSubClassOption], query: String) -> [AssetSubClassOption] {
+        let sorted = options.sorted { lhs, rhs in
+            lhs.name.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current) <
+            rhs.name.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+        }
+        guard !query.isEmpty else { return sorted }
+        let needle = query.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+        return sorted.filter {
+            $0.name.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current).contains(needle)
+        }
+    }
+}
+
+struct AssetSubClassPicker: View {
+    let options: [AssetSubClassOption]
+    @Binding var selection: Int
+    var placeholder = "Select Asset SubClass"
+    var onSelect: () -> Void = {}
+
+    @State private var isPresented = false
+    @State private var search = ""
+    @State private var debouncedSearch = ""
+    @State private var highlighted: Int?
+    @State private var searchTask: Task<Void, Never>?
+    @FocusState private var searchFocused: Bool
+
+    var body: some View {
+        Button(action: { isPresented = true }) {
+            HStack {
+                Text(options.first(where: { $0.id == selection })?.name ?? placeholder)
+                    .foregroundColor(.black)
+                    .font(.system(size: 16))
+                Spacer()
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(.gray)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(Color.white.opacity(0.8))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+            )
+            .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
+        }
+        .buttonStyle(PlainButtonStyle())
+        .popover(isPresented: $isPresented) {
+            VStack(spacing: 0) {
+                HStack {
+                    Image(systemName: "magnifyingglass")
+                    TextField("Search…", text: $search)
+                        .focused($searchFocused)
+                        .onSubmit { selectHighlighted() }
+                        .onExitCommand { handleEscape() }
+                        .onMoveCommand { dir in handleMove(dir) }
+                        .textFieldStyle(.roundedBorder)
+                        .frame(maxWidth: .infinity)
+                    if !search.isEmpty {
+                        Button(action: { search = "" }) {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundColor(.gray)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(8)
+                Divider()
+                content
+            }
+            .frame(width: 260, height: 360)
+            .onAppear {
+                search = ""
+                debouncedSearch = ""
+                searchFocused = true
+                highlighted = selection
+            }
+            .onChange(of: search) { _, newValue in
+                debounceSearch(newValue)
+            }
+        }
+    }
+
+    private var filtered: [AssetSubClassOption] {
+        AssetSubClassPickerLogic.filteredOptions(from: options, query: debouncedSearch)
+    }
+
+    @ViewBuilder private var content: some View {
+        if filtered.isEmpty {
+            VStack {
+                Spacer()
+                Text("No matches found. Clear the search to see all.")
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding()
+                Spacer()
+            }
+        } else {
+            ScrollViewReader { proxy in
+                List(selection: $highlighted) {
+                    ForEach(filtered) { option in
+                        Button(action: { select(option) }) {
+                            Text(option.name)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        .tag(option.id)
+                        .buttonStyle(.plain)
+                    }
+                }
+                .listStyle(.plain)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .onAppear {
+                    if let sel = highlighted {
+                        proxy.scrollTo(sel, anchor: .center)
+                    }
+                }
+                .onChange(of: highlighted) { _, newValue in
+                    if let id = newValue {
+                        withAnimation { proxy.scrollTo(id, anchor: .center) }
+                    }
+                }
+                .onChange(of: filtered.count) { _, _ in
+                    announceResults()
+                    if let hi = highlighted, !filtered.contains(where: { $0.id == hi }) {
+                        highlighted = filtered.first?.id
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private func select(_ option: AssetSubClassOption) {
+        selection = option.id
+        onSelect()
+        isPresented = false
+    }
+
+    private func selectHighlighted() {
+        if let id = highlighted, let opt = filtered.first(where: { $0.id == id }) {
+            select(opt)
+        }
+    }
+
+    private func handleEscape() {
+        if !search.isEmpty {
+            search = ""
+        } else {
+            isPresented = false
+        }
+    }
+
+    private func handleMove(_ direction: MoveCommandDirection) {
+        guard !filtered.isEmpty else { return }
+        guard let current = highlighted, let idx = filtered.firstIndex(where: { $0.id == current }) else {
+            highlighted = filtered.first?.id
+            return
+        }
+        switch direction {
+        case .down:
+            let next = min(idx + 1, filtered.count - 1)
+            highlighted = filtered[next].id
+        case .up:
+            let prev = max(idx - 1, 0)
+            highlighted = filtered[prev].id
+        case .pageDown:
+            let next = min(idx + 10, filtered.count - 1)
+            highlighted = filtered[next].id
+        case .pageUp:
+            let prev = max(idx - 10, 0)
+            highlighted = filtered[prev].id
+        default:
+            break
+        }
+    }
+
+    private func debounceSearch(_ text: String) {
+        searchTask?.cancel()
+        searchTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 150_000_000)
+            debouncedSearch = text
+            highlighted = filtered.first?.id
+        }
+    }
+
+    private func announceResults() {
+#if os(macOS)
+        let message = "\(filtered.count) results"
+        NSAccessibility.post(element: NSApp, notification: .announcementRequested, userInfo: [NSAccessibility.announcementKey: message])
+#endif
+    }
+}

--- a/DragonShield/Views/InstrumentEditView.swift
+++ b/DragonShield/Views/InstrumentEditView.swift
@@ -11,7 +11,7 @@ struct InstrumentEditView: View {
     @State private var isin = ""
     @State private var valorNr = ""
     @State private var sector = ""
-    @State private var instrumentGroups: [(id: Int, name: String)] = []
+    @State private var instrumentGroups: [AssetSubClassOption] = []
     @State private var availableCurrencies: [(code: String, name: String, symbol: String)] = []
     @State private var showingAlert = false
     @State private var alertMessage = ""
@@ -576,36 +576,7 @@ struct InstrumentEditView: View {
                 Spacer()
             }
             
-            Menu {
-                ForEach(instrumentGroups, id: \.id) { group in
-                    Button(group.name) {
-                        selectedGroupId = group.id
-                        detectChanges()
-                    }
-                }
-            } label: {
-                HStack {
-                    Text(instrumentGroups.first(where: { $0.id == selectedGroupId })?.name ?? "Select Asset SubClass")
-                        .foregroundColor(.black)
-                        .font(.system(size: 16))
-                    
-                    Spacer()
-                    
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(.gray)
-                }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 12)
-                .background(Color.white.opacity(0.8))
-                .clipShape(RoundedRectangle(cornerRadius: 10))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(Color.gray.opacity(0.3), lineWidth: 1)
-                )
-                .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
-            }
-            .buttonStyle(PlainButtonStyle())
+            AssetSubClassPicker(options: instrumentGroups, selection: $selectedGroupId, onSelect: detectChanges)
         }
     }
     
@@ -721,7 +692,8 @@ struct InstrumentEditView: View {
     // MARK: - Functions
     func loadInstrumentGroups() {
         let dbManager = DatabaseManager()
-        instrumentGroups = dbManager.fetchAssetTypes()
+        let groups = dbManager.fetchAssetTypes().map { AssetSubClassOption(id: $0.id, name: $0.name) }
+        instrumentGroups = AssetSubClassPickerLogic.filteredOptions(from: groups, query: "")
     }
     
     func loadAvailableCurrencies() {

--- a/DragonShieldTests/AssetSubClassPickerTests.swift
+++ b/DragonShieldTests/AssetSubClassPickerTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import DragonShield
+
+final class AssetSubClassPickerTests: XCTestCase {
+    func testSortingIsCaseAndDiacriticInsensitive() {
+        let options = [
+            AssetSubClassOption(id: 1, name: "Crypto Fund"),
+            AssetSubClassOption(id: 2, name: "Équity ETF"),
+            AssetSubClassOption(id: 3, name: "corporate bond")
+        ]
+        let result = AssetSubClassPickerLogic.filteredOptions(from: options, query: "")
+        XCTAssertEqual(result.map { $0.name }, ["corporate bond", "Crypto Fund", "Équity ETF"])
+    }
+
+    func testFilteringIsCaseAndDiacriticInsensitive() {
+        let options = [
+            AssetSubClassOption(id: 1, name: "Crypto Fund"),
+            AssetSubClassOption(id: 2, name: "Équity ETF"),
+            AssetSubClassOption(id: 3, name: "Equity Fund"),
+            AssetSubClassOption(id: 4, name: "Infrastructure")
+        ]
+        let result = AssetSubClassPickerLogic.filteredOptions(from: options, query: "equity")
+        XCTAssertEqual(result.map { $0.name }, ["Équity ETF", "Equity Fund"])
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable searchable Asset SubClass picker
- use searchable picker in add & edit instrument sheets
- cover picker sorting and filtering logic with unit tests
- expand picker list to show many items and allow selection

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild -scheme DragonShield build` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68aac20427708323b2e941c63c94dca5