### PR TITLE
feat: support instrument notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 - Copy or export Value Report data from reports (#PR_NUMBER)
 - Add repository for strict unused instruments report (#PR_NUMBER)
 - Expose strict unused instruments report from Instruments view (#PR_NUMBER)
+- Allow notes on instruments with overview icon (#PR_NUMBER)
 
 ### Changed
 - Replace status alerts with SwiftUI windows (#PR_NUMBER)

--- a/DragonShield/AssetManager.swift
+++ b/DragonShield/AssetManager.swift
@@ -8,6 +8,7 @@ struct DragonAsset: Identifiable {
     var valorNr: String?
     var tickerSymbol: String?
     var isin: String?
+    var note: String?
 }
 
 class AssetManager: ObservableObject {
@@ -36,7 +37,8 @@ class AssetManager: ObservableObject {
                 currency: instrument.currency,
                 valorNr: instrument.valorNr,
                 tickerSymbol: instrument.tickerSymbol,
-                isin: instrument.isin
+                isin: instrument.isin,
+                note: instrument.notes
             )
         }
         

--- a/DragonShield/Views/AddInstrumentView.swift
+++ b/DragonShield/Views/AddInstrumentView.swift
@@ -10,6 +10,7 @@ struct AddInstrumentView: View {
     @State private var isin = ""
     @State private var valorNr = ""
     @State private var sector = ""
+    @State private var notes = ""
     @State private var instrumentGroups: [(id: Int, name: String)] = []
     @State private var showingAlert = false
     @State private var alertMessage = ""
@@ -49,7 +50,7 @@ struct AddInstrumentView: View {
     private var completionPercentage: Double {
         var completed = 0.0
         let total = 7.0
-        
+
         if !instrumentName.isEmpty { completed += 1 }
         if selectedGroupId > 0 { completed += 1 }
         if !currency.isEmpty { completed += 1 }
@@ -327,6 +328,18 @@ struct AddInstrumentView: View {
                     icon: "briefcase.circle.fill",
                     isRequired: false
                 )
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Notes")
+                        .font(.subheadline)
+                        .foregroundColor(.gray)
+                    TextEditor(text: $notes)
+                        .frame(height: 80)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(Color.gray.opacity(0.3))
+                        )
+                }
             }
         }
         .padding(24)
@@ -586,6 +599,7 @@ struct AddInstrumentView: View {
         isin = ""
         valorNr = ""
         sector = ""
+        notes = ""
         if !instrumentGroups.isEmpty {
             selectedGroupId = instrumentGroups[0].id
         }
@@ -604,7 +618,7 @@ struct AddInstrumentView: View {
         isLoading = true
         
         let dbManager = DatabaseManager()
-        
+
         let success = dbManager.addInstrument(
             name: trimmedName,
             subClassId: selectedGroupId,
@@ -614,7 +628,8 @@ struct AddInstrumentView: View {
             isin: isin.isEmpty ? nil : isin.uppercased(),
             countryCode: nil,
             exchangeCode: nil,
-            sector: sector.isEmpty ? nil : sector
+            sector: sector.isEmpty ? nil : sector,
+            notes: notes.isEmpty ? nil : notes
         )
         
         DispatchQueue.main.async {

--- a/DragonShield/Views/InstrumentEditView.swift
+++ b/DragonShield/Views/InstrumentEditView.swift
@@ -11,6 +11,7 @@ struct InstrumentEditView: View {
     @State private var isin = ""
     @State private var valorNr = ""
     @State private var sector = ""
+    @State private var notes = ""
     @State private var instrumentGroups: [(id: Int, name: String)] = []
     @State private var availableCurrencies: [(code: String, name: String, symbol: String)] = []
     @State private var showingAlert = false
@@ -31,6 +32,7 @@ struct InstrumentEditView: View {
     @State private var originalIsin = ""
     @State private var originalValorNr = ""
     @State private var originalSector = ""
+    @State private var originalNotes = ""
 
     @State private var showNotes = false
     @State private var notesInitialTab: InstrumentNotesView.Tab = .updates
@@ -64,7 +66,8 @@ struct InstrumentEditView: View {
                     tickerSymbol != originalTickerSymbol ||
                     isin != originalIsin ||
                     valorNr != originalValorNr ||
-                    sector != originalSector
+                    sector != originalSector ||
+                    notes != originalNotes
     }
     
     // MARK: - Computed Properties
@@ -404,6 +407,19 @@ struct InstrumentEditView: View {
                     isRequired: false
                 )
                 .onChange(of: sector) { oldValue, newValue in detectChanges() }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Notes")
+                        .font(.subheadline)
+                        .foregroundColor(.gray)
+                    TextEditor(text: $notes)
+                        .frame(height: 80)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(Color.gray.opacity(0.3))
+                        )
+                        .onChange(of: notes) { _, _ in detectChanges() }
+                }
             }
         }
         .padding(24)
@@ -697,7 +713,8 @@ struct InstrumentEditView: View {
             tickerSymbol = details.tickerSymbol ?? ""
             isin = details.isin ?? ""
             sector = details.sector ?? ""
-            
+            notes = details.notes ?? ""
+
             // Store original values for change detection
             originalName = instrumentName
             originalGroupId = selectedGroupId
@@ -706,6 +723,7 @@ struct InstrumentEditView: View {
             originalTickerSymbol = tickerSymbol
             originalIsin = isin
             originalSector = sector
+            originalNotes = notes
         }
     }
     
@@ -748,7 +766,8 @@ struct InstrumentEditView: View {
             valorNr: valorNr.isEmpty ? nil : valorNr,
             tickerSymbol: tickerSymbol.isEmpty ? nil : tickerSymbol.uppercased(),
             isin: isin.isEmpty ? nil : isin.uppercased(),
-            sector: sector.isEmpty ? nil : sector
+            sector: sector.isEmpty ? nil : sector,
+            notes: notes.isEmpty ? nil : notes
         )
         
         DispatchQueue.main.async {
@@ -762,6 +781,7 @@ struct InstrumentEditView: View {
                 self.originalTickerSymbol = self.tickerSymbol
                 self.originalIsin = self.isin
                 self.originalSector = self.sector
+                self.originalNotes = self.notes
                 self.detectChanges()
                 
                 NotificationCenter.default.post(name: NSNotification.Name("RefreshPortfolio"), object: nil)

--- a/DragonShield/Views/PortfolioView.swift
+++ b/DragonShield/Views/PortfolioView.swift
@@ -380,6 +380,10 @@ struct PortfolioView: View {
             headerCell(title: "ISIN", column: .isin)
                 .frame(width: 140, alignment: .leading)
 
+            Image(systemName: "note.text")
+                .frame(width: 32, alignment: .center)
+                .help("Notes")
+
             if FeatureFlags.portfolioInstrumentUpdatesEnabled() {
                 Image(systemName: "note.text")
                     .frame(width: 32, alignment: .center)
@@ -683,6 +687,9 @@ struct ModernAssetRowView: View {
                 .lineLimit(1)
                 .frame(width: 140, alignment: .leading)
 
+            InstrumentNoteIconView(note: asset.note)
+                .frame(width: 32, alignment: .center)
+
             if FeatureFlags.portfolioInstrumentUpdatesEnabled() {
                 NotesIconView(instrumentId: asset.id, instrumentName: asset.name, instrumentCode: asset.tickerSymbol ?? "")
                     .frame(width: 32, alignment: .center)
@@ -727,6 +734,32 @@ struct ModernAssetRowView: View {
             }
         }
         .animation(.easeInOut(duration: 0.2), value: isSelected)
+    }
+}
+
+struct InstrumentNoteIconView: View {
+    let note: String?
+    @State private var showNote = false
+
+    var body: some View {
+        if let note = note, !note.isEmpty {
+            Button {
+                showNote = true
+            } label: {
+                Image(systemName: "note.text")
+                    .font(.system(size: 14))
+            }
+            .buttonStyle(PlainButtonStyle())
+            .accessibilityLabel("Show note")
+            .popover(isPresented: $showNote) {
+                ScrollView { Text(note).padding() }
+                    .frame(width: 200, height: 120)
+            }
+        } else {
+            Image(systemName: "note.text")
+                .font(.system(size: 14))
+                .opacity(0)
+        }
     }
 }
 

--- a/DragonShield/Views/PositionFormView.swift
+++ b/DragonShield/Views/PositionFormView.swift
@@ -7,7 +7,8 @@ typealias InstrumentInfo = (
     currency: String,
     valorNr: String?,
     tickerSymbol: String?,
-    isin: String?
+    isin: String?,
+    notes: String?
 )
 
 typealias AccountInfo = (

--- a/DragonShield/db/migrations/023_instrument_notes.sql
+++ b/DragonShield/db/migrations/023_instrument_notes.sql
@@ -1,0 +1,8 @@
+-- migrate:up
+-- Purpose: add notes column to Instruments for free-form annotations
+-- Assumptions: Instruments table exists and notes column absent
+-- Idempotency: SQLite <3.35 lacks ADD COLUMN IF NOT EXISTS; rely on schema versioning
+ALTER TABLE Instruments ADD COLUMN notes TEXT;
+
+-- migrate:down
+-- No-op: dropping column requires table recreation. Rollback via restore from backup.

--- a/DragonShieldTests/InstrumentNotesTests.swift
+++ b/DragonShieldTests/InstrumentNotesTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+import SQLite3
+@testable import DragonShield
+
+final class InstrumentNotesTests: XCTestCase {
+    private func setupDb() -> DatabaseManager {
+        let manager = DatabaseManager()
+        var db: OpaquePointer?
+        sqlite3_open(":memory:", &db)
+        manager.db = db
+        let sql = """
+            CREATE TABLE Instruments (
+                instrument_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                instrument_name TEXT,
+                sub_class_id INTEGER,
+                currency TEXT,
+                valor_nr TEXT,
+                ticker_symbol TEXT,
+                isin TEXT,
+                sector TEXT,
+                notes TEXT,
+                is_active BOOLEAN
+            );
+        """
+        sqlite3_exec(db, sql, nil, nil, nil)
+        return manager
+    }
+
+    func testAddAndFetchInstrumentNotes() {
+        let dbm = setupDb()
+        let added = dbm.addInstrument(name: "Test", subClassId: 1, currency: "USD", valorNr: nil, tickerSymbol: nil, isin: nil, countryCode: nil, exchangeCode: nil, sector: nil, notes: "hello")
+        XCTAssertTrue(added)
+        let details = dbm.fetchInstrumentDetails(id: 1)
+        XCTAssertEqual(details?.notes, "hello")
+        sqlite3_close(dbm.db)
+    }
+}


### PR DESCRIPTION
## Summary
- allow storing notes on instruments with database column
- surface instrument notes in portfolio overview with note icon
- enable editing instrument notes in add/edit dialogs
- fix migration to omit unsupported IF NOT EXISTS clause for compatibility

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `sqlite3 /tmp/test.db "PRAGMA table_info(Instruments);"`


------
https://chatgpt.com/codex/tasks/task_e_68ac23714ee883238b2be3d38edf02c3