### PR TITLE
feat: introduce card-based theme updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 
 ### Changed
 - Replace status alerts with SwiftUI windows (#PR_NUMBER)
+- Replace theme updates list with card-based overview (#PR_NUMBER)
 
 ### Fixed
 

--- a/DragonShield/Core/MarkdownRenderer.swift
+++ b/DragonShield/Core/MarkdownRenderer.swift
@@ -12,4 +12,9 @@ enum MarkdownRenderer {
         }
         return attr
     }
+
+    static func plainText(from markdown: String) -> String {
+        let attr = attributedString(from: markdown)
+        return String(attr.characters)
+    }
 }

--- a/DragonShield/Views/PortfolioThemeUpdatesView.swift
+++ b/DragonShield/Views/PortfolioThemeUpdatesView.swift
@@ -1,7 +1,7 @@
 // DragonShield/Views/PortfolioThemeUpdatesView.swift
-// MARK: - Version 1.1
+// MARK: - Version 2.0
 // MARK: - History
-// - 1.0 -> 1.1: Support Markdown rendering, pinning, and ordering toggle.
+// - 1.1 -> 2.0: Replace legacy list with card-based overview supporting expand/collapse.
 
 import SwiftUI
 import AppKit
@@ -13,231 +13,218 @@ struct PortfolioThemeUpdatesView: View {
     let searchHint: String?
 
     @State private var updates: [PortfolioThemeUpdate] = []
+    @State private var previewCache: [Int: String] = [:]
+    @State private var attachments: [Int: [Attachment]] = [:]
+    @State private var links: [Int: [Link]] = [:]
+    @State private var expanded: Set<Int> = []
     @State private var showEditor = false
     @State private var editingUpdate: PortfolioThemeUpdate?
     @State private var themeName: String = ""
-    @State private var isArchived: Bool = false
-    @State private var pinnedFirst: Bool = true
-    @State private var selectedId: Int?
-    @State private var showDeleteConfirm = false
-    @State private var editingFromFooter = false
+    @State private var isArchived = false
+    @State private var pinnedFirst = true
     @State private var searchText: String = ""
-    @State private var selectedType: PortfolioThemeUpdate.UpdateType? = nil
+    @State private var selectedType: PortfolioThemeUpdate.UpdateType?
+    @State private var sortNewestFirst = true
+    @State private var dateFilter: DateFilter = .last30
     @State private var searchDebounce: DispatchWorkItem?
-    @State private var attachmentCounts: [Int: Int] = [:]
-    @State private var linkPreviews: [Int: [Link]] = [:]
-    @State private var expandedLinks: Set<Int> = []
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             if isArchived {
-                Text("Theme archived — composition locked; updates permitted")
+                Text("Theme archived - composition locked; updates permitted")
                     .frame(maxWidth: .infinity)
                     .padding(8)
                     .background(Color.yellow.opacity(0.1))
             }
-            HStack {
-                Button("+ New Update") { showEditor = true }
-                TextField("Search", text: $searchText)
-                    .textFieldStyle(.roundedBorder)
-                    .onChange(of: searchText) { _, _ in
-                        searchDebounce?.cancel()
-                        let task = DispatchWorkItem { load() }
-                        searchDebounce = task
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25, execute: task)
-                    }
-                Picker("Type", selection: $selectedType) {
-                    Text("All").tag(nil as PortfolioThemeUpdate.UpdateType?)
-                    ForEach(PortfolioThemeUpdate.UpdateType.allCases, id: \.self) { t in
-                        Text(t.rawValue).tag(Optional(t))
-                    }
-                }
-                    .onChange(of: selectedType) { _, _ in load() }
-                Spacer()
-                Toggle("Pinned first", isOn: $pinnedFirst)
-                    .toggleStyle(.checkbox)
-                    .onChange(of: pinnedFirst) { _, _ in load() }
-            }
+            filterBar
             if let hint = searchHint {
                 Text(hint)
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .padding(.horizontal, 4)
             }
