### PR TITLE
feat: add selectable label for copyable import summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 
 ### Added
 - Restructure changelog and archive history (#PR_NUMBER)
+- Add selectable label component enabling copy/paste in import summary panel (#PR_NUMBER)
 
 ### Changed
 

--- a/DragonShield/Views/ImportSummaryPanel.swift
+++ b/DragonShield/Views/ImportSummaryPanel.swift
@@ -9,8 +9,7 @@ struct ImportSummaryPanel: View {
         ScrollView(.vertical) {
             VStack(alignment: .leading, spacing: 8) {
                 HStack {
-                    Text("Import Summary")
-                        .font(.headline)
+                    SelectableLabel("Import Summary", textStyle: .headline)
                     Spacer()
                     Button(action: { isPresented = false }) {
                         Image(systemName: "xmark.circle.fill")
@@ -20,23 +19,22 @@ struct ImportSummaryPanel: View {
                 }
                 Divider()
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("Total Rows: \(summary.totalRows)")
-                    Text("Parsed Rows: \(summary.parsedRows)")
-                    Text("Cash Accounts: \(summary.cashAccounts)")
-                    Text("Securities: \(summary.securityRecords)")
+                    SelectableLabel("Total Rows: \(summary.totalRows)")
+                    SelectableLabel("Parsed Rows: \(summary.parsedRows)")
+                    SelectableLabel("Cash Accounts: \(summary.cashAccounts)")
+                    SelectableLabel("Securities: \(summary.securityRecords)")
                     if summary.unmatchedInstruments > 0 {
-                        Text("Unmatched Instruments: \(summary.unmatchedInstruments)")
+                        SelectableLabel("Unmatched Instruments: \(summary.unmatchedInstruments)")
                     }
                     if summary.percentValuationRecords > 0 {
-                        Text("% Valuation Processed: \(summary.percentValuationRecords)")
+                        SelectableLabel("% Valuation Processed: \(summary.percentValuationRecords)")
                     }
                 }
                 if !logs.isEmpty {
                     Divider()
                     VStack(alignment: .leading, spacing: 2) {
                         ForEach(Array(logs.enumerated()), id: \.offset) { _, msg in
-                            Text(msg)
-                                .font(.caption2)
+                            SelectableLabel(msg, textStyle: .caption2)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                         }
                     }

--- a/DragonShield/Views/SelectableLabel.swift
+++ b/DragonShield/Views/SelectableLabel.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+struct SelectableLabel: View {
+    let text: String
+    var textStyle: Font.TextStyle
+
+    init(_ text: String, textStyle: Font.TextStyle = .body) {
+        self.text = text
+        self.textStyle = textStyle
+    }
+
+    var body: some View {
+        SelectableLabelRepresentable(text: text, textStyle: textStyle)
+    }
+}
+
+#if os(macOS)
+import AppKit
+
+private struct SelectableLabelRepresentable: NSViewRepresentable {
+    let text: String
+    var textStyle: Font.TextStyle
+
+    func makeNSView(context: Context) -> NSTextView {
+        let textView = NSTextView()
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.drawsBackground = false
+        textView.textContainerInset = .zero
+        textView.textContainer?.lineFragmentPadding = 0
+        textView.string = text
+        textView.font = NSFont.preferredFont(forTextStyle: NSFont.TextStyle(textStyle))
+        return textView
+    }
+
+    func updateNSView(_ nsView: NSTextView, context: Context) {
+        nsView.string = text
+        nsView.font = NSFont.preferredFont(forTextStyle: NSFont.TextStyle(textStyle))
+    }
+}
+
+private extension NSFont.TextStyle {
+    init(_ style: Font.TextStyle) {
+        self.init(rawValue: style.rawValue)
+    }
+}
+#elseif os(iOS)
+import UIKit
+
+private struct SelectableLabelRepresentable: UIViewRepresentable {
+    let text: String
+    var textStyle: Font.TextStyle
+
+    func makeUIView(context: Context) -> UITextView {
+        let textView = UITextView()
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.isScrollEnabled = false
+        textView.backgroundColor = .clear
+        textView.text = text
+        textView.font = UIFont.preferredFont(forTextStyle: UIFont.TextStyle(textStyle))
+        textView.textContainerInset = .zero
+        textView.textContainer.lineFragmentPadding = 0
+        return textView
+    }
+
+    func updateUIView(_ uiView: UITextView, context: Context) {
+        uiView.text = text
+        uiView.font = UIFont.preferredFont(forTextStyle: UIFont.TextStyle(textStyle))
+    }
+}
+
+private extension UIFont.TextStyle {
+    init(_ style: Font.TextStyle) {
+        self.init(rawValue: style.rawValue)
+    }
+}
+#endif

--- a/DragonShieldTests/ImportSummaryPanelTests.swift
+++ b/DragonShieldTests/ImportSummaryPanelTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+import SwiftUI
+@testable import DragonShield
+#if canImport(AppKit)
+import AppKit
+#endif
+
+/// Test strategy
+/// 1. Host the view and retrieve `NSTextView` instances from `SelectableLabel`.
+/// 2. Positive case: select text, simulate Command-C, and verify pasteboard contents.
+/// 3. Negative case: copy without selection and ensure pasteboard remains empty.
+final class ImportSummaryPanelTests: XCTestCase {
+    func testCopyCopiesSelectedText() {
+        let summary = PositionImportSummary(totalRows: 1,
+                                           parsedRows: 1,
+                                           cashAccounts: 1,
+                                           securityRecords: 0,
+                                           unmatchedInstruments: 0,
+                                           percentValuationRecords: 0)
+        let log = "Sample log"
+        let view = ImportSummaryPanel(summary: summary,
+                                      logs: [log],
+                                      isPresented: .constant(true))
+#if canImport(AppKit)
+        let hosting = NSHostingView(rootView: view)
+        hosting.layoutSubtreeIfNeeded()
+        let textViews = hosting.allTextViews()
+        guard let summaryView = textViews.first(where: { $0.string.contains("Total Rows: 1") }),
+              let logView = textViews.first(where: { $0.string.contains(log) }) else {
+            XCTFail("Missing text views")
+            return
+        }
+        let cmdC = NSEvent.keyEvent(with: .keyDown,
+                                    location: .zero,
+                                    modifierFlags: [.command],
+                                    timestamp: 0,
+                                    windowNumber: 0,
+                                    context: nil,
+                                    characters: "c",
+                                    charactersIgnoringModifiers: "c",
+                                    isARepeat: false,
+                                    keyCode: 8)!
+        NSPasteboard.general.clearContents()
+        summaryView.selectAll(nil)
+        _ = summaryView.performKeyEquivalent(cmdC)
+        XCTAssertEqual(NSPasteboard.general.string(forType: .string), "Total Rows: 1")
+        NSPasteboard.general.clearContents()
+        logView.selectAll(nil)
+        _ = logView.performKeyEquivalent(cmdC)
+        XCTAssertEqual(NSPasteboard.general.string(forType: .string), log)
+#else
+        _ = view.body
+#endif
+    }
+
+    func testCopyWithoutSelectionIsEmpty() {
+        let summary = PositionImportSummary(totalRows: 1,
+                                           parsedRows: 1,
+                                           cashAccounts: 1,
+                                           securityRecords: 0,
+                                           unmatchedInstruments: 0,
+                                           percentValuationRecords: 0)
+        let view = ImportSummaryPanel(summary: summary,
+                                      logs: ["Sample log"],
+                                      isPresented: .constant(true))
+#if canImport(AppKit)
+        let hosting = NSHostingView(rootView: view)
+        hosting.layoutSubtreeIfNeeded()
+        let textViews = hosting.allTextViews()
+        guard let anyView = textViews.first else {
+            XCTFail("No text view found")
+            return
+        }
+        NSPasteboard.general.clearContents()
+        let cmdC = NSEvent.keyEvent(with: .keyDown,
+                                    location: .zero,
+                                    modifierFlags: [.command],
+                                    timestamp: 0,
+                                    windowNumber: 0,
+                                    context: nil,
+                                    characters: "c",
+                                    charactersIgnoringModifiers: "c",
+                                    isARepeat: false,
+                                    keyCode: 8)!
+        _ = anyView.performKeyEquivalent(cmdC)
+        XCTAssertNil(NSPasteboard.general.string(forType: .string))
+#else
+        _ = view.body
+#endif
+    }
+}
+
+#if canImport(AppKit)
+private extension NSView {
+    func allTextViews() -> [NSTextView] {
+        var result: [NSTextView] = []
+        func visit(_ view: NSView) {
+            if let textView = view as? NSTextView {
+                result.append(textView)
+            }
+            for sub in view.subviews {
+                visit(sub)
+            }
+        }
+        visit(self)
+        return result
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add cross-platform `SelectableLabel` wrapping native text views for copy support
- use `SelectableLabel` in `ImportSummaryPanel` for summary and log text
- verify copy via pasteboard tests including negative case

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68aae15b53948323a10ef2e5b3c6430d