### PR TITLE
feat: enlarge import report window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 ### Changed
 - Replace status alerts with SwiftUI windows (#PR_NUMBER)
 - Replace legacy theme updates list with card-based overview (#PR_NUMBER)
+- Enlarge import report window and enable text copying (#PR_NUMBER)
 
 ### Fixed
 

--- a/DragonShield/Views/ValueReportView.swift
+++ b/DragonShield/Views/ValueReportView.swift
@@ -22,7 +22,9 @@ struct ValueReportView: View {
                 TableColumn("Value") { item in Text(String(format: "%.2f", item.valueOrig)) }
                 TableColumn("Value CHF") { item in Text(String(format: "%.2f", item.valueChf)) }
             }
+            .textSelection(.enabled)
             Text("Total Value CHF: " + (Self.chfFormatter.string(from: NSNumber(value: totalValue)) ?? "0"))
+                .textSelection(.enabled)
             HStack {
                 Spacer()
                 Button("Close") { onClose() }
@@ -30,6 +32,6 @@ struct ValueReportView: View {
             }
         }
         .padding(24)
-        .frame(minWidth: 500, minHeight: 400)
+        .frame(minWidth: 800, minHeight: 560)
     }
 }

--- a/DragonShieldTests/ImportReportWindowTests.swift
+++ b/DragonShieldTests/ImportReportWindowTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+import AppKit
+@testable import DragonShield
+
+final class ImportReportWindowTests: XCTestCase {
+    func testResolveImportReportFrameDefaultsCentered() {
+        let screen = NSRect(x: 0, y: 0, width: 1440, height: 900)
+        let rect = ImportManager.resolveImportReportFrame(savedFrameString: nil, screenFrame: screen)
+        XCTAssertEqual(rect.size.width, 1000, accuracy: 0.1)
+        XCTAssertEqual(rect.size.height, 700, accuracy: 0.1)
+        XCTAssertEqual(rect.origin.x, (screen.width - 1000) / 2, accuracy: 0.1)
+        XCTAssertEqual(rect.origin.y, (screen.height - 700) / 2, accuracy: 0.1)
+    }
+
+    func testResolveImportReportFrameClampsToMinAndCenters() {
+        let screen = NSRect(x: 0, y: 0, width: 1440, height: 900)
+        let saved = NSStringFromRect(NSRect(x: -5000, y: -5000, width: 100, height: 100))
+        let rect = ImportManager.resolveImportReportFrame(savedFrameString: saved, screenFrame: screen)
+        XCTAssertEqual(rect.size.width, 800, accuracy: 0.1)
+        XCTAssertEqual(rect.size.height, 560, accuracy: 0.1)
+        XCTAssertEqual(rect.origin.x, (screen.width - 800) / 2, accuracy: 0.1)
+        XCTAssertEqual(rect.origin.y, (screen.height - 560) / 2, accuracy: 0.1)
+    }
+}


### PR DESCRIPTION
## Summary
- enlarge import report window and remember last size
- enable text selection in import value report
- add window sizing unit tests

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -scheme DragonShield -project DragonShield.xcodeproj` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68ab831d3fd48323ba20ae6ef727acee