-            List(selection: $selectedId) {
-                ForEach(updates) { update in
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("\(DateFormatting.userFriendly(update.createdAt))  •  \(update.author)  •  \(update.type.rawValue)\(update.updatedAt > update.createdAt ? "  •  edited" : "")")
-                            .font(.subheadline)
-                        HStack {
-                            Text("Title: \(update.title)").fontWeight(.semibold)
-                            if update.pinned { Image(systemName: "star.fill") }
-                            if (attachmentCounts[update.id] ?? 0) > 0 { Image(systemName: "paperclip") }
-                        }
-                        Text(MarkdownRenderer.attributedString(from: update.bodyMarkdown))
-                            .lineLimit(3)
-                        if let links = linkPreviews[update.id], !links.isEmpty {
-                            let displayed = expandedLinks.contains(update.id) ? links : Array(links.prefix(3))
-                            HStack {
-                                Text("Links:")
-                                ForEach(displayed, id: \.id) { link in
-                                    Button(displayTitle(link)) { openLink(link, updateId: update.id) }
-                                        .buttonStyle(.link)
-                                }
-                                if links.count > 3 {
-                                    Button(expandedLinks.contains(update.id) ? "Show less" : "+\(links.count - 3) more") {
-                                        if expandedLinks.contains(update.id) {
-                                            expandedLinks.remove(update.id)
-                                        } else {
-                                            expandedLinks.insert(update.id)
-                                        }
-                                    }
-                                }
-                            }
-                            if expandedLinks.contains(update.id) {
-                                ForEach(links, id: \.id) { link in
-                                    HStack {
-                                        Text(link.rawURL)
-                                            .font(.caption)
-                                        Spacer()
-                                        Button("Open") { openLink(link, updateId: update.id) }
-                                        Button("Copy") { copyLink(link) }
-                                    }
-                                }
-                            }
-                        }
-                        Text("Breadcrumb: Positions \(DateFormatting.userFriendly(update.positionsAsOf)) • Total CHF \(formatted(update.totalValueChf))")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                    .tag(update.id)
-                    .onTapGesture(count: 2) { editingUpdate = update; editingFromFooter = false }
-                    .contextMenu {
-                        Button("Edit") { editingUpdate = update; editingFromFooter = false }
-                        if update.pinned {
-                            Button("Unpin") {
-                                DispatchQueue.global(qos: .userInitiated).async {
-                                    _ = dbManager.updateThemeUpdate(id: update.id, title: nil, bodyMarkdown: nil, type: nil, pinned: false, actor: NSFullUserName(), expectedUpdatedAt: update.updatedAt)
-                                    DispatchQueue.main.async { load() }
-                                }
-                            }
-                        } else {
-                            Button("Pin") {
-                                DispatchQueue.global(qos: .userInitiated).async {
-                                    _ = dbManager.updateThemeUpdate(id: update.id, title: nil, bodyMarkdown: nil, type: nil, pinned: true, actor: NSFullUserName(), expectedUpdatedAt: update.updatedAt)
-                                    DispatchQueue.main.async { load() }
-                                }
-                            }
-                        }
-                        Button("Delete", role: .destructive) {
-                            DispatchQueue.global(qos: .userInitiated).async {
-                                _ = dbManager.softDeleteThemeUpdate(id: update.id, actor: NSFullUserName())
-                                DispatchQueue.main.async { load() }
-                            }
-                        }
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 12) {
+                    ForEach(updates) { update in
+                        card(for: update)
                     }
                 }
+                .padding(.vertical, 8)
             }
-            Divider()
-            HStack {
-                Button("Edit") { if let u = selectedUpdate { editingUpdate = u; editingFromFooter = true } }
-                    .disabled(selectedUpdate == nil)
-                Button("Delete") { showDeleteConfirm = true }
-                    .disabled(selectedUpdate == nil)
-                Button(selectedUpdate?.pinned == true ? "Unpin" : "Pin") {
-                    if let u = selectedUpdate {
-                        DispatchQueue.global(qos: .userInitiated).async {
-                            _ = dbManager.updateThemeUpdate(id: u.id, title: nil, bodyMarkdown: nil, type: nil, pinned: !u.pinned, actor: NSFullUserName(), expectedUpdatedAt: u.updatedAt, source: "footer")
-                            DispatchQueue.main.async {
-                                load()
-                                selectedId = u.id
-                            }
-                        }
-                    }
-                }
-                    .disabled(selectedUpdate == nil)
-            }
-            .padding(8)
-            .confirmationDialog("Delete this update? This action can't be undone.", isPresented: $showDeleteConfirm) {
-                Button("Delete", role: .destructive) { deleteSelected() }
-            }
-            Button(action: { if let u = selectedUpdate { editingUpdate = u; editingFromFooter = true } }) { EmptyView() }
-                .keyboardShortcut(.return, modifiers: [])
-                .hidden()
-            Button(action: { if selectedUpdate != nil { showDeleteConfirm = true } }) { EmptyView() }
-                .keyboardShortcut(.delete, modifiers: [])
-                .hidden()
         }
         .onAppear {
-            if let s = initialSearchText, searchText.isEmpty {
-                searchText = s
-            }
+            if let s = initialSearchText, searchText.isEmpty { searchText = s }
             load()
         }
         .sheet(isPresented: $showEditor) {
             ThemeUpdateEditorView(themeId: themeId, themeName: themeName, onSave: { _ in
                 showEditor = false
                 load()
-            }, onCancel: {
-                showEditor = false
-            })
+            }, onCancel: { showEditor = false })
             .environmentObject(dbManager)
         }
         .sheet(item: $editingUpdate) { upd in
             ThemeUpdateEditorView(themeId: themeId, themeName: themeName, existing: upd, onSave: { _ in
                 editingUpdate = nil
                 load()
-            }, onCancel: {
-                editingUpdate = nil
-            }, logSource: editingFromFooter ? "footer" : nil)
+            }, onCancel: { editingUpdate = nil })
             .environmentObject(dbManager)
