### PR TITLE
Expand asset subclass picker for instruments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Expand Asset SubClass picker sheet to display more rows
 - Ensure Portfolio Theme Overview date filter handles fractional-second timestamps and add tests for 7/30/90 day ranges
 - Replace Asset SubClass menu with searchable, alphabetically sorted picker in Add and Edit Instrument views
 - Remove duplicate note previews from Theme Details Overview rows

--- a/DragonShield/Views/AssetSubClassPicker.swift
+++ b/DragonShield/Views/AssetSubClassPicker.swift
@@ -142,7 +142,7 @@ private struct AssetSubClassPickerSheet: View {
                     }
                 }
                 .listStyle(PlainListStyle())
-                .frame(maxHeight: 360)
+                .frame(maxHeight: 700)
                 .onAppear {
                     filtered = AssetSubClassPickerModel.filter(groups, query: "")
                     highlighted = selectedId


### PR DESCRIPTION
## Summary
- enlarge Asset SubClass picker sheet to show more rows when selecting instrument asset sub classes
- document picker height change in changelog

## Testing
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `make setup` *(fails: No rule to make target 'setup')*

------
https://chatgpt.com/codex/tasks/task_e_68aad937f778832385489e3edfab154f