### PR TITLE
feat: size value report columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 ### Changed
 - Replace status alerts with SwiftUI windows (#PR_NUMBER)
 - Replace legacy theme updates list with card-based overview (#PR_NUMBER)
+- Adjust value report table columns to size to content (#PR_NUMBER)
 
 ### Fixed
 

--- a/DragonShield/Views/ImportSessionHistoryView.swift
+++ b/DragonShield/Views/ImportSessionHistoryView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 struct ImportSessionHistoryView: View {
     @EnvironmentObject var dbManager: DatabaseManager
@@ -226,15 +227,21 @@ private struct ImportSessionValueReportView: View {
     let totalValue: Double
     let onClose: () -> Void
 
+    @State private var columnWidths = ColumnWidths()
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Value Report")
                 .font(.headline)
             Table(items) {
                 TableColumn("Instrument") { Text($0.instrument) }
+                    .width(min: columnWidths.instrument, ideal: columnWidths.instrument, max: columnWidths.instrument)
                 TableColumn("Currency") { Text($0.currency) }
+                    .width(min: columnWidths.currency, ideal: columnWidths.currency, max: columnWidths.currency)
                 TableColumn("Value") { item in Text(String(format: "%.2f", item.valueOrig)) }
+                    .width(min: columnWidths.value, ideal: columnWidths.value, max: columnWidths.value)
                 TableColumn("Value CHF") { item in Text(String(format: "%.2f", item.valueChf)) }
+                    .width(min: columnWidths.valueChf, ideal: columnWidths.valueChf, max: columnWidths.valueChf)
             }
             Text(
                 "Total Value CHF: " + (ImportSessionHistoryView.chfFormatter.string(from: NSNumber(value: totalValue)) ?? "0")
@@ -247,6 +254,42 @@ private struct ImportSessionValueReportView: View {
         }
         .padding(24)
         .frame(minWidth: 500, minHeight: 400)
+        .onAppear { updateColumnWidths() }
+        .onChange(of: items) { _ in updateColumnWidths() }
+    }
+
+    private func updateColumnWidths() {
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: NSFont.systemFontSize)
+        ]
+
+        var instrumentWidth = ("Instrument" as NSString).size(withAttributes: attributes).width
+        var currencyWidth = ("Currency" as NSString).size(withAttributes: attributes).width
+        var valueWidth = ("Value" as NSString).size(withAttributes: attributes).width
+        var valueChfWidth = ("Value CHF" as NSString).size(withAttributes: attributes).width
+
+        for item in items {
+            instrumentWidth = max(instrumentWidth, (item.instrument as NSString).size(withAttributes: attributes).width)
+            currencyWidth = max(currencyWidth, (item.currency as NSString).size(withAttributes: attributes).width)
+            let valueStr = String(format: "%.2f", item.valueOrig)
+            valueWidth = max(valueWidth, (valueStr as NSString).size(withAttributes: attributes).width)
+            let valueChfStr = String(format: "%.2f", item.valueChf)
+            valueChfWidth = max(valueChfWidth, (valueChfStr as NSString).size(withAttributes: attributes).width)
+        }
+
+        columnWidths = ColumnWidths(
+            instrument: instrumentWidth,
+            currency: currencyWidth,
+            value: valueWidth,
+            valueChf: valueChfWidth
+        )
+    }
+
+    private struct ColumnWidths {
+        var instrument: CGFloat = 0
+        var currency: CGFloat = 0
+        var value: CGFloat = 0
+        var valueChf: CGFloat = 0
     }
 }
 

--- a/DragonShield/Views/ValueReportView.swift
+++ b/DragonShield/Views/ValueReportView.swift
@@ -1,9 +1,12 @@
 import SwiftUI
+import AppKit
 
 struct ValueReportView: View {
     let items: [DatabaseManager.ImportSessionValueItem]
     let totalValue: Double
     let onClose: () -> Void
+
+    @State private var columnWidths = ColumnWidths()
 
     private static let chfFormatter: NumberFormatter = {
         let f = NumberFormatter()
@@ -18,9 +21,13 @@ struct ValueReportView: View {
                 .font(.headline)
             Table(items) {
                 TableColumn("Instrument") { Text($0.instrument) }
+                    .width(min: columnWidths.instrument, ideal: columnWidths.instrument, max: columnWidths.instrument)
                 TableColumn("Currency") { Text($0.currency) }
+                    .width(min: columnWidths.currency, ideal: columnWidths.currency, max: columnWidths.currency)
                 TableColumn("Value") { item in Text(String(format: "%.2f", item.valueOrig)) }
+                    .width(min: columnWidths.value, ideal: columnWidths.value, max: columnWidths.value)
                 TableColumn("Value CHF") { item in Text(String(format: "%.2f", item.valueChf)) }
+                    .width(min: columnWidths.valueChf, ideal: columnWidths.valueChf, max: columnWidths.valueChf)
             }
             Text("Total Value CHF: " + (Self.chfFormatter.string(from: NSNumber(value: totalValue)) ?? "0"))
             HStack {
@@ -31,5 +38,41 @@ struct ValueReportView: View {
         }
         .padding(24)
         .frame(minWidth: 500, minHeight: 400)
+        .onAppear { updateColumnWidths() }
+        .onChange(of: items) { _ in updateColumnWidths() }
+    }
+
+    private func updateColumnWidths() {
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: NSFont.systemFontSize)
+        ]
+
+        var instrumentWidth = ("Instrument" as NSString).size(withAttributes: attributes).width
+        var currencyWidth = ("Currency" as NSString).size(withAttributes: attributes).width
+        var valueWidth = ("Value" as NSString).size(withAttributes: attributes).width
+        var valueChfWidth = ("Value CHF" as NSString).size(withAttributes: attributes).width
+
+        for item in items {
+            instrumentWidth = max(instrumentWidth, (item.instrument as NSString).size(withAttributes: attributes).width)
+            currencyWidth = max(currencyWidth, (item.currency as NSString).size(withAttributes: attributes).width)
+            let valueStr = String(format: "%.2f", item.valueOrig)
+            valueWidth = max(valueWidth, (valueStr as NSString).size(withAttributes: attributes).width)
+            let valueChfStr = String(format: "%.2f", item.valueChf)
+            valueChfWidth = max(valueChfWidth, (valueChfStr as NSString).size(withAttributes: attributes).width)
+        }
+
+        columnWidths = ColumnWidths(
+            instrument: instrumentWidth,
+            currency: currencyWidth,
+            value: valueWidth,
+            valueChf: valueChfWidth
+        )
+    }
+
+    private struct ColumnWidths {
+        var instrument: CGFloat = 0
+        var currency: CGFloat = 0
+        var value: CGFloat = 0
+        var valueChf: CGFloat = 0
     }
 }


### PR DESCRIPTION
## Summary
- measure text widths per column in ValueReportView and ImportSessionValueReportView
- apply fixed TableColumn widths so instrument names keep widest span
- document column sizing behavior

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68ab897fd38483239f3f6c3f400ce725