### PR TITLE
Add strict unused instruments repository and report UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 - Introduce bank-specific import cards with filename hints and instructions (#PR_NUMBER)
 - Allow sorting Composition table by Instrument, Research %, and User % (#PR_NUMBER)
 - Copy or export Value Report data from reports (#PR_NUMBER)
+- Add repository for strict unused instruments report (#PR_NUMBER)
+- Show strict unused instruments report from Instruments view (#PR_NUMBER)
 
 ### Changed
 - Replace status alerts with SwiftUI windows (#PR_NUMBER)

--- a/DragonShield/InstrumentUsageRepository.swift
+++ b/DragonShield/InstrumentUsageRepository.swift
@@ -1,0 +1,147 @@
+// DragonShield/InstrumentUsageRepository.swift
+// MARK: - Version 1.0.0
+// Repository providing queries for unused instruments under strict criteria.
+
+import Foundation
+import SQLite3
+
+struct UnusedInstrument {
+    let instrumentId: Int
+    let name: String
+    let type: String
+    let currency: String
+    let lastActivity: Date?
+    let themesCount: Int
+    let refsCount: Int
+}
+
+enum InstrumentUsageRepositoryError: LocalizedError {
+    case noSnapshot
+
+    var errorDescription: String? {
+        switch self {
+        case .noSnapshot:
+            return "No positions snapshot available"
+        }
+    }
+}
+
+/// Provides queries for analysing instrument usage across the database.
+final class InstrumentUsageRepository {
+    private let dbManager: DatabaseManager
+    private static let epsilon = 1e-9
+
+    init(dbManager: DatabaseManager) {
+        self.dbManager = dbManager
+    }
+
+    /// Returns all instruments that satisfy U1∧U2∧U3 from the specification.
+    /// - Parameter excludeCash: When true (default) excludes instruments of the cash subclass.
+    func unusedStrict(excludeCash: Bool = true) throws -> [UnusedInstrument] {
+        guard let db = dbManager.db else { return [] }
+
+        // Determine latest snapshot date.
+        var latestStmt: OpaquePointer?
+        var snapshotDate: String?
+        if sqlite3_prepare_v2(db, "SELECT MAX(report_date) FROM PositionReports", -1, &latestStmt, nil) == SQLITE_OK {
+            if sqlite3_step(latestStmt) == SQLITE_ROW, let ptr = sqlite3_column_text(latestStmt, 0) {
+                snapshotDate = String(cString: ptr)
+            }
+        }
+        sqlite3_finalize(latestStmt)
+
+        guard let reportDate = snapshotDate else {
+            throw InstrumentUsageRepositoryError.noSnapshot
+        }
+
+        // Build refs_count expression based on existing tables.
+        let referenceTables = ["Transactions", "PortfolioInstruments"].filter { tableExists($0, db: db) }
+        let refsExpression: String
+        if referenceTables.isEmpty {
+            refsExpression = "0"
+        } else {
+            let components = referenceTables.map {
+                "CASE WHEN EXISTS(SELECT 1 FROM \($0) r WHERE r.instrument_id = i.instrument_id) THEN 1 ELSE 0 END"
+            }
+            refsExpression = components.joined(separator: " + ")
+        }
+
+        let cashFilter = excludeCash ? "AND i.sub_class_id != 1" : ""
+
+        let sql = """
+        WITH latest_positions AS (
+            SELECT instrument_id, SUM(quantity) AS qty
+            FROM PositionReports
+            WHERE report_date = ?
+            GROUP BY instrument_id
+        ),
+        last_activity AS (
+            SELECT instrument_id, MAX(report_date) AS last_date
+            FROM PositionReports
+            GROUP BY instrument_id
+        ),
+        theme_counts AS (
+            SELECT instrument_id, COUNT(*) AS cnt
+            FROM PortfolioThemeAsset
+            GROUP BY instrument_id
+        )
+        SELECT i.instrument_id, i.instrument_name, asc.sub_class_name, i.currency,
+               la.last_date,
+               COALESCE(tc.cnt,0) AS themes_count,
+               \(refsExpression) AS refs_count
+        FROM Instruments i
+        LEFT JOIN latest_positions lp ON lp.instrument_id = i.instrument_id
+        LEFT JOIN last_activity la ON la.instrument_id = i.instrument_id
+        LEFT JOIN theme_counts tc ON tc.instrument_id = i.instrument_id
+        LEFT JOIN AssetSubClasses asc ON asc.sub_class_id = i.sub_class_id
+        WHERE (lp.instrument_id IS NULL OR ABS(lp.qty) < \(Self.epsilon))
+          AND COALESCE(tc.cnt,0) = 0
+          AND \(refsExpression) = 0
+          AND i.is_active = 1
+          \(cashFilter)
+        ORDER BY i.instrument_name
+        """
+
+        var stmt: OpaquePointer?
+        var results: [UnusedInstrument] = []
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            sqlite3_bind_text(stmt, 1, reportDate, -1, nil)
+            let formatter = DateFormatter.iso8601DateOnly
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                let id = Int(sqlite3_column_int(stmt, 0))
+                let name = sqlite3_column_text(stmt, 1).map { String(cString: $0) } ?? ""
+                let type = sqlite3_column_text(stmt, 2).map { String(cString: $0) } ?? ""
+                let currency = sqlite3_column_text(stmt, 3).map { String(cString: $0) } ?? ""
+                let lastDateStr = sqlite3_column_text(stmt, 4).map { String(cString: $0) }
+                let lastDate = lastDateStr.flatMap { formatter.date(from: $0) }
+                let themesCount = Int(sqlite3_column_int(stmt, 5))
+                let refsCount = Int(sqlite3_column_int(stmt, 6))
+                results.append(UnusedInstrument(
+                    instrumentId: id,
+                    name: name,
+                    type: type,
+                    currency: currency,
+                    lastActivity: lastDate,
+                    themesCount: themesCount,
+                    refsCount: refsCount
+                ))
+            }
+        } else {
+            LoggingService.shared.log("unusedStrict prepare failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+        sqlite3_finalize(stmt)
+        return results
+    }
+
+    private func tableExists(_ name: String, db: OpaquePointer) -> Bool {
+        let sql = "SELECT 1 FROM sqlite_master WHERE type='table' AND name=? LIMIT 1"
+        var stmt: OpaquePointer?
+        var exists = false
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            sqlite3_bind_text(stmt, 1, name, -1, nil)
+            exists = sqlite3_step(stmt) == SQLITE_ROW
+        }
+        sqlite3_finalize(stmt)
+        return exists
+    }
+}

--- a/DragonShield/Views/PortfolioView.swift
+++ b/DragonShield/Views/PortfolioView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 // MARK: - Main Portfolio View
 struct PortfolioView: View {
     @EnvironmentObject var assetManager: AssetManager
+    @EnvironmentObject var dbManager: DatabaseManager
     @State private var showAddInstrumentSheet = false
     @State private var showEditInstrumentSheet = false
     @State private var selectedAsset: DragonAsset? = nil
@@ -24,6 +25,7 @@ struct PortfolioView: View {
     @State private var headerOpacity: Double = 0
     @State private var contentOffset: CGFloat = 30
     @State private var buttonsOpacity: Double = 0
+    @State private var showUnusedReport = false
     
     // Filtered assets based on search and column filters
     var filteredAssets: [DragonAsset] {
@@ -111,6 +113,10 @@ struct PortfolioView: View {
                         selectedAsset = nil
                     }
             }
+        }
+        .sheet(isPresented: $showUnusedReport) {
+            UnusedInstrumentsReportView()
+                .environmentObject(dbManager)
         }
         
         .alert("Delete Instrument", isPresented: $showingDeleteAlert) {
@@ -486,6 +492,26 @@ struct PortfolioView: View {
                 }
                 .buttonStyle(ScaleButtonStyle())
                 
+                Button {
+                    showUnusedReport = true
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "doc.text.magnifyingglass")
+                        Text("Unused Report")
+                    }
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundColor(.blue)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 10)
+                    .background(Color.blue.opacity(0.1))
+                    .clipShape(Capsule())
+                    .overlay(
+                        Capsule()
+                            .stroke(Color.blue.opacity(0.3), lineWidth: 1)
+                    )
+                }
+                .buttonStyle(ScaleButtonStyle())
+
                 // Secondary actions
                 if selectedAsset != nil {
                     Button {
@@ -507,7 +533,7 @@ struct PortfolioView: View {
                         )
                     }
                     .buttonStyle(ScaleButtonStyle())
-                    
+
                     Button {
                         if let asset = selectedAsset {
                             assetToDelete = asset

--- a/DragonShield/Views/UnusedInstrumentsReportView.swift
+++ b/DragonShield/Views/UnusedInstrumentsReportView.swift
@@ -1,0 +1,83 @@
+// DragonShield/Views/UnusedInstrumentsReportView.swift
+// MARK: - Version 1.0
+// Modal listing instruments with no positions, themes, or active references.
+
+import SwiftUI
+import AppKit
+
+struct UnusedInstrumentsReportView: View {
+    @EnvironmentObject var dbManager: DatabaseManager
+    @Environment(\.dismiss) private var dismiss
+    @State private var instruments: [UnusedInstrument] = []
+    @State private var errorMessage: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text("Unused Instruments (strict)")
+                    .font(.headline)
+                Spacer()
+                Button("Export CSV") { exportCSV() }
+                Button("Close") { dismiss() }
+            }
+            .padding()
+
+            if let errorMessage = errorMessage {
+                Text(errorMessage)
+                    .padding()
+            } else {
+                Table(instruments) {
+                    TableColumn("Instrument") { item in
+                        Text(item.name)
+                    }
+                    TableColumn("Type") { item in
+                        Text(item.type)
+                    }
+                    TableColumn("Cur") { item in
+                        Text(item.currency)
+                    }
+                    TableColumn("Last Activity") { item in
+                        Text(item.lastActivity.map { DateFormatting.userFriendly($0) } ?? "—")
+                    }
+                    TableColumn("Themes") { item in
+                        Text("\(item.themesCount)")
+                    }
+                    TableColumn("Refs") { item in
+                        Text("\(item.refsCount)")
+                    }
+                }
+            }
+        }
+        .frame(minWidth: 800, minHeight: 560)
+        .onAppear(perform: load)
+    }
+
+    private func load() {
+        do {
+            let repo = InstrumentUsageRepository(dbManager: dbManager)
+            instruments = try repo.unusedStrict()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func exportCSV() {
+        let panel = NSSavePanel()
+        panel.nameFieldStringValue = "unused_instruments.csv"
+        if panel.runModal() == .OK, let url = panel.url {
+            let header = "Instrument,Type,Currency,Last Activity,Themes,Refs\n"
+            let formatter = DateFormatter.iso8601DateOnly
+            let rows = instruments.map { item in
+                [
+                    item.name,
+                    item.type,
+                    item.currency,
+                    item.lastActivity.map { formatter.string(from: $0) } ?? "",
+                    String(item.themesCount),
+                    String(item.refsCount)
+                ].map { $0.replacingOccurrences(of: ",", with: " ") }.joined(separator: ",")
+            }.joined(separator: "\n")
+            try? (header + rows).write(to: url, atomically: true, encoding: .utf8)
+        }
+    }
+}

--- a/DragonShieldTests/InstrumentUsageRepositoryTests.swift
+++ b/DragonShieldTests/InstrumentUsageRepositoryTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+import SQLite3
+@testable import DragonShield
+
+final class InstrumentUsageRepositoryTests: XCTestCase {
+    var manager: DatabaseManager!
+    var db: OpaquePointer?
+    var repo: InstrumentUsageRepository!
+
+    override func setUp() {
+        super.setUp()
+        manager = DatabaseManager()
+        sqlite3_open(":memory:", &db)
+        manager.db = db
+        sqlite3_exec(db, "PRAGMA foreign_keys = ON;", nil, nil, nil)
+        // Minimal schema
+        sqlite3_exec(db, "CREATE TABLE AssetSubClasses(sub_class_id INTEGER PRIMARY KEY, sub_class_name TEXT);", nil, nil, nil)
+        sqlite3_exec(db, "INSERT INTO AssetSubClasses(sub_class_id, sub_class_name) VALUES(1,'Cash'),(2,'Single Stock');", nil, nil, nil)
+        sqlite3_exec(db, "CREATE TABLE Instruments(instrument_id INTEGER PRIMARY KEY, instrument_name TEXT NOT NULL, sub_class_id INTEGER NOT NULL, currency TEXT NOT NULL, is_active INTEGER DEFAULT 1);", nil, nil, nil)
+        sqlite3_exec(db, "CREATE TABLE PortfolioThemeAsset(theme_id INTEGER, instrument_id INTEGER);", nil, nil, nil)
+        sqlite3_exec(db, "CREATE TABLE PositionReports(instrument_id INTEGER, quantity REAL, report_date TEXT);", nil, nil, nil)
+        sqlite3_exec(db, "CREATE TABLE Transactions(tx_id INTEGER PRIMARY KEY, instrument_id INTEGER);", nil, nil, nil)
+        // Instrument with position to establish snapshot
+        sqlite3_exec(db, "INSERT INTO Instruments(instrument_id, instrument_name, sub_class_id, currency) VALUES(1,'Used',2,'USD');", nil, nil, nil)
+        sqlite3_exec(db, "INSERT INTO PositionReports(instrument_id, quantity, report_date) VALUES(1,10,'2024-11-03');", nil, nil, nil)
+        // Unused instrument
+        sqlite3_exec(db, "INSERT INTO Instruments(instrument_id, instrument_name, sub_class_id, currency) VALUES(2,'Unused',2,'USD');", nil, nil, nil)
+        repo = InstrumentUsageRepository(dbManager: manager)
+    }
+
+    override func tearDown() {
+        sqlite3_close(db)
+        db = nil
+        manager = nil
+        repo = nil
+        super.tearDown()
+    }
+
+    func testReturnsInstrumentWithoutUsage() throws {
+        let list = try repo.unusedStrict()
+        XCTAssertEqual(list.map { $0.instrumentId }, [2])
+    }
+
+    func testInstrumentRemovedWhenThemeAdded() throws {
+        _ = try repo.unusedStrict()
+        sqlite3_exec(db, "INSERT INTO PortfolioThemeAsset(theme_id, instrument_id) VALUES(1,2);", nil, nil, nil)
+        let list = try repo.unusedStrict()
+        XCTAssertTrue(list.isEmpty)
+    }
+
+    func testInstrumentRemovedWhenTransactionAdded() throws {
+        _ = try repo.unusedStrict()
+        sqlite3_exec(db, "INSERT INTO Transactions(instrument_id) VALUES(2);", nil, nil, nil)
+        let list = try repo.unusedStrict()
+        XCTAssertTrue(list.isEmpty)
+    }
+}

--- a/DragonShieldTests/UnusedInstrumentsReportViewTests.swift
+++ b/DragonShieldTests/UnusedInstrumentsReportViewTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+import SwiftUI
+import SQLite3
+@testable import DragonShield
+
+final class UnusedInstrumentsReportViewTests: XCTestCase {
+    func testReportViewInitializes() {
+        let manager = DatabaseManager()
+        var db: OpaquePointer?
+        sqlite3_open(":memory:", &db)
+        manager.db = db
+        let view = UnusedInstrumentsReportView().environmentObject(manager)
+        XCTAssertNotNil(view.body)
+        sqlite3_close(db)
+    }
+}


### PR DESCRIPTION
## Summary
- add InstrumentUsageRepository to query instruments with no positions, themes, or active references
- expose strict unused instruments report from Instruments view
- cover report view initialization with tests and document feature in changelog

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ac09994254832380319b0c5a4a58c8