### PR TITLE
Expand import value report window and enable text copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 ### Changed
 - Replace status alerts with SwiftUI windows (#PR_NUMBER)
 - Replace legacy theme updates list with card-based overview (#PR_NUMBER)
+- Enlarge import value report window and enable text copy (#PR_NUMBER)
 
 ### Fixed
 

--- a/DragonShield/ImportManager.swift
+++ b/DragonShield/ImportManager.swift
@@ -274,14 +274,32 @@ class ImportManager {
         let view = ValueReportView(items: items, totalValue: total) {
             NSApp.stopModal()
         }
-        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 500, height: 400),
+        let defaultRect = NSRect(x: 0, y: 0, width: 1000, height: 700)
+        let window = NSWindow(contentRect: defaultRect,
                               styleMask: [.titled, .closable, .resizable],
                               backing: .buffered, defer: false)
         window.title = "Import Values"
         window.isReleasedWhenClosed = false
-        window.center()
+        window.minSize = NSSize(width: 800, height: 560)
+        if let saved = UserDefaults.standard.string(forKey: UserDefaultsKeys.importReportWindowFrame) {
+            var frame = NSRectFromString(saved)
+            if let screenFrame = NSScreen.main?.visibleFrame {
+                frame.size.width = min(frame.width, screenFrame.width)
+                frame.size.height = min(frame.height, screenFrame.height)
+                if !screenFrame.contains(frame) {
+                    frame.origin.x = screenFrame.midX - frame.width / 2
+                    frame.origin.y = screenFrame.midY - frame.height / 2
+                }
+            }
+            window.setFrame(frame, display: false)
+        } else {
+            window.setFrame(defaultRect, display: false)
+            window.center()
+        }
         window.contentView = NSHostingView(rootView: view)
         NSApp.runModal(for: window)
+        let frameString = NSStringFromRect(window.frame)
+        UserDefaults.standard.set(frameString, forKey: UserDefaultsKeys.importReportWindowFrame)
         window.close()
     }
 

--- a/DragonShield/Views/ImportSessionHistoryView.swift
+++ b/DragonShield/Views/ImportSessionHistoryView.swift
@@ -231,14 +231,15 @@ private struct ImportSessionValueReportView: View {
             Text("Value Report")
                 .font(.headline)
             Table(items) {
-                TableColumn("Instrument") { Text($0.instrument) }
-                TableColumn("Currency") { Text($0.currency) }
-                TableColumn("Value") { item in Text(String(format: "%.2f", item.valueOrig)) }
-                TableColumn("Value CHF") { item in Text(String(format: "%.2f", item.valueChf)) }
+                TableColumn("Instrument") { Text($0.instrument).textSelection(.enabled) }
+                TableColumn("Currency") { Text($0.currency).textSelection(.enabled) }
+                TableColumn("Value") { item in Text(String(format: "%.2f", item.valueOrig)).textSelection(.enabled) }
+                TableColumn("Value CHF") { item in Text(String(format: "%.2f", item.valueChf)).textSelection(.enabled) }
             }
             Text(
                 "Total Value CHF: " + (ImportSessionHistoryView.chfFormatter.string(from: NSNumber(value: totalValue)) ?? "0")
             )
+            .textSelection(.enabled)
             HStack {
                 Spacer()
                 Button("Close") { onClose() }
@@ -246,7 +247,7 @@ private struct ImportSessionValueReportView: View {
             }
         }
         .padding(24)
-        .frame(minWidth: 500, minHeight: 400)
+        .frame(minWidth: 800, minHeight: 560)
     }
 }
 

--- a/DragonShield/Views/ValueReportView.swift
+++ b/DragonShield/Views/ValueReportView.swift
@@ -17,12 +17,13 @@ struct ValueReportView: View {
             Text("Value Report")
                 .font(.headline)
             Table(items) {
-                TableColumn("Instrument") { Text($0.instrument) }
-                TableColumn("Currency") { Text($0.currency) }
-                TableColumn("Value") { item in Text(String(format: "%.2f", item.valueOrig)) }
-                TableColumn("Value CHF") { item in Text(String(format: "%.2f", item.valueChf)) }
+                TableColumn("Instrument") { Text($0.instrument).textSelection(.enabled) }
+                TableColumn("Currency") { Text($0.currency).textSelection(.enabled) }
+                TableColumn("Value") { item in Text(String(format: "%.2f", item.valueOrig)).textSelection(.enabled) }
+                TableColumn("Value CHF") { item in Text(String(format: "%.2f", item.valueChf)).textSelection(.enabled) }
             }
             Text("Total Value CHF: " + (Self.chfFormatter.string(from: NSNumber(value: totalValue)) ?? "0"))
+                .textSelection(.enabled)
             HStack {
                 Spacer()
                 Button("Close") { onClose() }
@@ -30,6 +31,6 @@ struct ValueReportView: View {
             }
         }
         .padding(24)
-        .frame(minWidth: 500, minHeight: 400)
+        .frame(minWidth: 800, minHeight: 560)
     }
 }

--- a/DragonShield/helpers/UserDefaultsKeys.swift
+++ b/DragonShield/helpers/UserDefaultsKeys.swift
@@ -25,4 +25,6 @@ struct UserDefaultsKeys {
     static let portfolioThemeDetailLastTab = "portfolioThemeDetailLastTab"
     /// Feature flag: enable attachments on theme updates.
     static let portfolioAttachmentsEnabled = "portfolioAttachmentsEnabled"
+    /// Persist window frame for import value report.
+    static let importReportWindowFrame = "importReport.windowFrame"
 }

--- a/DragonShieldTests/ValueReportViewTests.swift
+++ b/DragonShieldTests/ValueReportViewTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import DragonShield
+
+final class ValueReportViewTests: XCTestCase {
+    func testViewInitializes() {
+        let item = DatabaseManager.ImportSessionValueItem(id: 1, instrument: "Test", currency: "CHF", valueOrig: 1.0, valueChf: 1.0)
+        let view = ValueReportView(items: [item], totalValue: 1.0) {}
+        XCTAssertNotNil(view.body)
+    }
+}


### PR DESCRIPTION
## Summary
- enlarge import value report window with remembered size
- allow selecting and copying text in value report tables
- add basic ValueReportView initialization test

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68ab831d3fd48323ba20ae6ef727acee