### PR TITLE
feat: make import summary text copyable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 
 ### Added
 - Restructure changelog and archive history (#PR_NUMBER)
+- Introduce `SelectableLabel` and adopt it in import summary panel (#PR_NUMBER)
 
 ### Changed
 

--- a/DragonShield/Views/ImportSummaryPanel.swift
+++ b/DragonShield/Views/ImportSummaryPanel.swift
@@ -20,22 +20,22 @@ struct ImportSummaryPanel: View {
                 }
                 Divider()
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("Total Rows: \(summary.totalRows)")
-                    Text("Parsed Rows: \(summary.parsedRows)")
-                    Text("Cash Accounts: \(summary.cashAccounts)")
-                    Text("Securities: \(summary.securityRecords)")
+                    SelectableLabel("Total Rows: \(summary.totalRows)")
+                    SelectableLabel("Parsed Rows: \(summary.parsedRows)")
+                    SelectableLabel("Cash Accounts: \(summary.cashAccounts)")
+                    SelectableLabel("Securities: \(summary.securityRecords)")
                     if summary.unmatchedInstruments > 0 {
-                        Text("Unmatched Instruments: \(summary.unmatchedInstruments)")
+                        SelectableLabel("Unmatched Instruments: \(summary.unmatchedInstruments)")
                     }
                     if summary.percentValuationRecords > 0 {
-                        Text("% Valuation Processed: \(summary.percentValuationRecords)")
+                        SelectableLabel("% Valuation Processed: \(summary.percentValuationRecords)")
                     }
                 }
                 if !logs.isEmpty {
                     Divider()
                     VStack(alignment: .leading, spacing: 2) {
                         ForEach(Array(logs.enumerated()), id: \.offset) { _, msg in
-                            Text(msg)
+                            SelectableLabel(msg)
                                 .font(.caption2)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                         }

--- a/DragonShield/Views/SelectableLabel.swift
+++ b/DragonShield/Views/SelectableLabel.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+/// A text view that allows users to select and copy its contents.
+struct SelectableLabel: View {
+    private let text: String
+
+    init(_ text: String) {
+        self.text = text
+    }
+
+    var body: some View {
+        Representable(text: text)
+    }
+
+    #if os(macOS)
+    private struct Representable: NSViewRepresentable {
+        let text: String
+        @Environment(\.font) private var font
+
+        func makeNSView(context: Context) -> NSTextView {
+            let view = NSTextView()
+            view.isEditable = false
+            view.isSelectable = true
+            view.drawsBackground = false
+            view.textContainerInset = .zero
+            view.textContainer?.lineFragmentPadding = 0
+            return view
+        }
+
+        func updateNSView(_ nsView: NSTextView, context: Context) {
+            nsView.string = text
+            if let font {
+                nsView.font = NSFont(font)
+            }
+        }
+    }
+    #else
+    private struct Representable: UIViewRepresentable {
+        let text: String
+        @Environment(\.font) private var font
+
+        func makeUIView(context: Context) -> UITextView {
+            let view = UITextView()
+            view.isEditable = false
+            view.isSelectable = true
+            view.backgroundColor = .clear
+            view.textContainerInset = .zero
+            view.textContainer.lineFragmentPadding = 0
+            return view
+        }
+
+        func updateUIView(_ uiView: UITextView, context: Context) {
+            uiView.text = text
+            if let font {
+                uiView.font = UIFont(font)
+            }
+        }
+    }
+    #endif
+}

--- a/DragonShieldTests/ImportSummaryPanelTests.swift
+++ b/DragonShieldTests/ImportSummaryPanelTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+import SwiftUI
+@testable import DragonShield
+#if canImport(AppKit)
+import AppKit
+#endif
+
+/*
+ Test strategy
+ ----------------
+ These tests render `ImportSummaryPanel`, which uses `SelectableLabel` wrapping
+ `NSTextView` for copyable text. We programmatically select text, simulate a
+ Command-C key press via `performKeyEquivalent`, and confirm the pasted content
+ via `NSPasteboard`. A negative test verifies that copying without an active
+ selection leaves the pasteboard empty.
+ */
+final class ImportSummaryPanelTests: XCTestCase {
+    func testCopySelectedText() {
+        let summary = PositionImportSummary(totalRows: 1,
+                                           parsedRows: 1,
+                                           cashAccounts: 1,
+                                           securityRecords: 0,
+                                           unmatchedInstruments: 0,
+                                           percentValuationRecords: 0)
+        let view = ImportSummaryPanel(summary: summary,
+                                      logs: ["Sample log"],
+                                      isPresented: .constant(true))
+#if canImport(AppKit)
+        let hosting = NSHostingView(rootView: view)
+        hosting.layoutSubtreeIfNeeded()
+        let textViews = hosting.allTextViews()
+        let copyEvent = NSEvent.keyEvent(with: .keyDown,
+                                         location: .zero,
+                                         modifierFlags: .command,
+                                         timestamp: 0,
+                                         windowNumber: 0,
+                                         context: nil,
+                                         characters: "c",
+                                         charactersIgnoringModifiers: "c",
+                                         isARepeat: false,
+                                         keyCode: 8)!
+        // Summary field
+        let summaryView = textViews.first { $0.string.contains("Total Rows: 1") }!
+        NSPasteboard.general.clearContents()
+        summaryView.selectAll(nil)
+        summaryView.performKeyEquivalent(copyEvent)
+        let summaryPaste = NSPasteboard.general.string(forType: .string)
+        XCTAssertEqual(summaryPaste, "Total Rows: 1")
+        // Log message
+        let logView = textViews.first { $0.string.contains("Sample log") }!
+        NSPasteboard.general.clearContents()
+        logView.selectAll(nil)
+        logView.performKeyEquivalent(copyEvent)
+        let logPaste = NSPasteboard.general.string(forType: .string)
+        XCTAssertEqual(logPaste, "Sample log")
+#else
+        _ = view.body
+#endif
+    }
+
+    func testCopyWithoutSelectionProducesEmptyPasteboard() {
+        let summary = PositionImportSummary(totalRows: 1,
+                                           parsedRows: 1,
+                                           cashAccounts: 1,
+                                           securityRecords: 0,
+                                           unmatchedInstruments: 0,
+                                           percentValuationRecords: 0)
+        let view = ImportSummaryPanel(summary: summary,
+                                      logs: ["Sample log"],
+                                      isPresented: .constant(true))
+#if canImport(AppKit)
+        let hosting = NSHostingView(rootView: view)
+        hosting.layoutSubtreeIfNeeded()
+        let textViews = hosting.allTextViews()
+        let copyEvent = NSEvent.keyEvent(with: .keyDown,
+                                         location: .zero,
+                                         modifierFlags: .command,
+                                         timestamp: 0,
+                                         windowNumber: 0,
+                                         context: nil,
+                                         characters: "c",
+                                         charactersIgnoringModifiers: "c",
+                                         isARepeat: false,
+                                         keyCode: 8)!
+        NSPasteboard.general.clearContents()
+        textViews.first?.performKeyEquivalent(copyEvent)
+        XCTAssertNil(NSPasteboard.general.string(forType: .string))
+#else
+        _ = view.body
+#endif
+    }
+}
+
+#if canImport(AppKit)
+private extension NSView {
+    func allTextViews() -> [NSTextView] {
+        var result: [NSTextView] = []
+        func visit(_ view: NSView) {
+            if let tv = view as? NSTextView {
+                result.append(tv)
+            }
+            for sub in view.subviews {
+                visit(sub)
+            }
+        }
+        visit(self)
+        return result
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add `SelectableLabel` for selectable text
- replace import summary strings with `SelectableLabel`
- test copy/paste behavior including negative case

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68aae15b53948323a10ef2e5b3c6430d