### PR TITLE
Handle fractional-second timestamps in overview and test date filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Ensure Portfolio Theme Overview date filter handles fractional-second timestamps and add tests for 7/30/90 day ranges
 - Replace Asset SubClass menu with searchable, alphabetically sorted picker in Add and Edit Instrument views
 - Remove duplicate note previews from Theme Details Overview rows
 - Replace Theme Status editor pop-up with professional sheet layout and inline validation

--- a/DragonShield/Views/PortfolioThemeOverviewView.swift
+++ b/DragonShield/Views/PortfolioThemeOverviewView.swift
@@ -225,6 +225,7 @@ struct PortfolioThemeOverviewView: View {
         var list = dbManager.listThemeUpdates(themeId: themeId, view: .active, type: selectedType, searchQuery: query, pinnedFirst: pinnedFirst)
         if dateFilter != .all {
             let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
             let tz = TimeZone(identifier: dbManager.defaultTimeZone) ?? .current
             list = list.filter { upd in
                 if let date = formatter.date(from: upd.createdAt) {

--- a/DragonShieldTests/PortfolioThemeOverviewViewTests.swift
+++ b/DragonShieldTests/PortfolioThemeOverviewViewTests.swift
@@ -18,6 +18,30 @@ final class PortfolioThemeOverviewViewTests: XCTestCase {
         XCTAssertFalse(PortfolioThemeOverviewView.DateFilter.last7d.contains(eightDaysAgo, timeZone: tz))
     }
 
+    func testDateFilterLast30d() {
+        let tz = TimeZone(secondsFromGMT: 0)!
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = tz
+        let now = Date()
+        let startToday = calendar.startOfDay(for: now)
+        let twentyDaysAgo = calendar.date(byAdding: .day, value: -20, to: startToday)!
+        XCTAssertTrue(PortfolioThemeOverviewView.DateFilter.last30d.contains(twentyDaysAgo, timeZone: tz))
+        let thirtyOneDaysAgo = calendar.date(byAdding: .day, value: -31, to: startToday)!
+        XCTAssertFalse(PortfolioThemeOverviewView.DateFilter.last30d.contains(thirtyOneDaysAgo, timeZone: tz))
+    }
+
+    func testDateFilterLast90d() {
+        let tz = TimeZone(secondsFromGMT: 0)!
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = tz
+        let now = Date()
+        let startToday = calendar.startOfDay(for: now)
+        let sixtyDaysAgo = calendar.date(byAdding: .day, value: -60, to: startToday)!
+        XCTAssertTrue(PortfolioThemeOverviewView.DateFilter.last90d.contains(sixtyDaysAgo, timeZone: tz))
+        let ninetyOneDaysAgo = calendar.date(byAdding: .day, value: -91, to: startToday)!
+        XCTAssertFalse(PortfolioThemeOverviewView.DateFilter.last90d.contains(ninetyOneDaysAgo, timeZone: tz))
+    }
+
     func testTitleOrPlaceholder() {
         XCTAssertEqual(PortfolioThemeOverviewView.titleOrPlaceholder(""), "(No title)")
         XCTAssertEqual(PortfolioThemeOverviewView.titleOrPlaceholder("Alpha"), "Alpha")

--- a/DragonShieldTests/PortfolioThemeOverviewViewTests.swift
+++ b/DragonShieldTests/PortfolioThemeOverviewViewTests.swift
@@ -24,10 +24,10 @@ final class PortfolioThemeOverviewViewTests: XCTestCase {
         calendar.timeZone = tz
         let now = Date()
         let startToday = calendar.startOfDay(for: now)
-        let twentyDaysAgo = calendar.date(byAdding: .day, value: -20, to: startToday)!
-        XCTAssertTrue(PortfolioThemeOverviewView.DateFilter.last30d.contains(twentyDaysAgo, timeZone: tz))
-        let thirtyOneDaysAgo = calendar.date(byAdding: .day, value: -31, to: startToday)!
-        XCTAssertFalse(PortfolioThemeOverviewView.DateFilter.last30d.contains(thirtyOneDaysAgo, timeZone: tz))
+        let twentyNineDaysAgo = calendar.date(byAdding: .day, value: -29, to: startToday)!
+        XCTAssertTrue(PortfolioThemeOverviewView.DateFilter.last30d.contains(twentyNineDaysAgo, timeZone: tz))
+        let thirtyDaysAgo = calendar.date(byAdding: .day, value: -30, to: startToday)!
+        XCTAssertFalse(PortfolioThemeOverviewView.DateFilter.last30d.contains(thirtyDaysAgo, timeZone: tz))
     }
 
     func testDateFilterLast90d() {

--- a/DragonShieldTests/PortfolioThemeOverviewViewTests.swift
+++ b/DragonShieldTests/PortfolioThemeOverviewViewTests.swift
@@ -36,10 +36,10 @@ final class PortfolioThemeOverviewViewTests: XCTestCase {
         calendar.timeZone = tz
         let now = Date()
         let startToday = calendar.startOfDay(for: now)
-        let sixtyDaysAgo = calendar.date(byAdding: .day, value: -60, to: startToday)!
-        XCTAssertTrue(PortfolioThemeOverviewView.DateFilter.last90d.contains(sixtyDaysAgo, timeZone: tz))
-        let ninetyOneDaysAgo = calendar.date(byAdding: .day, value: -91, to: startToday)!
-        XCTAssertFalse(PortfolioThemeOverviewView.DateFilter.last90d.contains(ninetyOneDaysAgo, timeZone: tz))
+        let eightyNineDaysAgo = calendar.date(byAdding: .day, value: -89, to: startToday)!
+        XCTAssertTrue(PortfolioThemeOverviewView.DateFilter.last90d.contains(eightyNineDaysAgo, timeZone: tz))
+        let ninetyDaysAgo = calendar.date(byAdding: .day, value: -90, to: startToday)!
+        XCTAssertFalse(PortfolioThemeOverviewView.DateFilter.last90d.contains(ninetyDaysAgo, timeZone: tz))
     }
 
     func testTitleOrPlaceholder() {


### PR DESCRIPTION
## Summary
- ensure Portfolio Theme Overview uses an ISO formatter with fractional seconds
- add unit tests for 7/30/90 day date filters
- document the fix in the changelog

## Testing
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild -project DragonShield.xcodeproj -scheme DragonShield -quiet build` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68aad6546eb483239646f8bd4c738c1b