### PR TITLE
Add bank-specific import cards with instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 
 ### Added
 - Restructure changelog and archive history (#PR_NUMBER)
+- Add bank-specific import cards with filename hints and instructions (#PR_NUMBER)
 
 ### Changed
 - Replace status alerts with SwiftUI windows (#PR_NUMBER)

--- a/DragonShield/Views/BankImportCard.swift
+++ b/DragonShield/Views/BankImportCard.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+struct BankImportCard: View {
+    let bankName: String
+    let expectedFilename: String
+    let selectedFileURL: URL?
+    let note: String?
+    let instructionsEnabled: Bool
+    let instructionsTooltip: String
+    let openInstructions: () -> Void
+    let dropAction: ([URL]) -> Void
+    let selectFileAction: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("\(bankName) Statement")
+                    .font(.system(size: 16, weight: .bold))
+                    .accessibilityAddTraits(.isHeader)
+                Spacer()
+                Button(action: openInstructions) {
+                    Label("Instructions", systemImage: "info.circle")
+                }
+                .accessibilityLabel("Open instructions for \(bankName)")
+                .disabled(!instructionsEnabled)
+                .opacity(instructionsEnabled ? 1 : 0.5)
+                .help(instructionsTooltip)
+            }
+
+            if let url = selectedFileURL {
+                Text(url.lastPathComponent)
+                    .font(.system(size: 13))
+                    .lineLimit(1)
+                    .help(url.path)
+            }
+
+            Text("Expected filename: \"\(expectedFilename)\"")
+                .font(.system(size: 12))
+                .foregroundColor(.secondary)
+
+            if let note {
+                Text(note)
+                    .font(.system(size: 12))
+                    .foregroundColor(.secondary)
+            }
+
+            DropZone { urls in dropAction(urls) }
+                .frame(height: 120)
+                .accessibilityLabel("Drop file here to import")
+
+            Button("Select File", action: selectFileAction)
+                .buttonStyle(SecondaryButtonStyle())
+                .frame(height: 32)
+        }
+        .padding(16)
+        .background(Theme.surface)
+        .cornerRadius(8)
+        .shadow(color: .black.opacity(0.1), radius: 3, x: 0, y: 2)
+    }
+}
+
+struct DropZone: View {
+    var onDrop: ([URL]) -> Void
+    @State private var isTargeted = false
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(style: StrokeStyle(lineWidth: 1, dash: [5]))
+                .foregroundColor(.gray)
+                .background(isTargeted ? Color.blue.opacity(0.1) : Color.clear)
+            VStack {
+                Image(systemName: "tray.and.arrow.down")
+                Text("Drag & Drop")
+                    .font(.system(size: 13))
+                    .foregroundColor(.gray)
+            }
+        }
+        .onDrop(of: [UTType.fileURL], isTargeted: $isTargeted) { providers in
+            var urls: [URL] = []
+            for provider in providers {
+                _ = provider.loadObject(ofClass: URL.self) { url, _ in
+                    if let url { urls.append(url) }
+                }
+            }
+            DispatchQueue.main.async { onDrop(urls) }
+            return true
+        }
+    }
+}

--- a/DragonShield/Views/CreditSuisseInstructionsView.swift
+++ b/DragonShield/Views/CreditSuisseInstructionsView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct CreditSuisseInstructionsView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Instructions (German) — Credit-Suisse")
+                .font(.headline)
+            VStack(alignment: .leading, spacing: 8) {
+                Text("\u{2022} Sprache: Deutsch")
+                Text("\u{2022} In \u{201E}Gesamt\u00fcbersicht\u201c Depot \u{201E}398424-05\u201c ausw\u00e4hlen")
+                Text("\u{2022} \u{201E}PDF/Export\u201c w\u00e4hlen \u2192 \u201EXLS\u201c")
+            }
+            HStack {
+                Spacer()
+                Button("Close") { dismiss() }
+                    .buttonStyle(SecondaryButtonStyle())
+            }
+        }
+        .padding()
+        .frame(width: 400)
+    }
+}

--- a/DragonShieldTests/DataImportExportViewTests.swift
+++ b/DragonShieldTests/DataImportExportViewTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+import SwiftUI
+@testable import DragonShield
+
+final class DataImportExportViewTests: XCTestCase {
+    func testViewInitializes() {
+        let view = DataImportExportView().environmentObject(DatabaseManager())
+        XCTAssertNotNil(view.body)
+    }
+
+    func testInstructionsViewInitializes() {
+        let view = CreditSuisseInstructionsView()
+        XCTAssertNotNil(view.body)
+    }
+}


### PR DESCRIPTION
## Summary
- replace generic import panel with reusable bank cards showing expected filenames
- add Credit-Suisse instructions modal (German) and disabled ZKB instructions button
- log selected file name and note when multiple files dropped

Docs consulted: `UX_UI_concept/data_import_export_view.md` (bcc15dd2feac7db10deeee57494af3ec6ce9e267), `UX_UI_concept/dragon_shield_ui_guide.md` (72f954d70b879d402b0a41d3feb2964cdf6d31e5)

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -project DragonShield.xcodeproj -scheme DragonShield test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7e85af608323a4540c438eee0a24