### PR TITLE
Expand asset subclass dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Enlarge Asset SubClass dropdown in Instrument maintenance to show more rows
 - Ensure Portfolio Theme Overview date filter handles fractional-second timestamps and add tests for 7/30/90 day ranges
 - Replace Asset SubClass menu with searchable, alphabetically sorted picker in Add and Edit Instrument views
 - Remove duplicate note previews from Theme Details Overview rows

--- a/DragonShield/Views/AssetSubClassPicker.swift
+++ b/DragonShield/Views/AssetSubClassPicker.swift
@@ -142,7 +142,7 @@ private struct AssetSubClassPickerSheet: View {
                     }
                 }
                 .listStyle(PlainListStyle())
-                .frame(maxHeight: 360)
+                .frame(maxHeight: 600)
                 .onAppear {
                     filtered = AssetSubClassPickerModel.filter(groups, query: "")
                     highlighted = selectedId


### PR DESCRIPTION
## Summary
- Enlarge Asset SubClass dropdown in instrument maintenance to show more rows

## Testing
- `make setup` *(fails: No rule to make target `setup`)*
- `make fmt` *(fails: No rule to make target `fmt`)*
- `make lint` *(fails: No rule to make target `lint`)*
- `make migrate` *(fails: No rule to make target `migrate`)*
- `make build` *(fails: No rule to make target `build`)*
- `make test` *(fails: No rule to make target `test`)*
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68aad937f778832385489e3edfab154f