### PR TITLE
Add unused instruments query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 
 
 ### Added
-- Add query to report unused instruments (#PR_NUMBER)
+- Add unused instruments report with visible toolbar button (#PR_NUMBER)
 - Restructure changelog and archive history (#PR_NUMBER)
 - Introduce bank-specific import cards with filename hints and instructions (#PR_NUMBER)
 - Allow sorting Composition table by Instrument, Research %, and User % (#PR_NUMBER)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 
 
 ### Added
+- Add query to report unused instruments (#PR_NUMBER)
 - Restructure changelog and archive history (#PR_NUMBER)
 - Introduce bank-specific import cards with filename hints and instructions (#PR_NUMBER)
 - Allow sorting Composition table by Instrument, Research %, and User % (#PR_NUMBER)

--- a/DragonShield/DatabaseManager+UnusedInstruments.swift
+++ b/DragonShield/DatabaseManager+UnusedInstruments.swift
@@ -1,0 +1,67 @@
+import Foundation
+import SQLite3
+
+extension DatabaseManager {
+    func fetchUnusedInstruments(excludingCash: Bool = true) -> [UnusedInstrument] {
+        var unused: [UnusedInstrument] = []
+        guard let db = db else { return unused }
+
+        var stmt: OpaquePointer?
+        var latest: String?
+        if sqlite3_prepare_v2(db, "SELECT MAX(report_date) FROM PositionReports", -1, &stmt, nil) == SQLITE_OK {
+            if sqlite3_step(stmt) == SQLITE_ROW, let cstr = sqlite3_column_text(stmt, 0) {
+                latest = String(cString: cstr)
+            }
+        }
+        sqlite3_finalize(stmt)
+        guard let latestDate = latest else { return [] }
+
+        var sql = """
+            SELECT i.instrument_id, i.instrument_name, asc.sub_class_name, i.currency,
+                   MAX(pr.report_date) AS last_activity,
+                   COUNT(DISTINCT pta.theme_id) AS theme_count
+              FROM Instruments i
+              JOIN AssetSubClasses asc ON i.sub_class_id = asc.sub_class_id
+              LEFT JOIN (
+                    SELECT instrument_id, SUM(quantity) AS qty
+                      FROM PositionReports
+                     WHERE report_date = ?
+                     GROUP BY instrument_id
+              ) cur ON cur.instrument_id = i.instrument_id
+              LEFT JOIN PositionReports pr ON pr.instrument_id = i.instrument_id
+              LEFT JOIN PortfolioThemeAsset pta ON pta.instrument_id = i.instrument_id
+             WHERE IFNULL(cur.qty, 0) = 0
+            """
+        if excludingCash {
+            sql += " AND asc.sub_class_code <> 'CASH'"
+        }
+        sql += """
+             GROUP BY i.instrument_id, i.instrument_name, asc.sub_class_name, i.currency
+             ORDER BY last_activity ASC NULLS FIRST, i.instrument_name;
+            """
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) != SQLITE_OK {
+            return unused
+        }
+        sqlite3_bind_text(stmt, 1, latestDate, -1, nil)
+        let formatter = DateFormatter.iso8601DateOnly
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            let id = Int(sqlite3_column_int(stmt, 0))
+            guard let namePtr = sqlite3_column_text(stmt, 1),
+                  let typePtr = sqlite3_column_text(stmt, 2),
+                  let currencyPtr = sqlite3_column_text(stmt, 3) else { continue }
+            let name = String(cString: namePtr)
+            let type = String(cString: typePtr)
+            let currency = String(cString: currencyPtr)
+            var last: Date? = nil
+            if sqlite3_column_type(stmt, 4) != SQLITE_NULL {
+                let str = String(cString: sqlite3_column_text(stmt, 4))
+                last = formatter.date(from: str)
+            }
+            let themes = Int(sqlite3_column_int(stmt, 5))
+            unused.append(UnusedInstrument(id: id, name: name, type: type, currency: currency, lastActivity: last, themeCount: themes))
+        }
+        sqlite3_finalize(stmt)
+        return unused
+    }
+}
+

--- a/DragonShield/Models/UnusedInstrument.swift
+++ b/DragonShield/Models/UnusedInstrument.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+struct UnusedInstrument: Identifiable {
+    let id: Int
+    let name: String
+    let type: String
+    let currency: String
+    let lastActivity: Date?
+    let themeCount: Int
+}
+

--- a/DragonShield/Views/PortfolioView.swift
+++ b/DragonShield/Views/PortfolioView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 // MARK: - Main Portfolio View
 struct PortfolioView: View {
     @EnvironmentObject var assetManager: AssetManager
+    @EnvironmentObject var dbManager: DatabaseManager
     @State private var showAddInstrumentSheet = false
     @State private var showEditInstrumentSheet = false
     @State private var selectedAsset: DragonAsset? = nil
@@ -14,6 +15,7 @@ struct PortfolioView: View {
     @State private var currencyFilters: Set<String> = []
     @State private var sortColumn: SortColumn = .name
     @State private var sortAscending: Bool = true
+    @State private var showUnusedReport = false
 
     enum SortColumn {
         case name, type, currency, symbol, valor, isin
@@ -112,7 +114,11 @@ struct PortfolioView: View {
                     }
             }
         }
-        
+        .sheet(isPresented: $showUnusedReport) {
+            UnusedInstrumentsView()
+                .environmentObject(dbManager)
+        }
+
         .alert("Delete Instrument", isPresented: $showingDeleteAlert) {
             Button("Cancel", role: .cancel) { }
             Button("Delete", role: .destructive) {
@@ -531,7 +537,27 @@ struct PortfolioView: View {
                     }
                     .buttonStyle(ScaleButtonStyle())
                 }
-                
+
+                Button {
+                    showUnusedReport = true
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "tray")
+                        Text("Unused Instruments…")
+                    }
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundColor(.green)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 10)
+                    .background(Color.green.opacity(0.1))
+                    .clipShape(Capsule())
+                    .overlay(
+                        Capsule()
+                            .stroke(Color.green.opacity(0.3), lineWidth: 1)
+                    )
+                }
+                .buttonStyle(ScaleButtonStyle())
+
                 Spacer()
                 
                 // Selection indicator

--- a/DragonShield/Views/UnusedInstrumentsView.swift
+++ b/DragonShield/Views/UnusedInstrumentsView.swift
@@ -1,0 +1,60 @@
+// DragonShield/Views/UnusedInstrumentsView.swift
+// MARK: - Version 1.0
+// MARK: - History
+// - 1.0: Initial unused instruments report view.
+
+import SwiftUI
+
+struct UnusedInstrumentsView: View {
+    @EnvironmentObject var dbManager: DatabaseManager
+    @Environment(\.dismiss) private var dismiss
+    @State private var items: [UnusedInstrument] = []
+
+    static func exportString(items: [UnusedInstrument], delimiter: String = ",") -> String {
+        var lines = ["Instrument,Type,Currency,Last Activity,In Themes"]
+        for item in items {
+            let last = item.lastActivity.map { DateFormatter.iso8601DateOnly.string(from: $0) } ?? ""
+            lines.append([item.name, item.type, item.currency, last, "\(item.themeCount)"].joined(separator: delimiter))
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Unused Instruments")
+                .font(.headline)
+            Table(items) {
+                TableColumn("Instrument") { Text($0.name).textSelection(.enabled) }
+                TableColumn("Type") { Text($0.type).textSelection(.enabled) }
+                TableColumn("Currency") { Text($0.currency).textSelection(.enabled) }
+                TableColumn("Last Activity") { item in
+                    Text(item.lastActivity.map { DateFormatter.iso8601DateOnly.string(from: $0) } ?? "—")
+                        .textSelection(.enabled)
+                }
+                TableColumn("In Themes") { item in
+                    Text("\(item.themeCount)").textSelection(.enabled)
+                }
+            }
+            HStack {
+                Button("Export CSV") { exportAll() }
+                    .buttonStyle(SecondaryButtonStyle())
+                Spacer()
+                Button("Close") { dismiss() }
+                    .buttonStyle(PrimaryButtonStyle())
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 800, minHeight: 560)
+        .onAppear { items = dbManager.fetchUnusedInstruments() }
+    }
+
+    private func exportAll() {
+        let string = Self.exportString(items: items)
+        let panel = NSSavePanel()
+        panel.allowedFileTypes = ["csv", "txt"]
+        panel.nameFieldStringValue = "Unused_Instruments.csv"
+        if panel.runModal() == .OK, let url = panel.url {
+            try? string.data(using: .utf8)?.write(to: url)
+        }
+    }
+}

--- a/DragonShieldTests/UnusedInstrumentsTests.swift
+++ b/DragonShieldTests/UnusedInstrumentsTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+import SQLite3
+@testable import DragonShield
+
+final class UnusedInstrumentsTests: XCTestCase {
+    func makeManager(withPositions: Bool) -> DatabaseManager {
+        let manager = DatabaseManager()
+        var db: OpaquePointer?
+        sqlite3_open(":memory:", &db)
+        manager.db = db
+        sqlite3_exec(db, "PRAGMA foreign_keys = ON;", nil, nil, nil)
+        sqlite3_exec(db, """
+            CREATE TABLE AssetSubClasses(
+                sub_class_id INTEGER PRIMARY KEY,
+                class_id INTEGER,
+                sub_class_code TEXT,
+                sub_class_name TEXT
+            );
+            CREATE TABLE Instruments(
+                instrument_id INTEGER PRIMARY KEY,
+                instrument_name TEXT,
+                sub_class_id INTEGER,
+                currency TEXT,
+                is_active INTEGER DEFAULT 1
+            );
+            CREATE TABLE PositionReports(
+                position_id INTEGER PRIMARY KEY,
+                instrument_id INTEGER,
+                quantity REAL,
+                report_date TEXT
+            );
+            CREATE TABLE PortfolioTheme(
+                id INTEGER PRIMARY KEY
+            );
+            CREATE TABLE PortfolioThemeAsset(
+                theme_id INTEGER,
+                instrument_id INTEGER
+            );
+        """, nil, nil, nil)
+        sqlite3_exec(db, "INSERT INTO AssetSubClasses VALUES (1,1,'CASH','Cash');", nil, nil, nil)
+        sqlite3_exec(db, "INSERT INTO AssetSubClasses VALUES (2,1,'EQT','Equity');", nil, nil, nil)
+        sqlite3_exec(db, "INSERT INTO Instruments VALUES (1,'Stock A',2,'USD',1);", nil, nil, nil)
+        sqlite3_exec(db, "INSERT INTO Instruments VALUES (2,'Stock B',2,'EUR',1);", nil, nil, nil)
+        sqlite3_exec(db, "INSERT INTO Instruments VALUES (3,'Cash CHF',1,'CHF',1);", nil, nil, nil)
+        if withPositions {
+            sqlite3_exec(db, "INSERT INTO PositionReports VALUES (1,1,5,'2025-01-01');", nil, nil, nil)
+            sqlite3_exec(db, "INSERT INTO PositionReports VALUES (2,2,1,'2024-12-01');", nil, nil, nil)
+        }
+        sqlite3_exec(db, "INSERT INTO PortfolioTheme VALUES (1);", nil, nil, nil)
+        sqlite3_exec(db, "INSERT INTO PortfolioThemeAsset VALUES (1,2);", nil, nil, nil)
+        return manager
+    }
+
+    func testFetchUnusedInstrumentsExcludingCash() {
+        let manager = makeManager(withPositions: true)
+        let list = manager.fetchUnusedInstruments()
+        XCTAssertEqual(list.count, 1)
+        let item = list[0]
+        XCTAssertEqual(item.name, "Stock B")
+        XCTAssertEqual(item.themeCount, 1)
+        XCTAssertEqual(DateFormatter.iso8601DateOnly.string(from: item.lastActivity!), "2024-12-01")
+        sqlite3_close(manager.db)
+    }
+
+    func testFetchUnusedInstrumentsIncludingCashAndNoSnapshot() {
+        let manager = makeManager(withPositions: true)
+        let list = manager.fetchUnusedInstruments(excludingCash: false)
+        XCTAssertEqual(list.map { $0.name }.sorted(), ["Cash CHF", "Stock B"])
+        sqlite3_close(manager.db)
+
+        let manager2 = makeManager(withPositions: false)
+        let empty = manager2.fetchUnusedInstruments()
+        XCTAssertTrue(empty.isEmpty)
+        sqlite3_close(manager2.db)
+    }
+}
+

--- a/DragonShieldTests/UnusedInstrumentsViewTests.swift
+++ b/DragonShieldTests/UnusedInstrumentsViewTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+import SwiftUI
+import SQLite3
+@testable import DragonShield
+
+final class UnusedInstrumentsViewTests: XCTestCase {
+    func testViewInitializes() {
+        let manager = DatabaseManager()
+        var db: OpaquePointer?
+        sqlite3_open(":memory:", &db)
+        manager.db = db
+        let view = UnusedInstrumentsView().environmentObject(manager)
+        XCTAssertNotNil(view.body)
+        sqlite3_close(db)
+    }
+}


### PR DESCRIPTION
## Summary
- add UnusedInstrument model and database query to list instruments without holdings
- test fetching unused instruments and handle cash exclusion
- document unused instrument report in changelog

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -project DragonShield.xcodeproj -scheme DragonShield -destination 'platform=macOS'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac02bc20e4832385145206d09b1295