### PR TITLE
feat: support instrument notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 - Copy or export Value Report data from reports (#PR_NUMBER)
 - Add repository for strict unused instruments report (#PR_NUMBER)
 - Expose strict unused instruments report from Instruments view (#PR_NUMBER)
+- Edit instrument notes and show note indicator in Instruments table (#PR_NUMBER)
 
 ### Changed
 - Replace status alerts with SwiftUI windows (#PR_NUMBER)

--- a/DragonShield/AssetManager.swift
+++ b/DragonShield/AssetManager.swift
@@ -8,6 +8,7 @@ struct DragonAsset: Identifiable {
     var valorNr: String?
     var tickerSymbol: String?
     var isin: String?
+    var notes: String?
 }
 
 class AssetManager: ObservableObject {
@@ -36,7 +37,8 @@ class AssetManager: ObservableObject {
                 currency: instrument.currency,
                 valorNr: instrument.valorNr,
                 tickerSymbol: instrument.tickerSymbol,
-                isin: instrument.isin
+                isin: instrument.isin,
+                notes: instrument.notes
             )
         }
         

--- a/DragonShield/DatabaseManager+Instruments.swift
+++ b/DragonShield/DatabaseManager+Instruments.swift
@@ -8,11 +8,11 @@ import Foundation
 
 extension DatabaseManager {
     
-    func fetchAssets() -> [(id: Int, name: String, subClassId: Int, currency: String, valorNr: String?, tickerSymbol: String?, isin: String?)] {
-        var instruments: [(id: Int, name: String, subClassId: Int, currency: String, valorNr: String?, tickerSymbol: String?, isin: String?)] = []
+    func fetchAssets() -> [(id: Int, name: String, subClassId: Int, currency: String, valorNr: String?, tickerSymbol: String?, isin: String?, notes: String?)] {
+        var instruments: [(id: Int, name: String, subClassId: Int, currency: String, valorNr: String?, tickerSymbol: String?, isin: String?, notes: String?)] = []
         
         let query = """
-            SELECT instrument_id, instrument_name, sub_class_id, currency, valor_nr, ticker_symbol, isin
+            SELECT instrument_id, instrument_name, sub_class_id, currency, valor_nr, ticker_symbol, isin, notes
             FROM Instruments
             WHERE is_active = 1 AND instrument_name IS NOT NULL AND instrument_name != ''
             ORDER BY instrument_name
@@ -55,7 +55,15 @@ extension DatabaseManager {
                     isin = nil
                 }
 
-                instruments.append((id: id, name: name, subClassId: subClassId, currency: currency, valorNr: valorNr, tickerSymbol: tickerSymbol, isin: isin))
+                let notes: String?
+                if let notesPtr = sqlite3_column_text(statement, 7) {
+                    let notesValue = String(cString: notesPtr)
+                    notes = notesValue.isEmpty ? nil : notesValue
+                } else {
+                    notes = nil
+                }
+
+                instruments.append((id: id, name: name, subClassId: subClassId, currency: currency, valorNr: valorNr, tickerSymbol: tickerSymbol, isin: isin, notes: notes))
             }
         } else {
             print("❌ Failed to prepare fetchAssets: \(String(cString: sqlite3_errmsg(db)))")
@@ -64,10 +72,10 @@ extension DatabaseManager {
         return instruments
     }
     
-    func addInstrument(name: String, subClassId: Int, currency: String, valorNr: String?, tickerSymbol: String?, isin: String?, countryCode: String?, exchangeCode: String?, sector: String?) -> Bool {
+    func addInstrument(name: String, subClassId: Int, currency: String, valorNr: String?, tickerSymbol: String?, isin: String?, countryCode: String?, exchangeCode: String?, sector: String?, notes: String?) -> Bool {
         let query = """
-            INSERT INTO Instruments (instrument_name, sub_class_id, currency, valor_nr, ticker_symbol, isin, sector, is_active)
-            VALUES (?, ?, ?, ?, ?, ?, ?, 1)
+            INSERT INTO Instruments (instrument_name, sub_class_id, currency, valor_nr, ticker_symbol, isin, sector, notes, is_active)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1)
         """
         
         var statement: OpaquePointer?
@@ -118,6 +126,14 @@ extension DatabaseManager {
         } else {
             sqlite3_bind_null(statement, 7)
         }
+
+        if let noteText = notes, !noteText.isEmpty {
+            _ = noteText.withCString { notePtr in
+                sqlite3_bind_text(statement, 8, notePtr, -1, SQLITE_TRANSIENT)
+            }
+        } else {
+            sqlite3_bind_null(statement, 8)
+        }
         
         let result = sqlite3_step(statement) == SQLITE_DONE
         sqlite3_finalize(statement)
@@ -134,10 +150,10 @@ extension DatabaseManager {
     }
 
     /// Inserts a new instrument and returns the generated row ID on success.
-    func addInstrumentReturningId(name: String, subClassId: Int, currency: String, valorNr: String?, tickerSymbol: String?, isin: String?, countryCode: String?, exchangeCode: String?, sector: String?) -> Int? {
+    func addInstrumentReturningId(name: String, subClassId: Int, currency: String, valorNr: String?, tickerSymbol: String?, isin: String?, countryCode: String?, exchangeCode: String?, sector: String?, notes: String?) -> Int? {
         let query = """
-            INSERT INTO Instruments (instrument_name, sub_class_id, currency, valor_nr, ticker_symbol, isin, sector, is_active)
-            VALUES (?, ?, ?, ?, ?, ?, ?, 1)
+            INSERT INTO Instruments (instrument_name, sub_class_id, currency, valor_nr, ticker_symbol, isin, sector, notes, is_active)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1)
         """
 
         var statement: OpaquePointer?
@@ -177,6 +193,12 @@ extension DatabaseManager {
             sqlite3_bind_null(statement, 7)
         }
 
+        if let noteText = notes, !noteText.isEmpty {
+            _ = noteText.withCString { sqlite3_bind_text(statement, 8, $0, -1, SQLITE_TRANSIENT) }
+        } else {
+            sqlite3_bind_null(statement, 8)
+        }
+
         let success = sqlite3_step(statement) == SQLITE_DONE
         let insertedId = success ? Int(sqlite3_last_insert_rowid(db)) : nil
         sqlite3_finalize(statement)
@@ -190,10 +212,10 @@ extension DatabaseManager {
         return insertedId
     }
     
-    func updateInstrument(id: Int, name: String, subClassId: Int, currency: String, valorNr: String?, tickerSymbol: String?, isin: String?, sector: String?) -> Bool {
+    func updateInstrument(id: Int, name: String, subClassId: Int, currency: String, valorNr: String?, tickerSymbol: String?, isin: String?, sector: String?, notes: String?) -> Bool {
         let query = """
             UPDATE Instruments
-            SET instrument_name = ?, sub_class_id = ?, currency = ?, valor_nr = ?, ticker_symbol = ?, isin = ?, sector = ?, updated_at = CURRENT_TIMESTAMP
+            SET instrument_name = ?, sub_class_id = ?, currency = ?, valor_nr = ?, ticker_symbol = ?, isin = ?, sector = ?, notes = ?, updated_at = CURRENT_TIMESTAMP
             WHERE instrument_id = ?
         """
         
@@ -234,7 +256,13 @@ extension DatabaseManager {
             sqlite3_bind_null(statement, 7)
         }
 
-        sqlite3_bind_int(statement, 8, Int32(id))
+        if let noteText = notes, !noteText.isEmpty {
+            _ = noteText.withCString { notePtr in sqlite3_bind_text(statement, 8, notePtr, -1, SQLITE_TRANSIENT) }
+        } else {
+            sqlite3_bind_null(statement, 8)
+        }
+
+        sqlite3_bind_int(statement, 9, Int32(id))
         
         let result = sqlite3_step(statement) == SQLITE_DONE
         sqlite3_finalize(statement)
@@ -269,9 +297,9 @@ extension DatabaseManager {
         return result
     }
     
-    func fetchInstrumentDetails(id: Int) -> (id: Int, name: String, subClassId: Int, currency: String, valorNr: String?, tickerSymbol: String?, isin: String?, countryCode: String?, exchangeCode: String?, sector: String?)? {
+    func fetchInstrumentDetails(id: Int) -> (id: Int, name: String, subClassId: Int, currency: String, valorNr: String?, tickerSymbol: String?, isin: String?, countryCode: String?, exchangeCode: String?, sector: String?, notes: String?)? {
         let query = """
-            SELECT instrument_id, instrument_name, sub_class_id, currency, valor_nr, ticker_symbol, isin, sector
+            SELECT instrument_id, instrument_name, sub_class_id, currency, valor_nr, ticker_symbol, isin, sector, notes
             FROM Instruments
             WHERE instrument_id = ?
         """
@@ -290,9 +318,10 @@ extension DatabaseManager {
                 let tickerSymbol: String? = sqlite3_column_text(statement, 5).map { String(cString: $0) }.flatMap { $0.isEmpty ? nil : $0 }
                 let isin: String? = sqlite3_column_text(statement, 6).map { String(cString: $0) }.flatMap { $0.isEmpty ? nil : $0 }
                 let sector: String? = sqlite3_column_text(statement, 7).map { String(cString: $0) }.flatMap { $0.isEmpty ? nil : $0 }
+                let notes: String? = sqlite3_column_text(statement, 8).map { String(cString: $0) }.flatMap { $0.isEmpty ? nil : $0 }
 
                 sqlite3_finalize(statement)
-                return (id: instrumentId, name: instrumentName, subClassId: subClassId, currency: currency, valorNr: valorNr, tickerSymbol: tickerSymbol, isin: isin, countryCode: nil, exchangeCode: nil, sector: sector)
+                return (id: instrumentId, name: instrumentName, subClassId: subClassId, currency: currency, valorNr: valorNr, tickerSymbol: tickerSymbol, isin: isin, countryCode: nil, exchangeCode: nil, sector: sector, notes: notes)
             } else {
                  print("ℹ️ No instrument details found for ID: \(id)")
             }

--- a/DragonShield/Views/AddInstrumentView.swift
+++ b/DragonShield/Views/AddInstrumentView.swift
@@ -10,6 +10,7 @@ struct AddInstrumentView: View {
     @State private var isin = ""
     @State private var valorNr = ""
     @State private var sector = ""
+    @State private var notes = ""
     @State private var instrumentGroups: [(id: Int, name: String)] = []
     @State private var showingAlert = false
     @State private var alertMessage = ""
@@ -327,6 +328,22 @@ struct AddInstrumentView: View {
                     icon: "briefcase.circle.fill",
                     isRequired: false
                 )
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Image(systemName: "note.text").foregroundColor(.gray)
+                        Text("Notes")
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundColor(.black.opacity(0.7))
+                    }
+                    TextEditor(text: $notes)
+                        .frame(minHeight: 80, maxHeight: 150)
+                        .font(.system(size: 16))
+                        .padding(12)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+                        )
+                }
             }
         }
         .padding(24)
@@ -586,6 +603,7 @@ struct AddInstrumentView: View {
         isin = ""
         valorNr = ""
         sector = ""
+        notes = ""
         if !instrumentGroups.isEmpty {
             selectedGroupId = instrumentGroups[0].id
         }
@@ -614,7 +632,8 @@ struct AddInstrumentView: View {
             isin: isin.isEmpty ? nil : isin.uppercased(),
             countryCode: nil,
             exchangeCode: nil,
-            sector: sector.isEmpty ? nil : sector
+            sector: sector.isEmpty ? nil : sector,
+            notes: notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : notes
         )
         
         DispatchQueue.main.async {

--- a/DragonShield/Views/InstrumentEditView.swift
+++ b/DragonShield/Views/InstrumentEditView.swift
@@ -11,6 +11,7 @@ struct InstrumentEditView: View {
     @State private var isin = ""
     @State private var valorNr = ""
     @State private var sector = ""
+    @State private var notes = ""
     @State private var instrumentGroups: [(id: Int, name: String)] = []
     @State private var availableCurrencies: [(code: String, name: String, symbol: String)] = []
     @State private var showingAlert = false
@@ -31,6 +32,7 @@ struct InstrumentEditView: View {
     @State private var originalIsin = ""
     @State private var originalValorNr = ""
     @State private var originalSector = ""
+    @State private var originalNotes = ""
 
     @State private var showNotes = false
     @State private var notesInitialTab: InstrumentNotesView.Tab = .updates
@@ -64,7 +66,8 @@ struct InstrumentEditView: View {
                     tickerSymbol != originalTickerSymbol ||
                     isin != originalIsin ||
                     valorNr != originalValorNr ||
-                    sector != originalSector
+                    sector != originalSector ||
+                    notes != originalNotes
     }
     
     // MARK: - Computed Properties
@@ -404,6 +407,24 @@ struct InstrumentEditView: View {
                     isRequired: false
                 )
                 .onChange(of: sector) { oldValue, newValue in detectChanges() }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Image(systemName: "note.text").foregroundColor(.gray)
+                        Text("Notes")
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundColor(.black.opacity(0.7))
+                    }
+                    TextEditor(text: $notes)
+                        .frame(minHeight: 80, maxHeight: 150)
+                        .font(.system(size: 16))
+                        .padding(12)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+                        )
+                }
+                .onChange(of: notes) { oldValue, newValue in detectChanges() }
             }
         }
         .padding(24)
@@ -697,7 +718,8 @@ struct InstrumentEditView: View {
             tickerSymbol = details.tickerSymbol ?? ""
             isin = details.isin ?? ""
             sector = details.sector ?? ""
-            
+            notes = details.notes ?? ""
+
             // Store original values for change detection
             originalName = instrumentName
             originalGroupId = selectedGroupId
@@ -706,6 +728,7 @@ struct InstrumentEditView: View {
             originalTickerSymbol = tickerSymbol
             originalIsin = isin
             originalSector = sector
+            originalNotes = notes
         }
     }
     
@@ -748,7 +771,8 @@ struct InstrumentEditView: View {
             valorNr: valorNr.isEmpty ? nil : valorNr,
             tickerSymbol: tickerSymbol.isEmpty ? nil : tickerSymbol.uppercased(),
             isin: isin.isEmpty ? nil : isin.uppercased(),
-            sector: sector.isEmpty ? nil : sector
+            sector: sector.isEmpty ? nil : sector,
+            notes: notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : notes
         )
         
         DispatchQueue.main.async {
@@ -762,6 +786,7 @@ struct InstrumentEditView: View {
                 self.originalTickerSymbol = self.tickerSymbol
                 self.originalIsin = self.isin
                 self.originalSector = self.sector
+                self.originalNotes = self.notes
                 self.detectChanges()
                 
                 NotificationCenter.default.post(name: NSNotification.Name("RefreshPortfolio"), object: nil)

--- a/DragonShield/Views/PortfolioView.swift
+++ b/DragonShield/Views/PortfolioView.swift
@@ -379,11 +379,14 @@ struct PortfolioView: View {
 
             headerCell(title: "ISIN", column: .isin)
                 .frame(width: 140, alignment: .leading)
+            Image(systemName: "info.circle")
+                .frame(width: 32, alignment: .center)
+                .help("Notes")
 
             if FeatureFlags.portfolioInstrumentUpdatesEnabled() {
                 Image(systemName: "note.text")
                     .frame(width: 32, alignment: .center)
-                    .help("Notes")
+                    .help("Updates")
             }
         }
         .padding(.horizontal, 16)
@@ -646,6 +649,8 @@ struct ModernAssetRowView: View {
     let onTap: () -> Void
     let onEdit: () -> Void
 
+    @State private var showNote = false
+
     var body: some View {
         HStack {
             Text(asset.name)
@@ -682,6 +687,27 @@ struct ModernAssetRowView: View {
                 .foregroundColor(.secondary)
                 .lineLimit(1)
                 .frame(width: 140, alignment: .leading)
+
+            if let note = asset.notes, !note.isEmpty {
+                Button {
+                    showNote = true
+                } label: {
+                    Image(systemName: "info.circle")
+                        .foregroundColor(.blue)
+                }
+                .buttonStyle(PlainButtonStyle())
+                .frame(width: 32, alignment: .center)
+                .accessibilityLabel("Show note for \(asset.name)")
+                .popover(isPresented: $showNote) {
+                    ScrollView {
+                        Text(note)
+                            .padding()
+                    }
+                    .frame(width: 250)
+                }
+            } else {
+                Color.clear.frame(width: 32)
+            }
 
             if FeatureFlags.portfolioInstrumentUpdatesEnabled() {
                 NotesIconView(instrumentId: asset.id, instrumentName: asset.name, instrumentCode: asset.tickerSymbol ?? "")

--- a/DragonShield/Views/PositionFormView.swift
+++ b/DragonShield/Views/PositionFormView.swift
@@ -7,7 +7,8 @@ typealias InstrumentInfo = (
     currency: String,
     valorNr: String?,
     tickerSymbol: String?,
-    isin: String?
+    isin: String?,
+    notes: String?
 )
 
 typealias AccountInfo = (

--- a/DragonShieldTests/InstrumentNotesTests.swift
+++ b/DragonShieldTests/InstrumentNotesTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+import SQLite3
+@testable import DragonShield
+
+final class InstrumentNotesTests: XCTestCase {
+    var manager: DatabaseManager!
+    var db: OpaquePointer?
+
+    override func setUp() {
+        super.setUp()
+        manager = DatabaseManager()
+        sqlite3_open(":memory:", &db)
+        manager.db = db
+        sqlite3_exec(db, "PRAGMA foreign_keys = ON;", nil, nil, nil)
+        sqlite3_exec(db, "CREATE TABLE AssetSubClasses(sub_class_id INTEGER PRIMARY KEY, sub_class_name TEXT);", nil, nil, nil)
+        sqlite3_exec(db, "INSERT INTO AssetSubClasses(sub_class_id, sub_class_name) VALUES(1,'Stock');", nil, nil, nil)
+        sqlite3_exec(db, "CREATE TABLE Instruments(\n            instrument_id INTEGER PRIMARY KEY AUTOINCREMENT,\n            instrument_name TEXT NOT NULL,\n            sub_class_id INTEGER NOT NULL,\n            currency TEXT NOT NULL,\n            valor_nr TEXT,\n            ticker_symbol TEXT,\n            isin TEXT,\n            sector TEXT,\n            notes TEXT,\n            is_active INTEGER DEFAULT 1\n        );", nil, nil, nil)
+    }
+
+    override func tearDown() {
+        sqlite3_close(db)
+        db = nil
+        manager = nil
+        super.tearDown()
+    }
+
+    func testInsertFetchAndUpdateNotes() {
+        let id = manager.addInstrumentReturningId(name: "Test", subClassId: 1, currency: "USD", valorNr: nil, tickerSymbol: nil, isin: nil, countryCode: nil, exchangeCode: nil, sector: nil, notes: "Initial")
+        XCTAssertNotNil(id)
+        var details = manager.fetchInstrumentDetails(id: id!)
+        XCTAssertEqual(details?.notes, "Initial")
+        let updated = manager.updateInstrument(id: id!, name: "Test", subClassId: 1, currency: "USD", valorNr: nil, tickerSymbol: nil, isin: nil, sector: nil, notes: "Changed")
+        XCTAssertTrue(updated)
+        details = manager.fetchInstrumentDetails(id: id!)
+        XCTAssertEqual(details?.notes, "Changed")
+    }
+}

--- a/DragonShieldTests/PositionFormCurrencyTests.swift
+++ b/DragonShieldTests/PositionFormCurrencyTests.swift
@@ -4,8 +4,8 @@ import XCTest
 final class PositionFormCurrencyTests: XCTestCase {
     func testInstrumentCurrencyLookup() {
         let instruments: [InstrumentInfo] = [
-            (id: 1, name: "A", subClassId: 1, currency: "USD", valorNr: nil, tickerSymbol: nil, isin: nil),
-            (id: 2, name: "B", subClassId: 1, currency: "CHF", valorNr: nil, tickerSymbol: nil, isin: nil)
+            (id: 1, name: "A", subClassId: 1, currency: "USD", valorNr: nil, tickerSymbol: nil, isin: nil, notes: nil),
+            (id: 2, name: "B", subClassId: 1, currency: "CHF", valorNr: nil, tickerSymbol: nil, isin: nil, notes: nil)
         ]
         XCTAssertEqual(instrumentCurrency(for: 2, instruments: instruments), "CHF")
         XCTAssertNil(instrumentCurrency(for: nil, instruments: instruments))


### PR DESCRIPTION
## Summary
- allow entering notes for instruments and persist to database
- display note indicator in instruments table with popover
- cover instrument note persistence with tests

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild test -scheme DragonShield -destination 'platform=macOS'` *(fails: command not found)*
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2aafde1483238a5a26e1938dab26