### PR TITLE
feat: modernize theme updates view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 
 ### Changed
 - Replace status alerts with SwiftUI windows (#PR_NUMBER)
+- Theme Updates tab now uses card-based layout for better readability (#PR_NUMBER)
 
 ### Fixed
 

--- a/DragonShield/Core/MarkdownRenderer.swift
+++ b/DragonShield/Core/MarkdownRenderer.swift
@@ -12,4 +12,9 @@ enum MarkdownRenderer {
         }
         return attr
     }
+
+    static func plainText(from markdown: String) -> String {
+        let attr = attributedString(from: markdown)
+        return String(attr.characters)
+    }
 }

--- a/DragonShield/Views/PortfolioThemeUpdatesView.swift
+++ b/DragonShield/Views/PortfolioThemeUpdatesView.swift
@@ -1,8 +1,3 @@
-// DragonShield/Views/PortfolioThemeUpdatesView.swift
-// MARK: - Version 1.1
-// MARK: - History
-// - 1.0 -> 1.1: Support Markdown rendering, pinning, and ordering toggle.
-
 import SwiftUI
 import AppKit
 
@@ -13,20 +8,19 @@ struct PortfolioThemeUpdatesView: View {
     let searchHint: String?
 
     @State private var updates: [PortfolioThemeUpdate] = []
+    @State private var expanded: Set<Int> = []
+    @State private var previews: [Int: String] = [:]
+    @State private var attachments: [Int: [Attachment]] = [:]
+    @State private var links: [Int: [Link]] = [:]
     @State private var showEditor = false
     @State private var editingUpdate: PortfolioThemeUpdate?
     @State private var themeName: String = ""
     @State private var isArchived: Bool = false
     @State private var pinnedFirst: Bool = true
-    @State private var selectedId: Int?
-    @State private var showDeleteConfirm = false
-    @State private var editingFromFooter = false
     @State private var searchText: String = ""
     @State private var selectedType: PortfolioThemeUpdate.UpdateType? = nil
     @State private var searchDebounce: DispatchWorkItem?
-    @State private var attachmentCounts: [Int: Int] = [:]
-    @State private var linkPreviews: [Int: [Link]] = [:]
-    @State private var expandedLinks: Set<Int> = []
+    @State private var deleteTarget: PortfolioThemeUpdate?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -36,137 +30,39 @@ struct PortfolioThemeUpdatesView: View {
                     .padding(8)
                     .background(Color.yellow.opacity(0.1))
             }
-            HStack {
-                Button("+ New Update") { showEditor = true }
-                TextField("Search", text: $searchText)
-                    .textFieldStyle(.roundedBorder)
-                    .onChange(of: searchText) { _, _ in
-                        searchDebounce?.cancel()
-                        let task = DispatchWorkItem { load() }
-                        searchDebounce = task
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25, execute: task)
-                    }
-                Picker("Type", selection: $selectedType) {
-                    Text("All").tag(nil as PortfolioThemeUpdate.UpdateType?)
-                    ForEach(PortfolioThemeUpdate.UpdateType.allCases, id: \.self) { t in
-                        Text(t.rawValue).tag(Optional(t))
-                    }
-                }
-                    .onChange(of: selectedType) { _, _ in load() }
-                Spacer()
-                Toggle("Pinned first", isOn: $pinnedFirst)
-                    .toggleStyle(.checkbox)
-                    .onChange(of: pinnedFirst) { _, _ in load() }
-            }
+            controlBar
             if let hint = searchHint {
                 Text(hint)
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .padding(.horizontal, 4)
             }
