### PR TITLE
Enable text selection in import summary panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 
 ### Added
 - Restructure changelog and archive history (#PR_NUMBER)
+- Enable text selection in import summary panel (#PR_NUMBER)
 
 ### Changed
 

--- a/DragonShield/Views/ImportSummaryPanel.swift
+++ b/DragonShield/Views/ImportSummaryPanel.swift
@@ -31,6 +31,7 @@ struct ImportSummaryPanel: View {
                         Text("% Valuation Processed: \(summary.percentValuationRecords)")
                     }
                 }
+                .textSelection(.enabled)
                 if !logs.isEmpty {
                     Divider()
                     VStack(alignment: .leading, spacing: 2) {
@@ -40,6 +41,7 @@ struct ImportSummaryPanel: View {
                                 .frame(maxWidth: .infinity, alignment: .leading)
                         }
                     }
+                    .textSelection(.enabled)
                 }
             }
             .padding()

--- a/DragonShieldTests/ImportSummaryPanelTests.swift
+++ b/DragonShieldTests/ImportSummaryPanelTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+import SwiftUI
+@testable import DragonShield
+#if canImport(AppKit)
+import AppKit
+#endif
+
+final class ImportSummaryPanelTests: XCTestCase {
+    func testTextSelectionEnabled() {
+        let summary = PositionImportSummary(totalRows: 1,
+                                           parsedRows: 1,
+                                           cashAccounts: 1,
+                                           securityRecords: 0,
+                                           unmatchedInstruments: 0,
+                                           percentValuationRecords: 0)
+        let view = ImportSummaryPanel(summary: summary,
+                                      logs: ["Sample log"],
+                                      isPresented: .constant(true))
+#if canImport(AppKit)
+        let hosting = NSHostingView(rootView: view)
+        hosting.layoutSubtreeIfNeeded()
+        let textFields = hosting.allTextFields()
+        XCTAssertTrue(textFields.contains { $0.stringValue.contains("Total Rows: 1") })
+        XCTAssertTrue(textFields.contains { $0.stringValue.contains("Sample log") })
+        XCTAssertTrue(textFields.allSatisfy(\.isSelectable))
+#else
+        _ = view.body
+#endif
+    }
+}
+
+#if canImport(AppKit)
+private extension NSView {
+    func allTextFields() -> [NSTextField] {
+        var result: [NSTextField] = []
+        func visit(_ view: NSView) {
+            if let field = view as? NSTextField {
+                result.append(field)
+            }
+            for sub in view.subviews {
+                visit(sub)
+            }
+        }
+        visit(self)
+        return result
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- allow selecting/copying values in import summary panel
- add test verifying summary and log fields support selection

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68aae15b53948323a10ef2e5b3c6430d