### PR TITLE
Add cascading deletes across asset hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Cascade deletes from AssetClasses through AssetSubClasses, Instruments, and PositionReports (migration 022)
 - Enlarge Asset SubClass picker sheet to show more options at once
 - Remove Kanban To-Do board and sidebar link
 - Ensure Portfolio Theme Overview date filter handles fractional-second timestamps and add tests for 7/30/90 day ranges

--- a/DragonShield/db/migrations/022_cascade_delete_chain.sql
+++ b/DragonShield/db/migrations/022_cascade_delete_chain.sql
@@ -1,0 +1,184 @@
+-- migrate:up
+-- Purpose: enforce cascading deletes from asset classes down to position reports
+-- Assumptions: existing records have valid foreign-key relations; triggers and indexes will be recreated
+-- Idempotency: recreates tables using temporary names; safe to run once
+
+-- Recreate AssetSubClasses with cascade on class_id
+CREATE TABLE AssetSubClasses_new (
+    sub_class_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    class_id INTEGER NOT NULL,
+    sub_class_code TEXT NOT NULL UNIQUE,
+    sub_class_name TEXT NOT NULL,
+    sub_class_description TEXT,
+    sort_order INTEGER DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (class_id) REFERENCES AssetClasses(class_id) ON DELETE CASCADE
+);
+INSERT INTO AssetSubClasses_new SELECT * FROM AssetSubClasses;
+DROP TABLE AssetSubClasses;
+ALTER TABLE AssetSubClasses_new RENAME TO AssetSubClasses;
+
+-- Recreate Instruments with cascade on sub_class_id
+CREATE TABLE Instruments_new (
+    instrument_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    isin TEXT UNIQUE,
+    valor_nr TEXT UNIQUE,
+    ticker_symbol TEXT,
+    instrument_name TEXT NOT NULL,
+    sub_class_id INTEGER NOT NULL,
+    currency TEXT NOT NULL,
+    country_code TEXT,
+    exchange_code TEXT,
+    sector TEXT,
+    include_in_portfolio BOOLEAN DEFAULT 1,
+    is_active BOOLEAN DEFAULT 1,
+    notes TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    isin_original TEXT,
+    valor_original TEXT,
+    validation_status TEXT DEFAULT 'valid' CHECK(validation_status IN ('valid','invalid','pending_validation')),
+    restore_source TEXT DEFAULT 'original',
+    restore_timestamp DATETIME,
+    is_deleted BOOLEAN DEFAULT 0,
+    deleted_at DATETIME,
+    deleted_reason TEXT,
+    FOREIGN KEY (sub_class_id) REFERENCES AssetSubClasses(sub_class_id) ON DELETE CASCADE,
+    FOREIGN KEY (currency) REFERENCES Currencies(currency_code)
+);
+INSERT INTO Instruments_new SELECT * FROM Instruments;
+DROP TABLE Instruments;
+ALTER TABLE Instruments_new RENAME TO Instruments;
+
+CREATE INDEX idx_instruments_isin ON Instruments(isin);
+CREATE INDEX idx_instruments_ticker ON Instruments(ticker_symbol);
+CREATE INDEX idx_instruments_sub_class ON Instruments(sub_class_id);
+CREATE INDEX idx_instruments_currency ON Instruments(currency);
+
+CREATE TRIGGER tr_instruments_updated_at
+AFTER UPDATE ON Instruments
+BEGIN
+    UPDATE Instruments
+       SET updated_at = CURRENT_TIMESTAMP
+     WHERE instrument_id = NEW.instrument_id;
+END;
+
+-- Recreate PositionReports with cascade on instrument_id
+CREATE TABLE PositionReports_new (
+    position_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    import_session_id INTEGER,
+    account_id INTEGER NOT NULL,
+    institution_id INTEGER NOT NULL,
+    instrument_id INTEGER NOT NULL,
+    quantity REAL NOT NULL,
+    purchase_price REAL,
+    current_price REAL,
+    instrument_updated_at DATE,
+    notes TEXT,
+    report_date DATE NOT NULL,
+    uploaded_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (import_session_id) REFERENCES ImportSessions(import_session_id),
+    FOREIGN KEY (account_id) REFERENCES Accounts(account_id),
+    FOREIGN KEY (institution_id) REFERENCES Institutions(institution_id),
+    FOREIGN KEY (instrument_id) REFERENCES Instruments(instrument_id) ON DELETE CASCADE
+);
+INSERT INTO PositionReports_new SELECT * FROM PositionReports;
+DROP TABLE PositionReports;
+ALTER TABLE PositionReports_new RENAME TO PositionReports;
+
+DELETE FROM sqlite_sequence WHERE name IN ('AssetSubClasses','Instruments','PositionReports');
+INSERT INTO sqlite_sequence(name, seq) SELECT 'AssetSubClasses', IFNULL(MAX(sub_class_id),0) FROM AssetSubClasses;
+INSERT INTO sqlite_sequence(name, seq) SELECT 'Instruments', IFNULL(MAX(instrument_id),0) FROM Instruments;
+INSERT INTO sqlite_sequence(name, seq) SELECT 'PositionReports', IFNULL(MAX(position_id),0) FROM PositionReports;
+
+-- migrate:down
+-- Purpose: revert cascading deletes to previous restrict behavior
+-- Assumptions: data fits original constraints
+-- Idempotency: recreates tables without ON DELETE CASCADE
+
+CREATE TABLE PositionReports_old (
+    position_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    import_session_id INTEGER,
+    account_id INTEGER NOT NULL,
+    institution_id INTEGER NOT NULL,
+    instrument_id INTEGER NOT NULL,
+    quantity REAL NOT NULL,
+    purchase_price REAL,
+    current_price REAL,
+    instrument_updated_at DATE,
+    notes TEXT,
+    report_date DATE NOT NULL,
+    uploaded_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (import_session_id) REFERENCES ImportSessions(import_session_id),
+    FOREIGN KEY (account_id) REFERENCES Accounts(account_id),
+    FOREIGN KEY (institution_id) REFERENCES Institutions(institution_id),
+    FOREIGN KEY (instrument_id) REFERENCES Instruments(instrument_id)
+);
+INSERT INTO PositionReports_old SELECT * FROM PositionReports;
+DROP TABLE PositionReports;
+ALTER TABLE PositionReports_old RENAME TO PositionReports;
+
+CREATE TABLE Instruments_old (
+    instrument_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    isin TEXT UNIQUE,
+    valor_nr TEXT UNIQUE,
+    ticker_symbol TEXT,
+    instrument_name TEXT NOT NULL,
+    sub_class_id INTEGER NOT NULL,
+    currency TEXT NOT NULL,
+    country_code TEXT,
+    exchange_code TEXT,
+    sector TEXT,
+    include_in_portfolio BOOLEAN DEFAULT 1,
+    is_active BOOLEAN DEFAULT 1,
+    notes TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    isin_original TEXT,
+    valor_original TEXT,
+    validation_status TEXT DEFAULT 'valid' CHECK(validation_status IN ('valid','invalid','pending_validation')),
+    restore_source TEXT DEFAULT 'original',
+    restore_timestamp DATETIME,
+    is_deleted BOOLEAN DEFAULT 0,
+    deleted_at DATETIME,
+    deleted_reason TEXT,
+    FOREIGN KEY (sub_class_id) REFERENCES AssetSubClasses(sub_class_id),
+    FOREIGN KEY (currency) REFERENCES Currencies(currency_code)
+);
+INSERT INTO Instruments_old SELECT * FROM Instruments;
+DROP TABLE Instruments;
+ALTER TABLE Instruments_old RENAME TO Instruments;
+
+CREATE INDEX idx_instruments_isin ON Instruments(isin);
+CREATE INDEX idx_instruments_ticker ON Instruments(ticker_symbol);
+CREATE INDEX idx_instruments_sub_class ON Instruments(sub_class_id);
+CREATE INDEX idx_instruments_currency ON Instruments(currency);
+
+CREATE TRIGGER tr_instruments_updated_at
+AFTER UPDATE ON Instruments
+BEGIN
+    UPDATE Instruments
+       SET updated_at = CURRENT_TIMESTAMP
+     WHERE instrument_id = NEW.instrument_id;
+END;
+
+CREATE TABLE AssetSubClasses_old (
+    sub_class_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    class_id INTEGER NOT NULL,
+    sub_class_code TEXT NOT NULL UNIQUE,
+    sub_class_name TEXT NOT NULL,
+    sub_class_description TEXT,
+    sort_order INTEGER DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (class_id) REFERENCES AssetClasses(class_id)
+);
+INSERT INTO AssetSubClasses_old SELECT * FROM AssetSubClasses;
+DROP TABLE AssetSubClasses;
+ALTER TABLE AssetSubClasses_old RENAME TO AssetSubClasses;
+
+DELETE FROM sqlite_sequence WHERE name IN ('AssetSubClasses','Instruments','PositionReports');
+INSERT INTO sqlite_sequence(name, seq) SELECT 'AssetSubClasses', IFNULL(MAX(sub_class_id),0) FROM AssetSubClasses;
+INSERT INTO sqlite_sequence(name, seq) SELECT 'Instruments', IFNULL(MAX(instrument_id),0) FROM Instruments;
+INSERT INTO sqlite_sequence(name, seq) SELECT 'PositionReports', IFNULL(MAX(position_id),0) FROM PositionReports;