-            List(selection: $selectedId) {
-                ForEach(updates) { update in
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("\(DateFormatting.userFriendly(update.createdAt))  •  \(update.author)  •  \(update.type.rawValue)\(update.updatedAt > update.createdAt ? "  •  edited" : "")")
-                            .font(.subheadline)
-                        HStack {
-                            Text("Title: \(update.title)").fontWeight(.semibold)
-                            if update.pinned { Image(systemName: "star.fill") }
-                            if (attachmentCounts[update.id] ?? 0) > 0 { Image(systemName: "paperclip") }
-                        }
-                        Text(MarkdownRenderer.attributedString(from: update.bodyMarkdown))
-                            .lineLimit(3)
-                        if let links = linkPreviews[update.id], !links.isEmpty {
-                            let displayed = expandedLinks.contains(update.id) ? links : Array(links.prefix(3))
-                            HStack {
-                                Text("Links:")
-                                ForEach(displayed, id: \.id) { link in
-                                    Button(displayTitle(link)) { openLink(link, updateId: update.id) }
-                                        .buttonStyle(.link)
-                                }
-                                if links.count > 3 {
-                                    Button(expandedLinks.contains(update.id) ? "Show less" : "+\(links.count - 3) more") {
-                                        if expandedLinks.contains(update.id) {
-                                            expandedLinks.remove(update.id)
-                                        } else {
-                                            expandedLinks.insert(update.id)
-                                        }
-                                    }
-                                }
-                            }
-                            if expandedLinks.contains(update.id) {
-                                ForEach(links, id: \.id) { link in
-                                    HStack {
-                                        Text(link.rawURL)
-                                            .font(.caption)
-                                        Spacer()
-                                        Button("Open") { openLink(link, updateId: update.id) }
-                                        Button("Copy") { copyLink(link) }
-                                    }
-                                }
-                            }
-                        }
-                        Text("Breadcrumb: Positions \(DateFormatting.userFriendly(update.positionsAsOf)) • Total CHF \(formatted(update.totalValueChf))")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                    .tag(update.id)
-                    .onTapGesture(count: 2) { editingUpdate = update; editingFromFooter = false }
-                    .contextMenu {
-                        Button("Edit") { editingUpdate = update; editingFromFooter = false }
-                        if update.pinned {
-                            Button("Unpin") {
-                                DispatchQueue.global(qos: .userInitiated).async {
-                                    _ = dbManager.updateThemeUpdate(id: update.id, title: nil, bodyMarkdown: nil, type: nil, pinned: false, actor: NSFullUserName(), expectedUpdatedAt: update.updatedAt)
-                                    DispatchQueue.main.async { load() }
-                                }
-                            }
-                        } else {
-                            Button("Pin") {
-                                DispatchQueue.global(qos: .userInitiated).async {
-                                    _ = dbManager.updateThemeUpdate(id: update.id, title: nil, bodyMarkdown: nil, type: nil, pinned: true, actor: NSFullUserName(), expectedUpdatedAt: update.updatedAt)
-                                    DispatchQueue.main.async { load() }
-                                }
-                            }
-                        }
-                        Button("Delete", role: .destructive) {
-                            DispatchQueue.global(qos: .userInitiated).async {
-                                _ = dbManager.softDeleteThemeUpdate(id: update.id, actor: NSFullUserName())
-                                DispatchQueue.main.async { load() }
-                            }
+            if updates.isEmpty {
+                Text("No updates match your filters.")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                    .padding()
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 12) {
+                        ForEach(updates) { update in
+                            UpdateCard(
+                                update: update,
+                                preview: previews[update.id] ?? "",
+                                links: links[update.id] ?? [],
+                                attachments: attachments[update.id] ?? [],
+                                expanded: expanded.contains(update.id),
+                                onToggleExpand: { toggleExpand(update.id) },
+                                onEdit: { editingUpdate = update },
+                                onDelete: { deleteTarget = update },
+                                onPin: { togglePin(update) },
+                                openLink: { openLink($0, updateId: update.id) },
+                                openAttachment: { openAttachment($0) }
+                            )
                         }
                     }
+                    .padding(8)
                 }
             }
-            Divider()
-            HStack {
-                Button("Edit") { if let u = selectedUpdate { editingUpdate = u; editingFromFooter = true } }
-                    .disabled(selectedUpdate == nil)
-                Button("Delete") { showDeleteConfirm = true }
-                    .disabled(selectedUpdate == nil)
-                Button(selectedUpdate?.pinned == true ? "Unpin" : "Pin") {
-                    if let u = selectedUpdate {
-                        DispatchQueue.global(qos: .userInitiated).async {
-                            _ = dbManager.updateThemeUpdate(id: u.id, title: nil, bodyMarkdown: nil, type: nil, pinned: !u.pinned, actor: NSFullUserName(), expectedUpdatedAt: u.updatedAt, source: "footer")
-                            DispatchQueue.main.async {
-                                load()
-                                selectedId = u.id
-                            }
-                        }
-                    }
-                }
-                    .disabled(selectedUpdate == nil)
-            }
-            .padding(8)
-            .confirmationDialog("Delete this update? This action can't be undone.", isPresented: $showDeleteConfirm) {
-                Button("Delete", role: .destructive) { deleteSelected() }
-            }
-            Button(action: { if let u = selectedUpdate { editingUpdate = u; editingFromFooter = true } }) { EmptyView() }
-                .keyboardShortcut(.return, modifiers: [])
-                .hidden()
-            Button(action: { if selectedUpdate != nil { showDeleteConfirm = true } }) { EmptyView() }
-                .keyboardShortcut(.delete, modifiers: [])
-                .hidden()
         }
         .onAppear {
             if let s = initialSearchText, searchText.isEmpty {
@@ -178,19 +74,75 @@ struct PortfolioThemeUpdatesView: View {
             ThemeUpdateEditorView(themeId: themeId, themeName: themeName, onSave: { _ in
                 showEditor = false
                 load()
-            }, onCancel: {
-                showEditor = false
-            })
+            }, onCancel: { showEditor = false })
             .environmentObject(dbManager)
         }
         .sheet(item: $editingUpdate) { upd in
             ThemeUpdateEditorView(themeId: themeId, themeName: themeName, existing: upd, onSave: { _ in
                 editingUpdate = nil
                 load()
-            }, onCancel: {
-                editingUpdate = nil
-            }, logSource: editingFromFooter ? "footer" : nil)
+            }, onCancel: { editingUpdate = nil })
             .environmentObject(dbManager)