+        }
+    }
+
+    private var filterBar: some View {
+        HStack {
+            Button("+ New Update") { showEditor = true }
+            TextField("Search", text: $searchText)
+                .textFieldStyle(.roundedBorder)
+                .onChange(of: searchText) { _, _ in
+                    searchDebounce?.cancel()
+                    let task = DispatchWorkItem { load() }
+                    searchDebounce = task
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.15, execute: task)
+                }
+            Picker("Type", selection: $selectedType) {
+                Text("All").tag(nil as PortfolioThemeUpdate.UpdateType?)
+                ForEach(PortfolioThemeUpdate.UpdateType.allCases, id: \.self) { t in
+                    Text(t.rawValue).tag(Optional(t))
+                }
+            }
+            .onChange(of: selectedType) { _, _ in load() }
+            Picker("Sort", selection: $sortNewestFirst) {
+                Text("Newest first").tag(true)
+                Text("Oldest first").tag(false)
+            }
+            .onChange(of: sortNewestFirst) { _, _ in load() }
+            Toggle("Pinned first", isOn: $pinnedFirst)
+                .toggleStyle(.checkbox)
+                .onChange(of: pinnedFirst) { _, _ in load() }
+            Picker("Date", selection: $dateFilter) {
+                ForEach(DateFilter.allCases) { f in
+                    Text(f.label).tag(f)
+                }
+            }
+            .onChange(of: dateFilter) { _, _ in load() }
+        }
+    }
+
+    private func card(for update: PortfolioThemeUpdate) -> some View {
+        let isExpanded = expanded.contains(update.id)
+        return VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top) {
+                Button(action: { togglePin(update) }) {
+                    Image(systemName: update.pinned ? "star.fill" : "star")
+                }
+                .buttonStyle(.plain)
+                .help(update.pinned ? "Unpin" : "Pin")
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(update.title)
+                        .fontWeight(.semibold)
+                        .lineLimit(1)
+                        .help(update.title)
+                    Text("\(DateFormatting.userFriendly(update.createdAt)) - \(update.author) - \(update.type.rawValue.uppercased())")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                Spacer()
+                HStack {
+                    Button("Edit") { editingUpdate = update }
+                    Button("Delete", role: .destructive) { delete(update) }
+                    Button(isExpanded ? "Collapse ▲" : "Expand ▼") { toggleExpand(update.id) }
+                }
+                .font(.footnote)
+            }
+            if isExpanded {
+                Text(MarkdownRenderer.attributedString(from: update.bodyMarkdown))
+                chipSection(update: update)
+            } else {
+                Text(previewCache[update.id] ?? "")
+                    .lineLimit(3)
+                chipSection(update: update)
+            }
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.gray.opacity(0.2))
+        )
+        .padding(.horizontal, 4)
+    }
+
+    @ViewBuilder
+    private func chipSection(update: PortfolioThemeUpdate) -> some View {
+        let linkItems = links[update.id] ?? []
+        let fileItems = attachments[update.id] ?? []
+        if !linkItems.isEmpty || !fileItems.isEmpty {
+            WrapLayout(spacing: 8) {
+                ForEach(linkItems, id: \.id) { link in
+                    ChipView(text: displayTitle(link)) { openLink(link, updateId: update.id) }
+                        .help(link.rawURL)
+                }
+                ForEach(fileItems, id: \.id) { att in
+                    ChipView(text: att.originalFilename) { AttachmentService(dbManager: dbManager).quickLook(attachmentId: att.id) }
+                        .help(att.originalFilename)
+                }
+            }
+        }
+    }
+
+    private func toggleExpand(_ id: Int) {
+        if expanded.contains(id) {
+            expanded.remove(id)
+        } else {
+            expanded.insert(id)
+        }
+    }
+
+    private func togglePin(_ update: PortfolioThemeUpdate) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            _ = dbManager.updateThemeUpdate(id: update.id, title: nil, bodyMarkdown: nil, type: nil, pinned: !update.pinned, actor: NSFullUserName(), expectedUpdatedAt: update.updatedAt)
+            DispatchQueue.main.async { load() }
+        }
+    }
+
+    private func delete(_ update: PortfolioThemeUpdate) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            _ = dbManager.softDeleteThemeUpdate(id: update.id, actor: NSFullUserName())
+            DispatchQueue.main.async { load() }
         }
     }
 
     private func load() {
         let query = searchText.isEmpty ? nil : searchText
-        updates = dbManager.listThemeUpdates(themeId: themeId, view: .active, type: selectedType, searchQuery: query, pinnedFirst: pinnedFirst)
+        var list = dbManager.listThemeUpdates(themeId: themeId, view: .active, type: selectedType, searchQuery: query, pinnedFirst: pinnedFirst)
+        let now = Date()
+        if let start = dateFilter.lowerBound(from: now) {
+            let fmt = ISO8601DateFormatter()
+            list = list.filter { fmt.date(from: $0.createdAt).map { $0 >= start && $0 < now } ?? false }
+        }
+        if !sortNewestFirst {
+            list.reverse()
+        }
+        updates = list
         if let theme = dbManager.getPortfolioTheme(id: themeId) {
             themeName = theme.name
             isArchived = theme.archivedAt != nil
         }
-        if FeatureFlags.portfolioAttachmentsEnabled(), !updates.isEmpty {
-            attachmentCounts = dbManager.getAttachmentCounts(for: updates.map { $0.id })
-        } else {
-            attachmentCounts = [:]
+        previewCache = Dictionary(uniqueKeysWithValues: list.map { ($0.id, MarkdownRenderer.plainText(from: $0.bodyMarkdown)) })
+        let linkRepo = ThemeUpdateLinkRepository(dbManager: dbManager)
+        let attRepo = ThemeUpdateRepository(dbManager: dbManager)
+        var linkDict: [Int: [Link]] = [:]
+        var attDict: [Int: [Attachment]] = [:]
+        for u in list {
+            linkDict[u.id] = linkRepo.listLinks(updateId: u.id)
+            attDict[u.id] = attRepo.listAttachments(updateId: u.id)
         }
-        if !updates.isEmpty {
-            let lrepo = ThemeUpdateLinkRepository(dbManager: dbManager)
-            var dict: [Int: [Link]] = [:]
-            for u in updates {
-                dict[u.id] = lrepo.listLinks(updateId: u.id)
-            }
-            linkPreviews = dict
-        } else {
-            linkPreviews = [:]
-        }
-    }
-
-    private var selectedUpdate: PortfolioThemeUpdate? {
-        updates.first { $0.id == selectedId }
-    }
-
-    private func formatted(_ value: Double?) -> String {
-        guard let v = value else { return "—" }
-        return v.formatted(.currency(code: dbManager.baseCurrency).precision(.fractionLength(2)))
+        links = linkDict
+        attachments = attDict
+        expanded = expanded.intersection(Set(list.map { $0.id }))
     }
 
     private func openLink(_ link: Link, updateId: Int) {
         if let url = URL(string: link.rawURL) {
             NSWorkspace.shared.open(url)
-            LoggingService.shared.log("{ themeUpdateId: \(updateId), linkId: \(link.id), host: \(url.host ?? ""), op:'link_open' }", type: .info, logger: .database)
+            LoggingService.shared.log("{ themeUpdateId: \(updateId), linkId: \(link.id), host: \(url.host ?? \"\"), op:'link_open' }", type: .info, logger: .database)
         }
-    }
-
-    private func copyLink(_ link: Link) {
-        let pb = NSPasteboard.general
-        pb.clearContents()
-        pb.setString(link.rawURL, forType: .string)
     }
 
     private func displayTitle(_ link: Link) -> String {
@@ -252,16 +239,46 @@ struct PortfolioThemeUpdatesView: View {
         return link.rawURL
     }
 
-    private func deleteSelected() {
-        if let u = selectedUpdate {
-            DispatchQueue.global(qos: .userInitiated).async {
-                if dbManager.softDeleteThemeUpdate(id: u.id, actor: NSFullUserName(), source: "footer") {
-                    DispatchQueue.main.async {
-                        load()
-                        selectedId = nil
-                    }
-                }
+    enum DateFilter: String, CaseIterable, Identifiable {
+        case today, last7, last30, last90, last365, all
+        var id: String { rawValue }
+        var label: String {
+            switch self {
+            case .today: return "Today"
+            case .last7: return "Last 7d"
+            case .last30: return "Last 30d"
+            case .last90: return "Last 90d"
+            case .last365: return "Last 365d"
+            case .all: return "All"
             }
+        }
+        func lowerBound(from now: Date) -> Date? {
+            let cal = Calendar.current
+            switch self {
+            case .today: return cal.startOfDay(for: now)
+            case .last7: return cal.date(byAdding: .day, value: -7, to: now)
+            case .last30: return cal.date(byAdding: .day, value: -30, to: now)
+            case .last90: return cal.date(byAdding: .day, value: -90, to: now)
+            case .last365: return cal.date(byAdding: .day, value: -365, to: now)
+            case .all: return nil
+            }
+        }
+    }
+
+    struct ChipView: View {
+        let text: String
+        let action: () -> Void
+        var body: some View {
+            HStack(spacing: 4) {
+                Text(text)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Button("Open", action: action)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(Color.secondary.opacity(0.1))
+            .clipShape(RoundedRectangle(cornerRadius: 8))
         }
     }
 }

--- a/DragonShield/helpers/WrapLayout.swift
+++ b/DragonShield/helpers/WrapLayout.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct WrapLayout: Layout {
+    var spacing: CGFloat = 8
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        var width: CGFloat = 0
+        var height: CGFloat = 0
+        var lineHeight: CGFloat = 0
+        for sub in subviews {
+            let size = sub.sizeThatFits(.unspecified)
+            if width + size.width > maxWidth {
+                height += lineHeight + spacing
+                width = 0
+                lineHeight = 0
+            }
+            width += size.width + spacing
+            lineHeight = max(lineHeight, size.height)
+        }
+        height += lineHeight
+        return CGSize(width: maxWidth, height: height)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        var x = bounds.minX
+        var y = bounds.minY
+        var lineHeight: CGFloat = 0
+        for sub in subviews {
+            let size = sub.sizeThatFits(.unspecified)
+            if x + size.width > bounds.maxX {
+                x = bounds.minX
+                y += lineHeight + spacing
+                lineHeight = 0
+            }
+            sub.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(width: size.width, height: size.height))
+            x += size.width + spacing
+            lineHeight = max(lineHeight, size.height)
+        }
+    }
+}
+

--- a/DragonShieldTests/MarkdownRendererTests.swift
+++ b/DragonShieldTests/MarkdownRendererTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import DragonShield
+
+final class MarkdownRendererTests: XCTestCase {
+    func testPlainTextStripsMarkdown() {
+        let md = "**Bold** _Italic_"
+        let plain = MarkdownRenderer.plainText(from: md)
+        XCTAssertEqual(plain, "Bold Italic")
+    }
+}


### PR DESCRIPTION
## Summary
- replace dense theme updates list with card-based layout
- add markdown plain text helper and wrapping layout
- note: build and test commands not available in this environment

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68aafd46703483239757320e5c89b573