### PR TITLE
Remove debug settings and parsing checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 ### Fixed
 
 ### Removed
+- Remove development-only toggles for database re-copy and parsing checkpoints (#PR_NUMBER)
 
 ### Security
 

--- a/DragonShield/DatabaseManager.swift
+++ b/DragonShield/DatabaseManager.swift
@@ -1,6 +1,7 @@
 // DragonShield/DatabaseManager.swift
-// MARK: - Version 1.6.0.1
+// MARK: - Version 1.6.0.2
 // MARK: - History
+// - 1.6.0.1 -> 1.6.0.2: Remove debug database re-copy option.
 // - 1.5 -> 1.6: Expose database path, creation date and modification date via
 //               @Published properties.
 // - 1.6 -> 1.6.0.1: Use sqlite3_open_v2 with FULLMUTEX and log errors when opening fails.
@@ -58,18 +59,6 @@ class DatabaseManager: ObservableObject {
         let mode = DatabaseMode(rawValue: savedMode ?? "production") ?? .production
         self.dbMode = mode
         self.dbPath = appDir.appendingPathComponent(DatabaseManager.fileName(for: mode)).path
-        
-        #if DEBUG
-        let shouldForceReCopy = UserDefaults.standard.bool(forKey: UserDefaultsKeys.forceOverwriteDatabaseOnDebug)
-        if shouldForceReCopy && FileManager.default.fileExists(atPath: dbPath) {
-            do {
-                try FileManager.default.removeItem(atPath: dbPath)
-                print("🗑️ [DEBUG] Deleted existing database at: \(dbPath) (Force Re-Copy Setting is ON)")
-            } catch {
-                print("⚠️ [DEBUG] Could not delete existing database for re-copy: \(error)")
-            }
-        }
-        #endif
         
         if !FileManager.default.fileExists(atPath: dbPath) {
             if let bundlePath = Bundle.main.path(forResource: "dragonshield", ofType: "sqlite") {

--- a/DragonShield/ImportManager.swift
+++ b/DragonShield/ImportManager.swift
@@ -1,7 +1,8 @@
 // DragonShield/ImportManager.swift
 
-// MARK: - Version 2.0.3.0
+// MARK: - Version 2.0.3.1
 // MARK: - History
+// - 2.0.3.0 -> 2.0.3.1: Remove parsing checkpoint feature.
 // - 1.11 -> 2.0.0.0: Rewritten to use native Swift XLSX processing instead of Python parser.
 // - 2.0.0.0 -> 2.0.0.1: Replace deprecated allowedFileTypes API.
 // - 2.0.0.1 -> 2.0.0.2: Begin security-scoped access when reading selected file.
@@ -34,9 +35,7 @@ class ImportManager {
         PositionReportRepository(dbManager: dbManager)
     }()
 
-    private var checkpointsEnabled: Bool {
-        UserDefaults.standard.bool(forKey: UserDefaultsKeys.enableParsingCheckpoints)
-    }
+    
 
     private static let cashValorMap: [String: (ticker: String, currency: String)] = [
         "CH9304835039842401009": ("CASHCHF", "CHF"),
@@ -74,93 +73,28 @@ class ImportManager {
         return 1
     }
 
-    enum RecordPromptResult {
-        case save(ParsedPositionRecord)
-        case ignore
-        case abort
-    }
-
-    enum InstrumentPromptResult {
-        case save(name: String, subClassId: Int, currency: String, ticker: String?, isin: String?, valorNr: String?, sector: String?)
-        case ignore
-        case abort
-    }
-
-    enum AccountPromptResult {
-        case save(name: String, institutionId: Int, number: String, accountTypeId: Int, currency: String)
-        case cancel
-        case abort
-    }
-
     enum ImportError: Error {
         case aborted
     }
+
+    
+
+    
+
+    
+
+    
 
     enum StatementType {
         case creditSuisse
         case zkb
     }
 
+    
 
-    private func promptForInstrument(record: ParsedPositionRecord) -> InstrumentPromptResult {
-        var result: InstrumentPromptResult = .ignore
-        let view = InstrumentPromptView(
-            name: record.instrumentName,
-            ticker: record.tickerSymbol ?? "",
-            isin: record.isin ?? "",
-            valorNr: record.valorNr ?? "",
-            currency: record.currency,
-            subClassId: record.subClassIdGuess
-        ) { action in
-            result = action
-            NSApp.stopModal()
-        }
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 700, height: 500),
-            styleMask: [.titled, .closable, .resizable],
-            backing: .buffered, defer: false)
-        window.title = "Add Instrument"
-        window.isReleasedWhenClosed = false
-        window.center()
-        window.contentView = NSHostingView(rootView: view)
-        NSApp.runModal(for: window)
-        return result
-    }
+    
 
-    private func promptForAccount(number: String,
-                                  currency: String,
-                                  accountTypeCode: String = "CUSTODY") -> AccountPromptResult {
-        var result: AccountPromptResult = .cancel
-        let instId = dbManager.findInstitutionId(name: "Credit-Suisse") ?? 1
-        let typeId = dbManager.findAccountTypeId(code: accountTypeCode) ?? 1
-        let defaultName = accountTypeCode == "CASH" ? "Credit-Suisse Cash Account" : "Credit-Suisse Account"
-        let view = AccountPromptView(accountName: defaultName,
-                                     accountNumber: number,
-                                     institutionId: instId,
-                                     accountTypeId: typeId,
-                                     currencyCode: currency) { action in
-            result = action
-            NSApp.stopModal()
-        }
-        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 700, height: 500),
-                              styleMask: [.titled, .closable, .resizable],
-                              backing: .buffered, defer: false)
-        window.title = "Add Account"
-        window.isReleasedWhenClosed = false
-        window.center()
-        window.contentView = NSHostingView(rootView: view.environmentObject(dbManager))
-        NSApp.runModal(for: window)
-        return result
-    }
-
-    private func confirmCashAccount(name: String, currency: String, amount: Double) -> Bool {
-        let alert = NSAlert()
-        alert.messageText = "Create Cash Account?"
-        alert.informativeText = "Account: \(name)\nCurrency: \(currency)\nBalance: \(amount)"
-        alert.addButton(withTitle: "Create")
-        alert.addButton(withTitle: "Skip")
-        return alert.runModal() == .alertFirstButtonReturn
-    }
+    
 
     /// Asks the user whether the given instrument is an option.
     /// - Parameter name: The instrument description.
@@ -193,29 +127,7 @@ class ImportManager {
         return nil
     }
 
-    private func promptForPosition(record: ParsedPositionRecord) -> RecordPromptResult {
-        var mutable = record
-        var result: RecordPromptResult = .ignore
-        let view = PositionReviewView(record: mutable) { action in
-            result = action
-            NSApp.stopModal()
-        }
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 700, height: 600),
-            styleMask: [.titled, .closable, .resizable],
-            backing: .buffered, defer: false)
-        window.title = "Review Position"
-        window.isReleasedWhenClosed = false
-        window.center()
-        window.contentView = NSHostingView(rootView: view)
-        NSApp.runModal(for: window)
-        // capture updated record if Save was chosen
-        if case .save(let updated) = result {
-            mutable = updated
-            result = .save(mutable)
-        }
-        return result
-    }
+    
 
     private func showImportSummary(fileName: String, account: String?, valueDate: Date?, validRows: Int) {
         let view = ImportSummaryView(fileName: fileName,
@@ -235,40 +147,9 @@ class ImportManager {
         NSApp.runModal(for: window)
     }
 
-    private struct StatusAlertView: View {
-        let title: String
-        let message: String
-        let dismiss: () -> Void
+    
 
-        var body: some View {
-            VStack(spacing: 20) {
-                Text(title)
-                    .font(.headline)
-                Text(message)
-                    .font(.body)
-                Button("OK") {
-                    dismiss()
-                }
-            }
-            .frame(minWidth: 700, minHeight: 420)
-            .padding()
-        }
-    }
-
-    private func showStatusWindow(title: String, message: String) {
-        let view = StatusAlertView(title: title, message: message) {
-            NSApp.stopModal()
-        }
-        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 700, height: 420),
-                              styleMask: [.titled, .closable, .resizable],
-                              backing: .buffered, defer: false)
-        window.title = title
-        window.isReleasedWhenClosed = false
-        window.center()
-        window.contentView = NSHostingView(rootView: view)
-        NSApp.runModal(for: window)
-        window.close()
-    }
+    
 
     private func showValueReport(items: [DatabaseManager.ImportSessionValueItem], total: Double) {
         let view = ValueReportView(items: items, totalValue: total) {
@@ -357,74 +238,26 @@ class ImportManager {
 
                 let custodyNumber = rows.first?.accountNumber ?? ""
                 var accountId = self.dbManager.findAccountId(accountNumber: custodyNumber)
-                LoggingService.shared.log("Lookup account for \(custodyNumber) -> \(accountId?.description ?? "nil")", type: .debug, logger: .database)
+                LoggingService.shared.log("Lookup account for \(custodyNumber) -> \(accountId?.description ?? \"nil\")", type: .debug, logger: .database)
                 if accountId == nil {
                     accountId = self.dbManager.findAccountId(accountNumber: custodyNumber, nameContains: institutionName)
-                    LoggingService.shared.log("Lookup with name filter -> \(accountId?.description ?? "nil")", type: .debug, logger: .database)
+                    LoggingService.shared.log("Lookup with name filter -> \(accountId?.description ?? \"nil\")", type: .debug, logger: .database)
                 }
-                while accountId == nil {
-                    if self.checkpointsEnabled {
-                        var accAction: AccountPromptResult = .cancel
-                    DispatchQueue.main.sync {
-                        accAction = self.promptForAccount(number: custodyNumber,
-                                                         currency: rows.first?.currency ?? "CHF",
-                                                         accountTypeCode: "CUSTODY")
-                    }
-                    switch accAction {
-                    case let .save(name, instId, number, typeId, curr):
-                        _ = self.dbManager.addAccount(accountName: name,
-                                                       institutionId: instId,
-                                                       accountNumber: number,
-                                                       accountTypeId: typeId,
-                                                       currencyCode: curr,
-                                                       openingDate: nil,
-                                                       closingDate: nil,
-                                                       includeInPortfolio: true,
-                                                       isActive: true,
-                                                       notes: nil)
-                        accountId = self.dbManager.findAccountId(accountNumber: number)
-                        LoggingService.shared.log("Post-create lookup -> \(accountId?.description ?? "nil")", type: .debug, logger: .database)
-                        if accountId == nil {
-                        accountId = self.dbManager.findAccountId(accountNumber: number, nameContains: institutionName)
-                            LoggingService.shared.log("Post-create lookup with name filter -> \(accountId?.description ?? "nil")", type: .debug, logger: .database)
-                        }
-                        if accountId != nil {
-                            LoggingService.shared.log("Created account \(name)", type: .info, logger: .database)
-                        }
-                    case .cancel:
-                        accountId = self.dbManager.findAccountId(accountNumber: custodyNumber)
-                        LoggingService.shared.log("Retry lookup -> \(accountId?.description ?? "nil")", type: .debug, logger: .database)
-                        if accountId == nil {
-                        accountId = self.dbManager.findAccountId(accountNumber: custodyNumber, nameContains: institutionName)
-                            LoggingService.shared.log("Retry lookup with name filter -> \(accountId?.description ?? "nil")", type: .debug, logger: .database)
-                        }
-                        if accountId == nil {
-                            if self.checkpointsEnabled {
-                                DispatchQueue.main.sync {
-                                    self.showStatusWindow(title: "Account Required",
-                                                          message: "Account \(custodyNumber) is required to save positions.")
-                                }
-                            }
-                        }
-                    case .abort:
-                        throw ImportError.aborted
-                    }
-                    } else {
-                        let instId = institutionIdDefault
-                        let typeId = self.dbManager.findAccountTypeId(code: "CUSTODY") ?? 1
-                        let defaultName = type == .creditSuisse ? "Credit-Suisse Account" : "ZKB Account"
-                        _ = self.dbManager.addAccount(accountName: defaultName,
-                                                       institutionId: instId,
-                                                       accountNumber: custodyNumber,
-                                                       accountTypeId: typeId,
-                                                       currencyCode: rows.first?.currency ?? "CHF",
-                                                       openingDate: nil,
-                                                       closingDate: nil,
-                                                       includeInPortfolio: true,
-                                                       isActive: true,
-                                                       notes: nil)
-                        accountId = self.dbManager.findAccountId(accountNumber: custodyNumber)
-                    }
+                if accountId == nil {
+                    let instId = institutionIdDefault
+                    let typeId = self.dbManager.findAccountTypeId(code: "CUSTODY") ?? 1
+                    let defaultName = type == .creditSuisse ? "Credit-Suisse Account" : "ZKB Account"
+                    _ = self.dbManager.addAccount(accountName: defaultName,
+                                                   institutionId: instId,
+                                                   accountNumber: custodyNumber,
+                                                   accountTypeId: typeId,
+                                                   currencyCode: rows.first?.currency ?? "CHF",
+                                                   openingDate: nil,
+                                                   closingDate: nil,
+                                                   includeInPortfolio: true,
+                                                   isActive: true,
+                                                   notes: nil)
+                    accountId = self.dbManager.findAccountId(accountNumber: custodyNumber)
                 }
                 let accId = accountId!
                 let accountInfo = self.dbManager.fetchAccountDetails(id: accId)
@@ -485,26 +318,15 @@ class ImportManager {
                                 continue
                             } else {
                                 LoggingService.shared.log("Row \(idx+1) valor \(sanitized) not recognized as cash account", type: .debug, logger: .parser)
-                            }
                         } else {
                             LoggingService.shared.log("Row \(idx+1) cash account missing valor", type: .error, logger: .parser)
                         }
                         let accNumber = row.tickerSymbol ?? ""
                         var accId = self.dbManager.findAccountId(accountNumber: accNumber)
                         if accId == nil {
-                            var proceed = true
-                            if self.checkpointsEnabled {
-                                proceed = false
-                                DispatchQueue.main.sync {
-                                    proceed = self.confirmCashAccount(name: row.accountName,
-                                                                      currency: row.currency,
-                                                                      amount: row.quantity)
-                                }
-                            }
-                            if proceed {
-                                let instId = self.dbManager.findInstitutionId(name: "Credit-Suisse") ?? 1
-                                let typeId = self.dbManager.findAccountTypeId(code: "CASH") ?? 5
-                                _ = self.dbManager.addAccount(accountName: row.accountName,
+                            let instId = self.dbManager.findInstitutionId(name: "Credit-Suisse") ?? 1
+                            let typeId = self.dbManager.findAccountTypeId(code: "CASH") ?? 5
+                            _ = self.dbManager.addAccount(accountName: row.accountName,
                                                            institutionId: instId,
                                                            accountNumber: accNumber,
                                                            accountTypeId: typeId,
@@ -514,8 +336,7 @@ class ImportManager {
                                                            includeInPortfolio: true,
                                                            isActive: true,
                                                            notes: nil)
-                                accId = self.dbManager.findAccountId(accountNumber: accNumber)
-                            }
+                            accId = self.dbManager.findAccountId(accountNumber: accNumber)
                         }
                         if let aId = accId {
                             let curr = row.currency.uppercased()
@@ -543,21 +364,9 @@ class ImportManager {
                                 }
                             } else {
                                 LoggingService.shared.log("Row \(idx+1) currency \(curr) has no cash instrument mapping", type: .error, logger: .parser)
-                            }
                         } else {
                             LoggingService.shared.log("Row \(idx+1) skipped - account not found for number \(accNumber)", type: .error, logger: .parser)
                         }
-                        continue
-                    }
-
-                    var action: RecordPromptResult = .save(row)
-                    if self.checkpointsEnabled {
-                        DispatchQueue.main.sync {
-                            action = self.promptForPosition(record: row)
-                        }
-                    }
-                    guard case let .save(row) = action else {
-                        if case .abort = action { throw ImportError.aborted }
                         continue
                     }
                     let instrumentId = self.lookupInstrumentId(name: row.instrumentName,
@@ -597,11 +406,6 @@ class ImportManager {
                         reportDate: row.reportDate
                     )
                     success += 1
-                    if self.checkpointsEnabled {
-                        DispatchQueue.main.sync {
-                            self.showStatusWindow(title: "Position Saved",
-                                                  message: "Saved \(row.instrumentName)")
-                        }
                     }
                 }
                 summary.unmatchedInstruments = unmatched
@@ -633,7 +437,6 @@ class ImportManager {
             }
         }
     }
-
 
     /// Presents an open panel and processes the selected XLSX file.
     func openAndParseDocument() {

--- a/DragonShield/Views/SettingsView.swift
+++ b/DragonShield/Views/SettingsView.swift
@@ -1,6 +1,7 @@
 // DragonShield/Views/SettingsView.swift
-// MARK: - Version 1.4
+// MARK: - Version 1.5
 // MARK: - History
+// - 1.4 -> 1.5: Remove development debug options.
 // - 1.3 -> 1.4: Added database information section (path, created, updated).
 // - 1.2 -> 1.3: Replaced script-based versioning with a 100% Swift solution (AppVersionProvider) to fix build errors.
 // - 1.1 -> 1.2: Removed redundant .onChange modifiers that were causing a state update crash loop.
@@ -12,12 +13,6 @@ struct SettingsView: View {
     // Inject DatabaseManager to access @Published config properties
     @EnvironmentObject var dbManager: DatabaseManager
     @EnvironmentObject var runner: HealthCheckRunner
-
-    @AppStorage(UserDefaultsKeys.forceOverwriteDatabaseOnDebug)
-    private var forceOverwriteDatabaseOnDebug: Bool = false
-
-    @AppStorage(UserDefaultsKeys.enableParsingCheckpoints)
-    private var enableParsingCheckpoints: Bool = false
 
     @AppStorage("runStartupHealthChecks")
     private var runStartupHealthChecks: Bool = true
@@ -130,19 +125,6 @@ struct SettingsView: View {
                 NavigationLink("Theme Statuses", destination: ThemeStatusSettingsView().environmentObject(dbManager))
             }
 
-            #if DEBUG
-            Section(header: Text("Development / Debug Options")) {
-                VStack(alignment: .leading) {
-                    Toggle("Force Re-copy Database on Next Launch", isOn: $forceOverwriteDatabaseOnDebug)
-                    Text("Enable this to delete the current database and copy a fresh version from the bundle on next app start. Only for Debug builds.")
-                        .font(.caption)
-                        .foregroundColor(.gray)
-                    Toggle("Enable Parsing Checkpoints", isOn: $enableParsingCheckpoints)
-                        .padding(.top, 4)
-                }
-            }
-            #endif
-
 
             Section(header: Text("About")) {
                 HStack {
@@ -167,9 +149,6 @@ struct SettingsView: View {
 
 struct SettingsView_Previews: PreviewProvider {
     static var previews: some View {
-        // NOTE: You must have a `UserDefaultsKeys` struct with the appropriate key defined for this preview to work.
-        UserDefaults.standard.set(true, forKey: "forceOverwriteDatabaseOnDebug")
-        UserDefaults.standard.set(false, forKey: "enableParsingCheckpoints")
         let dbManager = DatabaseManager() // Create a preview instance
         let runner = HealthCheckRunner()
 

--- a/DragonShield/helpers/UserDefaultsKeys.swift
+++ b/DragonShield/helpers/UserDefaultsKeys.swift
@@ -1,13 +1,12 @@
 // DragonShield/Utils/UserDefaultsKeys.swift
-// MARK: - Version 1.0 (2025-05-31)
+// MARK: - Version 1.1 (2025-05-31)
 // MARK: - History
+// - 1.0 -> 1.1: Remove obsolete debug keys.
 // - Initial creation: Defines keys for UserDefaults.
 
 import Foundation
 
 struct UserDefaultsKeys {
-    static let forceOverwriteDatabaseOnDebug = "forceOverwriteDatabaseOnDebug"
-    static let enableParsingCheckpoints = "enableParsingCheckpoints"
     static let automaticBackupsEnabled = "automaticBackupsEnabled"
     static let automaticBackupTime = "automaticBackupTime"
     static let backupLog = "backupLog"


### PR DESCRIPTION
## Summary
- remove development-only settings section
- drop unused user defaults and debug database reset logic
- strip parsing checkpoint code from importer

## Testing
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ab06472a98832388f057253a8dbfe8