### PR TITLE
feat: make import summary text copyable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 
 ### Added
 - Restructure changelog and archive history (#PR_NUMBER)
+- Introduce `SelectableLabel` for copyable text and adopt it in the import summary panel (#PR_NUMBER)
 
 ### Changed
 

--- a/DragonShield/Views/ImportSummaryPanel.swift
+++ b/DragonShield/Views/ImportSummaryPanel.swift
@@ -9,7 +9,7 @@ struct ImportSummaryPanel: View {
         ScrollView(.vertical) {
             VStack(alignment: .leading, spacing: 8) {
                 HStack {
-                    Text("Import Summary")
+                    SelectableLabel("Import Summary")
                         .font(.headline)
                     Spacer()
                     Button(action: { isPresented = false }) {
@@ -20,22 +20,22 @@ struct ImportSummaryPanel: View {
                 }
                 Divider()
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("Total Rows: \(summary.totalRows)")
-                    Text("Parsed Rows: \(summary.parsedRows)")
-                    Text("Cash Accounts: \(summary.cashAccounts)")
-                    Text("Securities: \(summary.securityRecords)")
+                    SelectableLabel("Total Rows: \(summary.totalRows)")
+                    SelectableLabel("Parsed Rows: \(summary.parsedRows)")
+                    SelectableLabel("Cash Accounts: \(summary.cashAccounts)")
+                    SelectableLabel("Securities: \(summary.securityRecords)")
                     if summary.unmatchedInstruments > 0 {
-                        Text("Unmatched Instruments: \(summary.unmatchedInstruments)")
+                        SelectableLabel("Unmatched Instruments: \(summary.unmatchedInstruments)")
                     }
                     if summary.percentValuationRecords > 0 {
-                        Text("% Valuation Processed: \(summary.percentValuationRecords)")
+                        SelectableLabel("% Valuation Processed: \(summary.percentValuationRecords)")
                     }
                 }
                 if !logs.isEmpty {
                     Divider()
                     VStack(alignment: .leading, spacing: 2) {
                         ForEach(Array(logs.enumerated()), id: \.offset) { _, msg in
-                            Text(msg)
+                            SelectableLabel(msg)
                                 .font(.caption2)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                         }

--- a/DragonShield/Views/SelectableLabel.swift
+++ b/DragonShield/Views/SelectableLabel.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+struct SelectableLabel: View {
+    private let text: String
+
+    init(_ text: String) {
+        self.text = text
+    }
+
+    var body: some View {
+        Representable(text: text)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+}
+
+#if os(macOS)
+import AppKit
+private struct Representable: NSViewRepresentable {
+    let text: String
+    @Environment(\.font) private var font
+
+    func makeNSView(context: Context) -> NSTextView {
+        let view = NSTextView()
+        view.isEditable = false
+        view.isSelectable = true
+        view.drawsBackground = false
+        view.isRichText = false
+        view.importsGraphics = false
+        view.textContainerInset = .zero
+        view.textContainer?.lineFragmentPadding = 0
+        return view
+    }
+
+    func updateNSView(_ nsView: NSTextView, context: Context) {
+        nsView.string = text
+        if let font = font {
+            nsView.font = NSFont(font)
+        }
+    }
+}
+#else
+import UIKit
+private struct Representable: UIViewRepresentable {
+    let text: String
+    @Environment(\.font) private var font
+
+    func makeUIView(context: Context) -> UITextView {
+        let view = UITextView()
+        view.isEditable = false
+        view.isSelectable = true
+        view.isScrollEnabled = false
+        view.backgroundColor = .clear
+        view.textContainerInset = .zero
+        view.textContainer.lineFragmentPadding = 0
+        return view
+    }
+
+    func updateUIView(_ uiView: UITextView, context: Context) {
+        uiView.text = text
+        if let font = font {
+            uiView.font = UIFont(font)
+        }
+    }
+}
+#endif

--- a/DragonShieldTests/ImportSummaryPanelTests.swift
+++ b/DragonShieldTests/ImportSummaryPanelTests.swift
@@ -1,0 +1,118 @@
+import XCTest
+import SwiftUI
+@testable import DragonShield
+#if canImport(AppKit)
+import AppKit
+#endif
+
+/*
+ Test strategy:
+ 1. Render ImportSummaryPanel containing SelectableLabel components.
+ 2. For a positive case, programmatically select text, send Command-C via performKeyEquivalent, and verify the pasteboard contains the expected string.
+ 3. For a negative case, invoke copy without selection and assert the pasteboard remains empty.
+*/
+
+final class ImportSummaryPanelTests: XCTestCase {
+    func testCopyingSelectableLabelCopiesText() {
+        let summary = PositionImportSummary(totalRows: 1,
+                                           parsedRows: 1,
+                                           cashAccounts: 1,
+                                           securityRecords: 0,
+                                           unmatchedInstruments: 0,
+                                           percentValuationRecords: 0)
+        let view = ImportSummaryPanel(summary: summary,
+                                      logs: ["Sample log"],
+                                      isPresented: .constant(true))
+#if canImport(AppKit)
+        let hosting = NSHostingView(rootView: view)
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 200, height: 200),
+                              styleMask: [.borderless],
+                              backing: .buffered,
+                              defer: false)
+        window.contentView = hosting
+        window.makeKeyAndOrderFront(nil)
+        hosting.layoutSubtreeIfNeeded()
+        let textViews = hosting.allTextViews()
+        guard let totalRowsView = textViews.first(where: { $0.string.contains("Total Rows: 1") }) else {
+            return XCTFail("Missing Total Rows view")
+        }
+        NSPasteboard.general.clearContents()
+        totalRowsView.setSelectedRange(NSRange(location: 0, length: totalRowsView.string.count))
+        let event = NSEvent.keyEvent(with: .keyDown,
+                                     location: .zero,
+                                     modifierFlags: [.command],
+                                     timestamp: 0,
+                                     windowNumber: window.windowNumber,
+                                     context: nil,
+                                     characters: "c",
+                                     charactersIgnoringModifiers: "c",
+                                     isARepeat: false,
+                                     keyCode: 8)!
+        _ = totalRowsView.performKeyEquivalent(event)
+        let pbString = NSPasteboard.general.string(forType: .string)
+        XCTAssertEqual(pbString, totalRowsView.string)
+#else
+        _ = view.body
+#endif
+    }
+
+    func testCopyWithoutSelectionProducesEmptyPasteboardEntry() {
+        let summary = PositionImportSummary(totalRows: 1,
+                                           parsedRows: 1,
+                                           cashAccounts: 1,
+                                           securityRecords: 0,
+                                           unmatchedInstruments: 0,
+                                           percentValuationRecords: 0)
+        let view = ImportSummaryPanel(summary: summary,
+                                      logs: ["Sample log"],
+                                      isPresented: .constant(true))
+#if canImport(AppKit)
+        let hosting = NSHostingView(rootView: view)
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 200, height: 200),
+                              styleMask: [.borderless],
+                              backing: .buffered,
+                              defer: false)
+        window.contentView = hosting
+        window.makeKeyAndOrderFront(nil)
+        hosting.layoutSubtreeIfNeeded()
+        let textViews = hosting.allTextViews()
+        guard let totalRowsView = textViews.first(where: { $0.string.contains("Total Rows: 1") }) else {
+            return XCTFail("Missing Total Rows view")
+        }
+        NSPasteboard.general.clearContents()
+        let event = NSEvent.keyEvent(with: .keyDown,
+                                     location: .zero,
+                                     modifierFlags: [.command],
+                                     timestamp: 0,
+                                     windowNumber: window.windowNumber,
+                                     context: nil,
+                                     characters: "c",
+                                     charactersIgnoringModifiers: "c",
+                                     isARepeat: false,
+                                     keyCode: 8)!
+        _ = totalRowsView.performKeyEquivalent(event)
+        let pbString = NSPasteboard.general.string(forType: .string)
+        XCTAssertNil(pbString)
+#else
+        _ = view.body
+#endif
+    }
+}
+
+#if canImport(AppKit)
+private extension NSView {
+    func allTextViews() -> [NSTextView] {
+        var result: [NSTextView] = []
+        func visit(_ view: NSView) {
+            if let field = view as? NSTextView {
+                result.append(field)
+            }
+            for sub in view.subviews {
+                visit(sub)
+            }
+        }
+        visit(self)
+        return result
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add `SelectableLabel` view to expose copy support
- render import summary fields and logs with `SelectableLabel`
- test that Command-C copies selected text and that unselected text does not copy

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories)*
- `xcodebuild test -scheme DragonShield -destination 'platform=macOS'` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68aae15b53948323a10ef2e5b3c6430d