### PR TITLE
feat: display institution notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 - Copy or export Value Report data from reports (#PR_NUMBER)
 - Add repository for strict unused instruments report (#PR_NUMBER)
 - Expose strict unused instruments report from Instruments view (#PR_NUMBER)
+- Show note icon for institutions with notes in overview table (#PR_NUMBER)
 
 ### Changed
 - Replace status alerts with SwiftUI windows (#PR_NUMBER)

--- a/DragonShield/Views/InstitutionsView.swift
+++ b/DragonShield/Views/InstitutionsView.swift
@@ -158,6 +158,7 @@ struct AddInstitutionView: View {
                         Text("\(flagEmoji(code)) \(code)").tag(code)
                     }
                 }
+                Text("Notes")
                 TextEditor(text: $notes)
                     .frame(height: 60)
                 Toggle("Active", isOn: $isActive)
@@ -246,6 +247,7 @@ struct EditInstitutionView: View {
                         Text("\(flagEmoji(code)) \(code)").tag(code)
                     }
                 }
+                Text("Notes")
                 TextEditor(text: $notes)
                     .frame(height: 60)
                 Toggle("Active", isOn: $isActive)
@@ -485,6 +487,10 @@ private extension InstitutionsView {
                 .font(.system(size: 14, weight: .semibold))
                 .foregroundColor(.gray)
                 .frame(width: 70, alignment: .leading)
+            Text("Note")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(.gray)
+                .frame(width: 40, alignment: .center)
             Text("Status")
                 .font(.system(size: 14, weight: .semibold))
                 .foregroundColor(.gray)
@@ -636,6 +642,8 @@ struct ModernInstitutionRowView: View {
     let onTap: () -> Void
     let onEdit: () -> Void
 
+    @State private var showNote = false
+
     var body: some View {
         HStack {
             Text(institution.name)
@@ -665,7 +673,21 @@ struct ModernInstitutionRowView: View {
             Text(institution.countryCode.map { "\(flagEmoji($0)) \($0)" } ?? "")
                 .font(.system(size: 13))
                 .frame(width: 70, alignment: .leading)
-
+            if let note = institution.notes, !note.isEmpty {
+                Button(action: { showNote = true }) {
+                    Image(systemName: "note.text")
+                        .foregroundColor(.blue)
+                }
+                .buttonStyle(PlainButtonStyle())
+                .frame(width: 40, alignment: .center)
+                .alert("Note", isPresented: $showNote) {
+                    Button("Close", role: .cancel) { }
+                } message: {
+                    Text(note)
+                }
+            } else {
+                Spacer().frame(width: 40)
+            }
             HStack(spacing: 4) {
                 Circle()
                     .fill(institution.isActive ? Color.green : Color.orange)

--- a/DragonShieldTests/InstitutionNotesTests.swift
+++ b/DragonShieldTests/InstitutionNotesTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+import SQLite3
+@testable import DragonShield
+
+final class InstitutionNotesTests: XCTestCase {
+    var db: OpaquePointer?
+
+    override func setUp() {
+        super.setUp()
+        sqlite3_open(":memory:", &db)
+    }
+
+    override func tearDown() {
+        sqlite3_close(db)
+        db = nil
+        super.tearDown()
+    }
+
+    func testNotesPersistence() {
+        let setup = """
+        CREATE TABLE Institutions(
+            institution_id INTEGER PRIMARY KEY,
+            institution_name TEXT NOT NULL,
+            notes TEXT
+        );
+        INSERT INTO Institutions(institution_name, notes) VALUES('BankOne', 'First note');
+        INSERT INTO Institutions(institution_name) VALUES('BankTwo');
+        """
+        sqlite3_exec(db, setup, nil, nil, nil)
+
+        var stmt: OpaquePointer?
+        sqlite3_prepare_v2(db, "SELECT notes FROM Institutions WHERE institution_name='BankOne';", -1, &stmt, nil)
+        sqlite3_step(stmt)
+        let note1 = String(cString: sqlite3_column_text(stmt, 0))
+        sqlite3_finalize(stmt)
+        XCTAssertEqual(note1, "First note")
+
+        sqlite3_prepare_v2(db, "SELECT notes FROM Institutions WHERE institution_name='BankTwo';", -1, &stmt, nil)
+        sqlite3_step(stmt)
+        XCTAssertNil(sqlite3_column_text(stmt, 0))
+        sqlite3_finalize(stmt)
+    }
+}


### PR DESCRIPTION
## Summary
- show note icon for institutions with notes in overview table
- label note fields in institution editor
- test database persistence of institution notes

## Testing
- `make setup` (fails: No rule to make target 'setup')
- `make fmt` (fails: No rule to make target 'fmt')
- `make lint` (fails: No rule to make target 'lint')
- `make migrate` (fails: No rule to make target 'migrate')
- `make build` (fails: No rule to make target 'build')
- `make test` (fails: No rule to make target 'test')
- `swift test` (fails: Could not find Package.swift)


------
https://chatgpt.com/codex/tasks/task_e_68ac2a94316c832387015b844464b6f7