--- a/DragonShieldTests/CascadeDeleteTests.swift
+++ b/DragonShieldTests/CascadeDeleteTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+import SQLite3
+@testable import DragonShield
+
+final class CascadeDeleteTests: XCTestCase {
+    var db: OpaquePointer?
+
+    override func setUp() {
+        super.setUp()
+        sqlite3_open(":memory:", &db)
+        sqlite3_exec(db, "PRAGMA foreign_keys = ON;", nil, nil, nil)
+        let setup = """
+        CREATE TABLE AssetClasses(
+            class_id INTEGER PRIMARY KEY,
+            class_code TEXT NOT NULL,
+            class_name TEXT NOT NULL
+        );
+        CREATE TABLE AssetSubClasses(
+            sub_class_id INTEGER PRIMARY KEY,
+            class_id INTEGER NOT NULL,
+            sub_class_code TEXT NOT NULL,
+            sub_class_name TEXT NOT NULL,
+            FOREIGN KEY(class_id) REFERENCES AssetClasses(class_id) ON DELETE CASCADE
+        );
+        CREATE TABLE Instruments(
+            instrument_id INTEGER PRIMARY KEY,
+            instrument_name TEXT NOT NULL,
+            sub_class_id INTEGER NOT NULL,
+            currency TEXT NOT NULL,
+            FOREIGN KEY(sub_class_id) REFERENCES AssetSubClasses(sub_class_id) ON DELETE CASCADE
+        );
+        CREATE TABLE Accounts(account_id INTEGER PRIMARY KEY);
+        CREATE TABLE Institutions(institution_id INTEGER PRIMARY KEY);
+        CREATE TABLE ImportSessions(import_session_id INTEGER PRIMARY KEY);
+        CREATE TABLE PositionReports(
+            position_id INTEGER PRIMARY KEY,
+            import_session_id INTEGER,
+            account_id INTEGER NOT NULL,
+            institution_id INTEGER NOT NULL,
+            instrument_id INTEGER NOT NULL,
+            quantity REAL NOT NULL,
+            report_date DATE NOT NULL,
+            FOREIGN KEY(import_session_id) REFERENCES ImportSessions(import_session_id),
+            FOREIGN KEY(account_id) REFERENCES Accounts(account_id),
+            FOREIGN KEY(institution_id) REFERENCES Institutions(institution_id),
+            FOREIGN KEY(instrument_id) REFERENCES Instruments(instrument_id) ON DELETE CASCADE
+        );
+        INSERT INTO Accounts(account_id) VALUES(1);
+        INSERT INTO Institutions(institution_id) VALUES(1);
+        INSERT INTO ImportSessions(import_session_id) VALUES(1);
+        """
+        sqlite3_exec(db, setup, nil, nil, nil)
+    }
+
+    override func tearDown() {
+        sqlite3_close(db)
+        db = nil
+        super.tearDown()
+    }
+
+    private func count(_ table: String) -> Int {
+        var stmt: OpaquePointer?
+        sqlite3_prepare_v2(db, "SELECT COUNT(*) FROM \(table);", -1, &stmt, nil)
+        defer { sqlite3_finalize(stmt) }
+        sqlite3_step(stmt)
+        return Int(sqlite3_column_int(stmt, 0))
+    }
+
+    func testCascadeDelete() {
+        let insert = """
+        INSERT INTO AssetClasses(class_id, class_code, class_name) VALUES (1,'C','Class');
+        INSERT INTO AssetSubClasses(sub_class_id, class_id, sub_class_code, sub_class_name) VALUES (10,1,'SC','Sub');
+        INSERT INTO Instruments(instrument_id, instrument_name, sub_class_id, currency) VALUES (100,'Inst',10,'CHF');
+        INSERT INTO PositionReports(position_id, import_session_id, account_id, institution_id, instrument_id, quantity, report_date)
+        VALUES (1000,1,1,1,100,1,'2024-01-01');
+        """
+        sqlite3_exec(db, insert, nil, nil, nil)
+        sqlite3_exec(db, "DELETE FROM AssetClasses WHERE class_id=1;", nil, nil, nil)
+        XCTAssertEqual(count("AssetSubClasses"), 0)
+        XCTAssertEqual(count("Instruments"), 0)
+        XCTAssertEqual(count("PositionReports"), 0)
+    }
+}


### PR DESCRIPTION
## Summary
- cascade deletions from AssetClasses through AssetSubClasses, Instruments, and PositionReports
- test cascade behavior with in-memory SQLite
- document cascade deletion migration

## Testing
- `make setup` (fails: No rule to make target 'setup')
- `make fmt` (fails: No rule to make target 'fmt')
- `make lint` (fails: No rule to make target 'lint')
- `make migrate` (fails: No rule to make target 'migrate')
- `make build` (fails: No rule to make target 'build')
- `make test` (fails: No rule to make target 'test')
- `swift test` (fails: Could not find Package.swift)
- `sqlite3 /tmp/test.db` cascade verification

------
https://chatgpt.com/codex/tasks/task_e_68aade98f9848323a11e7411831be801