### PR TITLE
Make import summary text copyable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 
 ### Added
 - Restructure changelog and archive history (#PR_NUMBER)
+- Introduce SelectableLabel and use it in import summary panel (#PR_NUMBER)
 
 ### Changed
 

--- a/DragonShield/Views/ImportSummaryPanel.swift
+++ b/DragonShield/Views/ImportSummaryPanel.swift
@@ -20,22 +20,22 @@ struct ImportSummaryPanel: View {
                 }
                 Divider()
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("Total Rows: \(summary.totalRows)")
-                    Text("Parsed Rows: \(summary.parsedRows)")
-                    Text("Cash Accounts: \(summary.cashAccounts)")
-                    Text("Securities: \(summary.securityRecords)")
+                    SelectableLabel(text: "Total Rows: \(summary.totalRows)")
+                    SelectableLabel(text: "Parsed Rows: \(summary.parsedRows)")
+                    SelectableLabel(text: "Cash Accounts: \(summary.cashAccounts)")
+                    SelectableLabel(text: "Securities: \(summary.securityRecords)")
                     if summary.unmatchedInstruments > 0 {
-                        Text("Unmatched Instruments: \(summary.unmatchedInstruments)")
+                        SelectableLabel(text: "Unmatched Instruments: \(summary.unmatchedInstruments)")
                     }
                     if summary.percentValuationRecords > 0 {
-                        Text("% Valuation Processed: \(summary.percentValuationRecords)")
+                        SelectableLabel(text: "% Valuation Processed: \(summary.percentValuationRecords)")
                     }
                 }
                 if !logs.isEmpty {
                     Divider()
                     VStack(alignment: .leading, spacing: 2) {
                         ForEach(Array(logs.enumerated()), id: \.offset) { _, msg in
-                            Text(msg)
+                            SelectableLabel(text: msg)
                                 .font(.caption2)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                         }

--- a/DragonShield/Views/SelectableLabel.swift
+++ b/DragonShield/Views/SelectableLabel.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+struct SelectableLabel: View {
+    let text: String
+    @Environment(\.font) private var font
+
+    var body: some View {
+#if os(macOS)
+        Representable(text: text, font: font)
+#else
+        Representable(text: text, font: font)
+#endif
+    }
+}
+
+#if os(macOS)
+import AppKit
+
+private struct Representable: NSViewRepresentable {
+    let text: String
+    let font: Font?
+
+    func makeNSView(context: Context) -> NSTextView {
+        let view = NSTextView()
+        view.isEditable = false
+        view.isSelectable = true
+        view.drawsBackground = false
+        view.textContainerInset = .zero
+        view.textContainer?.lineFragmentPadding = 0
+        return view
+    }
+
+    func updateNSView(_ nsView: NSTextView, context: Context) {
+        nsView.string = text
+        nsView.font = NSFont(font ?? .body) ?? NSFont.systemFont(ofSize: NSFont.systemFontSize)
+    }
+}
+#else
+import UIKit
+
+private struct Representable: UIViewRepresentable {
+    let text: String
+    let font: Font?
+
+    func makeUIView(context: Context) -> UITextView {
+        let view = UITextView()
+        view.isEditable = false
+        view.isSelectable = true
+        view.backgroundColor = .clear
+        view.textContainerInset = .zero
+        view.textContainer.lineFragmentPadding = 0
+        return view
+    }
+
+    func updateUIView(_ uiView: UITextView, context: Context) {
+        uiView.text = text
+        uiView.font = UIFont(font ?? .body) ?? UIFont.systemFont(ofSize: UIFont.systemFontSize)
+    }
+}
+#endif

--- a/DragonShieldTests/ImportSummaryPanelTests.swift
+++ b/DragonShieldTests/ImportSummaryPanelTests.swift
@@ -1,0 +1,121 @@
+import XCTest
+import SwiftUI
+@testable import DragonShield
+#if canImport(AppKit)
+import AppKit
+#endif
+
+/// These tests ensure that text within ImportSummaryPanel is truly copyable.
+/// We programmatically select text in underlying NSTextView instances,
+/// issue Command-C via `performKeyEquivalent`, and validate the pasteboard.
+/// A negative test verifies that invoking copy with no selection leaves the
+/// pasteboard empty, preventing false positives.
+final class ImportSummaryPanelTests: XCTestCase {
+    func testCopyingSummaryAndLogText() {
+        let summary = PositionImportSummary(totalRows: 1,
+                                           parsedRows: 1,
+                                           cashAccounts: 1,
+                                           securityRecords: 0,
+                                           unmatchedInstruments: 0,
+                                           percentValuationRecords: 0)
+        let view = ImportSummaryPanel(summary: summary,
+                                      logs: ["Sample log"],
+                                      isPresented: .constant(true))
+#if canImport(AppKit)
+        let hosting = NSHostingView(rootView: view)
+        hosting.frame = NSRect(x: 0, y: 0, width: 300, height: 300)
+        let window = NSWindow(contentRect: hosting.bounds, styleMask: [], backing: .buffered, defer: false)
+        window.contentView = hosting
+        hosting.layoutSubtreeIfNeeded()
+        let textViews = hosting.allTextViews()
+        guard let summaryView = textViews.first(where: { $0.string.contains("Total Rows: 1") }) else {
+            return XCTFail("Missing summary text view")
+        }
+        let event = NSEvent.keyEvent(with: .keyDown,
+                                     location: .zero,
+                                     modifierFlags: .command,
+                                     timestamp: 0,
+                                     windowNumber: window.windowNumber,
+                                     context: nil,
+                                     characters: "c",
+                                     charactersIgnoringModifiers: "c",
+                                     isARepeat: false,
+                                     keyCode: 8)!
+        window.makeFirstResponder(summaryView)
+        summaryView.setSelectedRange(NSRange(location: 0, length: summaryView.string.count))
+        NSPasteboard.general.clearContents()
+        summaryView.performKeyEquivalent(with: event)
+        let summaryPaste = NSPasteboard.general.string(forType: .string)
+        XCTAssertEqual(summaryPaste, summaryView.string)
+        guard let logView = textViews.first(where: { $0.string.contains("Sample log") }) else {
+            return XCTFail("Missing log text view")
+        }
+        window.makeFirstResponder(logView)
+        logView.setSelectedRange(NSRange(location: 0, length: logView.string.count))
+        NSPasteboard.general.clearContents()
+        logView.performKeyEquivalent(with: event)
+        let logPaste = NSPasteboard.general.string(forType: .string)
+        XCTAssertEqual(logPaste, logView.string)
+#else
+        _ = view.body
+#endif
+    }
+
+    func testCopyWithoutSelectionProducesEmptyPasteboard() {
+        let summary = PositionImportSummary(totalRows: 1,
+                                           parsedRows: 1,
+                                           cashAccounts: 1,
+                                           securityRecords: 0,
+                                           unmatchedInstruments: 0,
+                                           percentValuationRecords: 0)
+        let view = ImportSummaryPanel(summary: summary,
+                                      logs: ["Sample log"],
+                                      isPresented: .constant(true))
+#if canImport(AppKit)
+        let hosting = NSHostingView(rootView: view)
+        hosting.frame = NSRect(x: 0, y: 0, width: 300, height: 300)
+        let window = NSWindow(contentRect: hosting.bounds, styleMask: [], backing: .buffered, defer: false)
+        window.contentView = hosting
+        hosting.layoutSubtreeIfNeeded()
+        let textViews = hosting.allTextViews()
+        guard let summaryView = textViews.first(where: { $0.string.contains("Total Rows: 1") }) else {
+            return XCTFail("Missing summary text view")
+        }
+        let event = NSEvent.keyEvent(with: .keyDown,
+                                     location: .zero,
+                                     modifierFlags: .command,
+                                     timestamp: 0,
+                                     windowNumber: window.windowNumber,
+                                     context: nil,
+                                     characters: "c",
+                                     charactersIgnoringModifiers: "c",
+                                     isARepeat: false,
+                                     keyCode: 8)!
+        window.makeFirstResponder(summaryView)
+        NSPasteboard.general.clearContents()
+        summaryView.performKeyEquivalent(with: event)
+        let paste = NSPasteboard.general.string(forType: .string)
+        XCTAssertNil(paste)
+#else
+        _ = view.body
+#endif
+    }
+}
+
+#if canImport(AppKit)
+private extension NSView {
+    func allTextViews() -> [NSTextView] {
+        var result: [NSTextView] = []
+        func visit(_ view: NSView) {
+            if let tv = view as? NSTextView {
+                result.append(tv)
+            }
+            for sub in view.subviews {
+                visit(sub)
+            }
+        }
+        visit(self)
+        return result
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add cross-platform `SelectableLabel` that wraps native text views for copy support
- replace `Text` views in `ImportSummaryPanel` with `SelectableLabel`
- exercise copy/paste behavior in `ImportSummaryPanelTests`

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68aae15b53948323a10ef2e5b3c6430d