+        }
+        .alert(item: $deleteTarget) { upd in
+            Alert(
+                title: Text("Delete this update? This action can't be undone."),
+                primaryButton: .destructive(Text("Delete")) {
+                    performDelete(upd)
+                },
+                secondaryButton: .cancel()
+            )
+        }
+    }
+
+    private var controlBar: some View {
+        HStack {
+            Button("+ New Update") { showEditor = true }
+            TextField("Search", text: $searchText)
+                .textFieldStyle(.roundedBorder)
+                .onChange(of: searchText) { _, _ in
+                    searchDebounce?.cancel()
+                    let task = DispatchWorkItem { load() }
+                    searchDebounce = task
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.15, execute: task)
+                }
+            Picker("Type", selection: $selectedType) {
+                Text("All").tag(nil as PortfolioThemeUpdate.UpdateType?)
+                ForEach(PortfolioThemeUpdate.UpdateType.allCases, id: \.self) { t in
+                    Text(t.rawValue).tag(Optional(t))
+                }
+            }
+            .onChange(of: selectedType) { _, _ in load() }
+            Spacer()
+            Toggle("Pinned first", isOn: $pinnedFirst)
+                .toggleStyle(.checkbox)
+                .onChange(of: pinnedFirst) { _, _ in load() }
+        }
+    }
+
+    private func toggleExpand(_ id: Int) {
+        if expanded.contains(id) { expanded.remove(id) } else { expanded.insert(id) }
+    }
+
+    private func togglePin(_ update: PortfolioThemeUpdate) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            _ = dbManager.updateThemeUpdate(
+                id: update.id,
+                title: nil,
+                bodyMarkdown: nil,
+                type: nil,
+                pinned: !update.pinned,
+                actor: NSFullUserName(),
+                expectedUpdatedAt: update.updatedAt
+            )
+            DispatchQueue.main.async { load() }
+        }
+    }
+
+    private func performDelete(_ update: PortfolioThemeUpdate) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            _ = dbManager.softDeleteThemeUpdate(id: update.id, actor: NSFullUserName())
+            DispatchQueue.main.async { load() }
         }
     }
 
