### PR TITLE
Remove unused debug settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 ### Fixed
 
 ### Removed
-
+ - Remove debug settings for database re-copy and parsing checkpoints (#PR_NUMBER)
 ### Security
 
 ## [4.6.0] - 2025-06-15

--- a/DragonShield/DatabaseManager.swift
+++ b/DragonShield/DatabaseManager.swift
@@ -1,13 +1,12 @@
 // DragonShield/DatabaseManager.swift
-// MARK: - Version 1.6.0.1
+// MARK: - Version 1.6.0.2
 // MARK: - History
 // - 1.5 -> 1.6: Expose database path, creation date and modification date via
 //               @Published properties.
 // - 1.6 -> 1.6.0.1: Use sqlite3_open_v2 with FULLMUTEX and log errors when opening fails.
+// - 1.6.0.1 -> 1.6.0.2: Remove debug database re-copy option.
 // - 1.3 -> 1.4: Added @Published properties for defaultTimeZone, tableRowSpacing, tableRowPadding.
 // - 1.4 -> 1.5: Added dbVersion property and logging of database version.
-// - 1.2 -> 1.3: Modified #if DEBUG block to use a UserDefaults setting for forcing DB re-copy.
-// - 1.1 -> 1.2: Added a #if DEBUG block to init() to force delete/re-copy database from bundle.
 
 import SQLite3
 import Foundation
@@ -58,18 +57,6 @@ class DatabaseManager: ObservableObject {
         let mode = DatabaseMode(rawValue: savedMode ?? "production") ?? .production
         self.dbMode = mode
         self.dbPath = appDir.appendingPathComponent(DatabaseManager.fileName(for: mode)).path
-        
-        #if DEBUG
-        let shouldForceReCopy = UserDefaults.standard.bool(forKey: UserDefaultsKeys.forceOverwriteDatabaseOnDebug)
-        if shouldForceReCopy && FileManager.default.fileExists(atPath: dbPath) {
-            do {
-                try FileManager.default.removeItem(atPath: dbPath)
-                print("🗑️ [DEBUG] Deleted existing database at: \(dbPath) (Force Re-Copy Setting is ON)")
-            } catch {
-                print("⚠️ [DEBUG] Could not delete existing database for re-copy: \(error)")
-            }
-        }
-        #endif
         
         if !FileManager.default.fileExists(atPath: dbPath) {
             if let bundlePath = Bundle.main.path(forResource: "dragonshield", ofType: "sqlite") {

--- a/DragonShield/ImportManager.swift
+++ b/DragonShield/ImportManager.swift
@@ -1,6 +1,6 @@
 // DragonShield/ImportManager.swift
 
-// MARK: - Version 2.0.3.0
+// MARK: - Version 2.0.3.1
 // MARK: - History
 // - 1.11 -> 2.0.0.0: Rewritten to use native Swift XLSX processing instead of Python parser.
 // - 2.0.0.0 -> 2.0.0.1: Replace deprecated allowedFileTypes API.
@@ -15,6 +15,7 @@
 // - 2.0.2.4 -> 2.0.2.5: Guard UTType initialization and minor cleanup.
 // - 2.0.2.5 -> 2.0.2.6: Log import details to file and forward progress.
 // - 2.0.2.6 -> 2.0.3.0: Route log messages through OSLog categories.
+// - 2.0.3.0 -> 2.0.3.1: Deprecate parsing checkpoint toggle.
 import Foundation
 import AppKit
 import SwiftUI
@@ -34,9 +35,7 @@ class ImportManager {
         PositionReportRepository(dbManager: dbManager)
     }()
 
-    private var checkpointsEnabled: Bool {
-        UserDefaults.standard.bool(forKey: UserDefaultsKeys.enableParsingCheckpoints)
-    }
+    private let checkpointsEnabled: Bool = false
 
     private static let cashValorMap: [String: (ticker: String, currency: String)] = [
         "CH9304835039842401009": ("CASHCHF", "CHF"),

--- a/DragonShield/Views/SettingsView.swift
+++ b/DragonShield/Views/SettingsView.swift
@@ -1,6 +1,7 @@
 // DragonShield/Views/SettingsView.swift
-// MARK: - Version 1.4
+// MARK: - Version 1.5
 // MARK: - History
+// - 1.4 -> 1.5: Removed debug options for database re-copy and parsing checkpoints.
 // - 1.3 -> 1.4: Added database information section (path, created, updated).
 // - 1.2 -> 1.3: Replaced script-based versioning with a 100% Swift solution (AppVersionProvider) to fix build errors.
 // - 1.1 -> 1.2: Removed redundant .onChange modifiers that were causing a state update crash loop.
@@ -13,18 +14,11 @@ struct SettingsView: View {
     @EnvironmentObject var dbManager: DatabaseManager
     @EnvironmentObject var runner: HealthCheckRunner
 
-    @AppStorage(UserDefaultsKeys.forceOverwriteDatabaseOnDebug)
-    private var forceOverwriteDatabaseOnDebug: Bool = false
-
-    @AppStorage(UserDefaultsKeys.enableParsingCheckpoints)
-    private var enableParsingCheckpoints: Bool = false
-
     @AppStorage("runStartupHealthChecks")
     private var runStartupHealthChecks: Bool = true
 
     @AppStorage(UserDefaultsKeys.portfolioAttachmentsEnabled)
     private var portfolioAttachmentsEnabled: Bool = false
-
 
     private var okCount: Int {
         runner.reports.filter { if case .ok = $0.result { return true } else { return false } }.count
@@ -70,7 +64,7 @@ struct SettingsView: View {
                             }
                         ),
                         in: 0...8)
-                
+
                 Toggle("Auto FX Update", isOn: Binding(
                     get: { dbManager.autoFxUpdate },
                     set: { newValue in
@@ -94,7 +88,7 @@ struct SettingsView: View {
                         }
                 }
             }
-            
+
             Section(header: Text("Table Display Settings")) {
                 Stepper("Row Spacing: \(String(format: "%.1f", dbManager.tableRowSpacing)) pts",
                         value: Binding(
@@ -104,7 +98,7 @@ struct SettingsView: View {
                             }
                         ),
                         in: 0.0...10.0, step: 0.5)
-                
+
                 Stepper("Row Padding: \(String(format: "%.1f", dbManager.tableRowPadding)) pts",
                         value: Binding(
                             get: { dbManager.tableRowPadding },
@@ -130,20 +124,6 @@ struct SettingsView: View {
                 NavigationLink("Theme Statuses", destination: ThemeStatusSettingsView().environmentObject(dbManager))
             }
 
-            #if DEBUG
-            Section(header: Text("Development / Debug Options")) {
-                VStack(alignment: .leading) {
-                    Toggle("Force Re-copy Database on Next Launch", isOn: $forceOverwriteDatabaseOnDebug)
-                    Text("Enable this to delete the current database and copy a fresh version from the bundle on next app start. Only for Debug builds.")
-                        .font(.caption)
-                        .foregroundColor(.gray)
-                    Toggle("Enable Parsing Checkpoints", isOn: $enableParsingCheckpoints)
-                        .padding(.top, 4)
-                }
-            }
-            #endif
-
-
             Section(header: Text("About")) {
                 HStack {
                     Text("App Version")
@@ -167,9 +147,6 @@ struct SettingsView: View {
 
 struct SettingsView_Previews: PreviewProvider {
     static var previews: some View {
-        // NOTE: You must have a `UserDefaultsKeys` struct with the appropriate key defined for this preview to work.
-        UserDefaults.standard.set(true, forKey: "forceOverwriteDatabaseOnDebug")
-        UserDefaults.standard.set(false, forKey: "enableParsingCheckpoints")
         let dbManager = DatabaseManager() // Create a preview instance
         let runner = HealthCheckRunner()
 
@@ -178,3 +155,4 @@ struct SettingsView_Previews: PreviewProvider {
             .environmentObject(runner)
     }
 }
+

--- a/DragonShield/helpers/UserDefaultsKeys.swift
+++ b/DragonShield/helpers/UserDefaultsKeys.swift
@@ -1,13 +1,12 @@
 // DragonShield/Utils/UserDefaultsKeys.swift
-// MARK: - Version 1.0 (2025-05-31)
+// MARK: - Version 1.1 (2025-06-16)
 // MARK: - History
 // - Initial creation: Defines keys for UserDefaults.
+// - 1.0 -> 1.1: Remove legacy debug keys.
 
 import Foundation
 
 struct UserDefaultsKeys {
-    static let forceOverwriteDatabaseOnDebug = "forceOverwriteDatabaseOnDebug"
-    static let enableParsingCheckpoints = "enableParsingCheckpoints"
     static let automaticBackupsEnabled = "automaticBackupsEnabled"
     static let automaticBackupTime = "automaticBackupTime"
     static let backupLog = "backupLog"


### PR DESCRIPTION
## Summary
- drop debug toggles from settings
- remove debug database recopy
- deprecate parsing checkpoint toggle

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68ab06472a98832388f057253a8dbfe8