### PR TITLE
feat: add sorting to theme composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 
 
 ### Added
+- Enable sortable columns in Portfolio Theme composition table (#PR_NUMBER)
 - Restructure changelog and archive history (#PR_NUMBER)
 
 ### Changed

--- a/DragonShield/Core/CompositionSorter.swift
+++ b/DragonShield/Core/CompositionSorter.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+enum CompositionSortField {
+    case instrument
+    case researchPct
+    case userPct
+}
+
+struct CompositionSorter {
+    static func sort(_ assets: [PortfolioThemeAsset], field: CompositionSortField, ascending: Bool, nameProvider: (Int) -> String) -> [PortfolioThemeAsset] {
+        assets.sorted { a, b in
+            let nameA = nameProvider(a.instrumentId).trimmingCharacters(in: .whitespacesAndNewlines)
+            let nameB = nameProvider(b.instrumentId).trimmingCharacters(in: .whitespacesAndNewlines)
+            switch field {
+            case .instrument:
+                let cmp = nameA.localizedCaseInsensitiveCompare(nameB)
+                if cmp == .orderedSame {
+                    if a.researchTargetPct == b.researchTargetPct {
+                        return a.instrumentId < b.instrumentId
+                    }
+                    return a.researchTargetPct > b.researchTargetPct
+                }
+                return ascending ? (cmp == .orderedAscending) : (cmp == .orderedDescending)
+            case .researchPct:
+                if a.researchTargetPct == b.researchTargetPct {
+                    let cmp = nameA.localizedCaseInsensitiveCompare(nameB)
+                    if cmp == .orderedSame {
+                        return a.instrumentId < b.instrumentId
+                    }
+                    return cmp == .orderedAscending
+                }
+                return ascending ? (a.researchTargetPct < b.researchTargetPct) : (a.researchTargetPct > b.researchTargetPct)
+            case .userPct:
+                if a.userTargetPct == b.userTargetPct {
+                    let cmp = nameA.localizedCaseInsensitiveCompare(nameB)
+                    if cmp == .orderedSame {
+                        return a.instrumentId < b.instrumentId
+                    }
+                    return cmp == .orderedAscending
+                }
+                return ascending ? (a.userTargetPct < b.userTargetPct) : (a.userTargetPct > b.userTargetPct)
+            }
+        }
+    }
+}
+

--- a/DragonShieldTests/CompositionSortingTests.swift
+++ b/DragonShieldTests/CompositionSortingTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import DragonShield
+
+final class CompositionSortingTests: XCTestCase {
+    private func nameMap(_ id: Int) -> String {
+        let map: [Int: String] = [1: "bitcoin", 2: "Ethereum", 3: "Bitcoin", 4: "Astera"]
+        return map[id]!
+    }
+
+    func testInstrumentSortUsesCaseInsensitiveOrderAndResearchTiebreaker() {
+        let assets = [
+            PortfolioThemeAsset(themeId: 1, instrumentId: 1, researchTargetPct: 10, userTargetPct: 10, notes: nil, createdAt: "", updatedAt: ""),
+            PortfolioThemeAsset(themeId: 1, instrumentId: 2, researchTargetPct: 20, userTargetPct: 20, notes: nil, createdAt: "", updatedAt: ""),
+            PortfolioThemeAsset(themeId: 1, instrumentId: 3, researchTargetPct: 15, userTargetPct: 15, notes: nil, createdAt: "", updatedAt: "")
+        ]
+        let sorted = CompositionSorter.sort(assets, field: .instrument, ascending: true, nameProvider: nameMap)
+        XCTAssertEqual(sorted.map { $0.instrumentId }, [3,1,2])
+    }
+
+    func testResearchSortDescendingTiebreaksByInstrument() {
+        func names(_ id: Int) -> String {
+            [1: "Beta", 2: "alpha", 3: "Gamma"][id]!
+        }
+        let assets = [
+            PortfolioThemeAsset(themeId: 1, instrumentId: 1, researchTargetPct: 20, userTargetPct: 0, notes: nil, createdAt: "", updatedAt: ""),
+            PortfolioThemeAsset(themeId: 1, instrumentId: 2, researchTargetPct: 20, userTargetPct: 0, notes: nil, createdAt: "", updatedAt: ""),
+            PortfolioThemeAsset(themeId: 1, instrumentId: 3, researchTargetPct: 10, userTargetPct: 0, notes: nil, createdAt: "", updatedAt: "")
+        ]
+        let sorted = CompositionSorter.sort(assets, field: .researchPct, ascending: false, nameProvider: names)
+        XCTAssertEqual(sorted.map { $0.instrumentId }, [2,1,3])
+    }
+
+    func testUserSortAscendingTiebreaksByInstrument() {
+        func names(_ id: Int) -> String {
+            [1: "Charlie", 2: "Bravo", 3: "Alpha"][id]!
+        }
+        let assets = [
+            PortfolioThemeAsset(themeId: 1, instrumentId: 1, researchTargetPct: 0, userTargetPct: 30, notes: nil, createdAt: "", updatedAt: ""),
+            PortfolioThemeAsset(themeId: 1, instrumentId: 2, researchTargetPct: 0, userTargetPct: 20, notes: nil, createdAt: "", updatedAt: ""),
+            PortfolioThemeAsset(themeId: 1, instrumentId: 3, researchTargetPct: 0, userTargetPct: 20, notes: nil, createdAt: "", updatedAt: "")
+        ]
+        let sorted = CompositionSorter.sort(assets, field: .userPct, ascending: true, nameProvider: names)
+        XCTAssertEqual(sorted.map { $0.instrumentId }, [3,2,1])
+    }
+}


### PR DESCRIPTION
## Summary
- add CompositionSorter core utility and tests
- enable sortable columns in Theme composition table with focus retention
- document new sortable composition feature

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_68ab7b8826bc8323a2b3732474a27877