@@ -201,67 +153,155 @@ struct PortfolioThemeUpdatesView: View {
             themeName = theme.name
             isArchived = theme.archivedAt != nil
         }
-        if FeatureFlags.portfolioAttachmentsEnabled(), !updates.isEmpty {
-            attachmentCounts = dbManager.getAttachmentCounts(for: updates.map { $0.id })
-        } else {
-            attachmentCounts = [:]
+        var prev: [Int: String] = [:]
+        var attDict: [Int: [Attachment]] = [:]
+        var linkDict: [Int: [Link]] = [:]
+        let repo = ThemeUpdateRepository(dbManager: dbManager)
+        let lrepo = ThemeUpdateLinkRepository(dbManager: dbManager)
+        for u in updates {
+            prev[u.id] = MarkdownRenderer.plainText(from: u.bodyMarkdown)
+            attDict[u.id] = repo.listAttachments(updateId: u.id)
+            linkDict[u.id] = lrepo.listLinks(updateId: u.id)
         }
-        if !updates.isEmpty {
-            let lrepo = ThemeUpdateLinkRepository(dbManager: dbManager)
-            var dict: [Int: [Link]] = [:]
-            for u in updates {
-                dict[u.id] = lrepo.listLinks(updateId: u.id)
-            }
-            linkPreviews = dict
-        } else {
-            linkPreviews = [:]
-        }
-    }
-
-    private var selectedUpdate: PortfolioThemeUpdate? {
-        updates.first { $0.id == selectedId }
-    }
-
-    private func formatted(_ value: Double?) -> String {
-        guard let v = value else { return "—" }
-        return v.formatted(.currency(code: dbManager.baseCurrency).precision(.fractionLength(2)))
+        previews = prev
+        attachments = attDict
+        links = linkDict
     }
 
     private func openLink(_ link: Link, updateId: Int) {
         if let url = URL(string: link.rawURL) {
             NSWorkspace.shared.open(url)
-            LoggingService.shared.log("{ themeUpdateId: \(updateId), linkId: \(link.id), host: \(url.host ?? ""), op:'link_open' }", type: .info, logger: .database)
+            LoggingService.shared.log(
+                "{ themeUpdateId: \\(updateId), linkId: \\(link.id), host: \\(url.host ?? \"\"), op:'link_open' }",
+                type: .info,
+                logger: .database
+            )
         }
     }
 
