### PR TITLE
Add copy and export actions to value reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 - Restructure changelog and archive history (#PR_NUMBER)
 - Introduce bank-specific import cards with filename hints and instructions (#PR_NUMBER)
 - Allow sorting Composition table by Instrument, Research %, and User % (#PR_NUMBER)
+- Copy or export Value Report data from reports (#PR_NUMBER)
 
 ### Changed
 - Replace status alerts with SwiftUI windows (#PR_NUMBER)

--- a/DragonShield/Views/ImportSessionHistoryView.swift
+++ b/DragonShield/Views/ImportSessionHistoryView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 struct ImportSessionHistoryView: View {
     @EnvironmentObject var dbManager: DatabaseManager
@@ -240,6 +241,12 @@ private struct ImportSessionValueReportView: View {
                 "Total Value CHF: " + (ImportSessionHistoryView.chfFormatter.string(from: NSNumber(value: totalValue)) ?? "0")
             )
             HStack {
+                Button("Copy All") { copyAll() }
+                    .buttonStyle(SecondaryButtonStyle())
+                    .accessibilityLabel("Copy All")
+                Button("Export…") { exportAll() }
+                    .buttonStyle(SecondaryButtonStyle())
+                    .accessibilityLabel("Export")
                 Spacer()
                 Button("Close") { onClose() }
                     .buttonStyle(PrimaryButtonStyle())
@@ -247,6 +254,23 @@ private struct ImportSessionValueReportView: View {
         }
         .padding(24)
         .frame(minWidth: 500, minHeight: 400)
+    }
+
+    private func copyAll() {
+        let string = ValueReportView.exportString(items: items, totalValue: totalValue)
+        let pb = NSPasteboard.general
+        pb.clearContents()
+        pb.setString(string, forType: .string)
+    }
+
+    private func exportAll() {
+        let string = ValueReportView.exportString(items: items, totalValue: totalValue)
+        let panel = NSSavePanel()
+        panel.allowedFileTypes = ["csv", "txt"]
+        panel.nameFieldStringValue = "ValueReport.csv"
+        if panel.runModal() == .OK, let url = panel.url {
+            try? string.data(using: .utf8)?.write(to: url)
+        }
     }
 }
 

--- a/DragonShield/Views/ValueReportView.swift
+++ b/DragonShield/Views/ValueReportView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 struct ValueReportView: View {
     let items: [DatabaseManager.ImportSessionValueItem]
@@ -12,6 +13,28 @@ struct ValueReportView: View {
         return f
     }()
 
+    static func exportString(
+        items: [DatabaseManager.ImportSessionValueItem],
+        totalValue: Double,
+        delimiter: String = ","
+    ) -> String {
+        var lines: [String] = [
+            ["Instrument", "Currency", "Value", "Value CHF"].joined(separator: delimiter)
+        ]
+        for item in items {
+            let value = String(format: "%.2f", item.valueOrig)
+            let chf = String(format: "%.2f", item.valueChf)
+            lines.append(
+                [item.instrument, item.currency, value, chf].joined(separator: delimiter)
+            )
+        }
+        let total = String(format: "%.2f", totalValue)
+        lines.append(
+            ["Total Value CHF", "", "", total].joined(separator: delimiter)
+        )
+        return lines.joined(separator: "\n")
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Value Report")
@@ -24,6 +47,12 @@ struct ValueReportView: View {
             }
             Text("Total Value CHF: " + (Self.chfFormatter.string(from: NSNumber(value: totalValue)) ?? "0"))
             HStack {
+                Button("Copy All") { copyAll() }
+                    .buttonStyle(SecondaryButtonStyle())
+                    .accessibilityLabel("Copy All")
+                Button("Export…") { exportAll() }
+                    .buttonStyle(SecondaryButtonStyle())
+                    .accessibilityLabel("Export")
                 Spacer()
                 Button("Close") { onClose() }
                     .buttonStyle(PrimaryButtonStyle())
@@ -31,5 +60,22 @@ struct ValueReportView: View {
         }
         .padding(24)
         .frame(minWidth: 500, minHeight: 400)
+    }
+
+    private func copyAll() {
+        let string = Self.exportString(items: items, totalValue: totalValue)
+        let pb = NSPasteboard.general
+        pb.clearContents()
+        pb.setString(string, forType: .string)
+    }
+
+    private func exportAll() {
+        let string = Self.exportString(items: items, totalValue: totalValue)
+        let panel = NSSavePanel()
+        panel.allowedFileTypes = ["csv", "txt"]
+        panel.nameFieldStringValue = "ValueReport.csv"
+        if panel.runModal() == .OK, let url = panel.url {
+            try? string.data(using: .utf8)?.write(to: url)
+        }
     }
 }

--- a/DragonShieldTests/ValueReportViewTests.swift
+++ b/DragonShieldTests/ValueReportViewTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import DragonShield
+
+final class ValueReportViewTests: XCTestCase {
+    func testExportStringProducesHeaderItemsAndTotal() {
+        let items = [
+            DatabaseManager.ImportSessionValueItem(id: 1, instrument: "InstA", currency: "USD", valueOrig: 1.23, valueChf: 1.11),
+            DatabaseManager.ImportSessionValueItem(id: 2, instrument: "InstB", currency: "EUR", valueOrig: 2.34, valueChf: 2.22)
+        ]
+        let csv = ValueReportView.exportString(items: items, totalValue: 3.33)
+        let lines = csv.split(separator: "\n")
+        XCTAssertEqual(lines.count, 1 + items.count + 1)
+        XCTAssertTrue(lines.first?.contains("Instrument") == true)
+        XCTAssertTrue(lines.last?.contains("3.33") == true)
+    }
+}


### PR DESCRIPTION
## Summary
- add Copy All and Export options to Value Report views
- support exporting report data as CSV and copying to clipboard
- cover export string generation with unit tests

## Testing
- `make setup` (fails: No rule to make target 'setup')
- `make fmt` (fails: No rule to make target 'fmt')
- `make lint` (fails: No rule to make target 'lint')
- `make migrate` (fails: No rule to make target 'migrate')
- `make build` (fails: No rule to make target 'build')
- `make test` (fails: No rule to make target 'test')
- `swift build` (fails: Could not find Package.swift)
- `swift test` (fails: Could not find Package.swift)


------
https://chatgpt.com/codex/tasks/task_e_68ab89867b50832394e67f2ee88a0f55