### PR TITLE
feat: add bank import cards with filename hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 
 ### Added
 - Restructure changelog and archive history (#PR_NUMBER)
+- Dual bank statement import cards with filename hints and instructions (Credit-Suisse, ZKB) (#PR_NUMBER)
 
 ### Changed
 - Replace status alerts with SwiftUI windows (#PR_NUMBER)

--- a/DragonShield/Views/BankStatementImportCard.swift
+++ b/DragonShield/Views/BankStatementImportCard.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct BankStatementImportCard: View {
+    let bankName: String
+    let expectedFilename: String
+    let instructionsEnabled: Bool
+    let instructionsAction: () -> Void
+    let instructionsTooltip: String
+    @Binding var selectedFile: URL?
+    let onDrop: ([URL]) -> Void
+    let selectFile: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("\(bankName) Statement")
+                    .font(.system(size: 16, weight: .bold))
+                    .accessibilityAddTraits(.isHeader)
+                if let file = selectedFile {
+                    Text(file.lastPathComponent)
+                        .font(.system(size: 14))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .help(file.path)
+                }
+            }
+
+            Text("Expected filename:\n\"\(expectedFilename)\"")
+                .font(.system(size: 13))
+                .foregroundColor(.secondary)
+
+            Button(action: instructionsAction) {
+                Label("Instructions", systemImage: "info.circle")
+            }
+            .buttonStyle(SecondaryButtonStyle())
+            .disabled(!instructionsEnabled)
+            .help(instructionsEnabled ? "" : instructionsTooltip)
+            .accessibilityLabel("Open instructions for \(bankName)")
+
+            DropZone(onDrop: onDrop)
+                .frame(height: 100)
+                .accessibilityLabel("Drop file here to import")
+
+            Button("Select File", action: selectFile)
+                .buttonStyle(SecondaryButtonStyle())
+        }
+        .padding(20)
+        .background(Theme.surface)
+        .cornerRadius(8)
+        .shadow(color: .black.opacity(0.1), radius: 3, x: 0, y: 2)
+    }
+}
+
+private struct DropZone: View {
+    var onDrop: ([URL]) -> Void
+    @State private var isTargeted = false
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(style: StrokeStyle(lineWidth: 1, dash: [5]))
+                .foregroundColor(.gray)
+                .background(isTargeted ? Color.blue.opacity(0.1) : Color.clear)
+            VStack {
+                Image(systemName: "tray.and.arrow.down")
+                Text("Drag & Drop")
+                    .font(.system(size: 13))
+                    .foregroundColor(.gray)
+            }
+        }
+        .onDrop(of: [UTType.fileURL], isTargeted: $isTargeted) { providers in
+            var urls: [URL] = []
+            for provider in providers {
+                _ = provider.loadObject(ofClass: URL.self) { url, _ in
+                    if let url { urls.append(url) }
+                }
+            }
+            DispatchQueue.main.async { onDrop(urls) }
+            return true
+        }
+    }
+}

--- a/DragonShield/Views/CreditSuisseInstructionsView.swift
+++ b/DragonShield/Views/CreditSuisseInstructionsView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct CreditSuisseInstructionsView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Instructions (German) — Credit-Suisse")
+                .font(.headline)
+            VStack(alignment: .leading, spacing: 8) {
+                Text("• Sprache: Deutsch")
+                Text("• In \u{201E}Gesamt\u00fcbersicht\u201C Depot \u{201E}398424-05\u201C ausw\u00e4hlen")
+                Text("• \u201EPDF/Export\u201C w\u00e4hlen \u2192 \u201EXLS\u201C")
+            }
+            Button("Close") { dismiss() }
+                .buttonStyle(SecondaryButtonStyle())
+                .frame(maxWidth: .infinity, alignment: .trailing)
+        }
+        .padding(20)
+        .frame(width: 360)
+    }
+}

--- a/DragonShieldTests/DataImportExportViewTests.swift
+++ b/DragonShieldTests/DataImportExportViewTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+import SwiftUI
+@testable import DragonShield
+
+final class DataImportExportViewTests: XCTestCase {
+    func testViewInitializes() {
+        let view = DataImportExportView()
+        XCTAssertNotNil(view.body)
+    }
+
+    func testInstructionsViewInitializes() {
+        let view = CreditSuisseInstructionsView()
+        XCTAssertNotNil(view.body)
+    }
+}

--- a/DragonShieldTests/ImportParsingTests.swift
+++ b/DragonShieldTests/ImportParsingTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import DragonShield
+
+final class ImportParsingTests: XCTestCase {
+    func testCreditSuisseSampleParses() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let url = root.appendingPathComponent("DragonShield/test_data/Position List Mar 26 2025.xlsx")
+        let records = try CreditSuisseXLSXProcessor().process(url: url)
+        XCTAssertGreaterThan(records.count, 0)
+    }
+
+    func testZKBSampleParses() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let url = root.appendingPathComponent("DragonShield/test_data/Depotauszug Feb 20 2025 ZKB.csv")
+        let (summary, records) = try ZKBStatementParser().parse(url: url)
+        XCTAssertGreaterThan(summary.parsedRows, 0)
+        XCTAssertGreaterThan(records.count, 0)
+    }
+}


### PR DESCRIPTION
## Summary
- show reusable bank statement import cards for Credit-Suisse and ZKB
- add Credit-Suisse instructions modal
- hint expected filenames and run sample parser tests

## Testing
- `make setup` (fails: No rule to make target 'setup')
- `make fmt && make lint` (fails: No rule to make target 'fmt')
- `make migrate` (fails: No rule to make target 'migrate')
- `make build` (fails: No rule to make target 'build')
- `make test` (fails: No rule to make target 'test')
- `swift test` (fails: Could not find Package.swift in this directory or any of its parent directories.)
- `xcodebuild -list` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68ab7e85af608323a4540c438eee0a24