-    private func copyLink(_ link: Link) {
-        let pb = NSPasteboard.general
-        pb.clearContents()
-        pb.setString(link.rawURL, forType: .string)
+    private func openAttachment(_ attachment: Attachment) {
+        AttachmentService(dbManager: dbManager).quickLook(attachmentId: attachment.id)
     }
 
-    private func displayTitle(_ link: Link) -> String {
-        if let t = link.title, !t.isEmpty { return t }
-        if let url = URL(string: link.rawURL) {
-            var host = url.host ?? link.rawURL
-            if !url.path.isEmpty && url.path != "/" {
-                host += url.path
-            }
-            return host
-        }
-        return link.rawURL
-    }
+    struct UpdateCard: View {
+        let update: PortfolioThemeUpdate
+        let preview: String
+        let links: [Link]
+        let attachments: [Attachment]
+        let expanded: Bool
+        let onToggleExpand: () -> Void
+        let onEdit: () -> Void
+        let onDelete: () -> Void
+        let onPin: () -> Void
+        let openLink: (Link) -> Void
+        let openAttachment: (Attachment) -> Void
 
-    private func deleteSelected() {
-        if let u = selectedUpdate {
-            DispatchQueue.global(qos: .userInitiated).async {
-                if dbManager.softDeleteThemeUpdate(id: u.id, actor: NSFullUserName(), source: "footer") {
-                    DispatchQueue.main.async {
-                        load()
-                        selectedId = nil
+        var body: some View {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .top) {
+                    Button(action: onPin) {
+                        Image(systemName: update.pinned ? "star.fill" : "star")
+                    }
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack(alignment: .top) {
+                            Text(update.title)
+                                .fontWeight(.semibold)
+                                .lineLimit(1)
+                                .help(update.title)
+                            Spacer()
+                            Button("View") { onToggleExpand() }
+                            Button("Edit") { onEdit() }
+                            Button("Delete", role: .destructive) { onDelete() }
+                        }
+                        Text("\(DateFormatting.userFriendly(update.createdAt)) · \(update.author) · \(update.type.rawValue)")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
                     }
                 }
+                if expanded {
+                    Text(MarkdownRenderer.attributedString(from: update.bodyMarkdown))
+                    if !links.isEmpty {
+                        Text("Links").font(.subheadline)
+                        chipGridLinks
+                    }
+                    if !attachments.isEmpty {
+                        Text("Files").font(.subheadline)
+                        chipGridAttachments
+                    }
+                } else {
+                    Text(preview)
+                        .lineLimit(3)
+                    if !links.isEmpty || !attachments.isEmpty {
+                        chipGridCollapsed
+                    }
+                }
+                HStack {
+                    Spacer()
+                    Button(expanded ? "Collapse" : "Expand") { onToggleExpand() }
+                }
             }
+            .padding(12)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(Color.secondary.opacity(0.3))
+            )
+        }
+
+        private var chipColumns: [GridItem] {
+            [GridItem(.adaptive(minimum: 160), spacing: 8)]
+        }
+
+        private var chipGridCollapsed: some View {
+            LazyVGrid(columns: chipColumns, alignment: .leading, spacing: 8) {
+                ForEach(links, id: \.id) { link in
+                    chip(label: displayTitle(link)) { openLink(link) }
+                }
+                ForEach(attachments, id: \.id) { att in
+                    chip(label: att.originalFilename) { openAttachment(att) }
+                }
+            }
+        }
+
+        private var chipGridLinks: some View {
+            LazyVGrid(columns: chipColumns, alignment: .leading, spacing: 8) {
+                ForEach(links, id: \.id) { link in
+                    chip(label: displayTitle(link)) { openLink(link) }
+                }
+            }
+        }
+
+        private var chipGridAttachments: some View {
+            LazyVGrid(columns: chipColumns, alignment: .leading, spacing: 8) {
+                ForEach(attachments, id: \.id) { att in
+                    chip(label: att.originalFilename) { openAttachment(att) }
+                }
+            }
+        }
+
+        private func chip(label: String, action: @escaping () -> Void) -> some View {
+            HStack(spacing: 4) {
+                Text(label)
+                    .lineLimit(1)
+                Spacer()
+                Button("Open", action: action)
+            }
+            .padding(6)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(Color.accentColor.opacity(0.6))
+            )
+        }
+
+        private func displayTitle(_ link: Link) -> String {
+            if let t = link.title, !t.isEmpty { return t }
+            if let url = URL(string: link.rawURL) {
+                var host = url.host ?? link.rawURL
+                if !url.path.isEmpty && url.path != "/" {
+                    host += url.path
+                }
+                return host
+            }
+            return link.rawURL
         }
     }
 }

--- a/DragonShieldTests/MarkdownRendererPlainTextTests.swift
+++ b/DragonShieldTests/MarkdownRendererPlainTextTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import DragonShield
+
+final class MarkdownRendererPlainTextTests: XCTestCase {
+    func testPlainTextStripsMarkdown() {
+        let md = "**Hello** _world_ [link](https://example.com)"
+        let result = MarkdownRenderer.plainText(from: md)
+        XCTAssertEqual(result, "Hello world link")
+    }
+}


### PR DESCRIPTION
## Summary
- replace updates list with multi-row cards including previews, attachments, and links
- expose plain text markdown preview helper
- add unit test for markdown plain text rendering

## Testing
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68aafd46703483239757320e5c89b573