### PR TITLE
feat: allow resizing institution columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 - Tighten composition table spacing in Portfolio Theme Detail view (#PR_NUMBER)
 - Slim valuation table research and user columns in Portfolio Theme Detail view (#PR_NUMBER)
 - Enlarge Portfolio Theme Detail window to fit valuation columns (#PR_NUMBER)
+- Allow resizing and persistence of Institutions column widths (#PR_NUMBER)
 
 ### Fixed
 

--- a/DragonShield/Views/InstitutionsView.swift
+++ b/DragonShield/Views/InstitutionsView.swift
@@ -16,6 +16,13 @@ import SwiftUI
 struct InstitutionsView: View {
     @EnvironmentObject var dbManager: DatabaseManager
 
+    @AppStorage(UserDefaultsKeys.institutionsNameColWidth) var nameColWidth: Double = 200
+    @AppStorage(UserDefaultsKeys.institutionsBicColWidth) var bicColWidth: Double = 100
+    @AppStorage(UserDefaultsKeys.institutionsTypeColWidth) var typeColWidth: Double = 120
+    @AppStorage(UserDefaultsKeys.institutionsCurColWidth) var curColWidth: Double = 50
+    @AppStorage(UserDefaultsKeys.institutionsCountryColWidth) var countryColWidth: Double = 70
+    @AppStorage(UserDefaultsKeys.institutionsStatusColWidth) var statusColWidth: Double = 80
+
     @State private var institutions: [DatabaseManager.InstitutionData] = []
     @State private var selectedInstitution: DatabaseManager.InstitutionData? = nil
     @State private var searchText = ""
@@ -444,6 +451,12 @@ private extension InstitutionsView {
                             institution: inst,
                             isSelected: selectedInstitution?.id == inst.id,
                             rowPadding: CGFloat(dbManager.tableRowPadding),
+                            nameWidth: CGFloat(nameColWidth),
+                            bicWidth: CGFloat(bicColWidth),
+                            typeWidth: CGFloat(typeColWidth),
+                            curWidth: CGFloat(curColWidth),
+                            countryWidth: CGFloat(countryColWidth),
+                            statusWidth: CGFloat(statusColWidth),
                             onTap: { selectedInstitution = inst },
                             onEdit: { selectedInstitution = inst; showEditSheet = true }
                         )
@@ -464,31 +477,36 @@ private extension InstitutionsView {
     }
 
     var modernTableHeader: some View {
-        HStack {
+        HStack(spacing: 0) {
             Text("Name")
                 .font(.system(size: 14, weight: .semibold))
                 .foregroundColor(.gray)
-                .frame(maxWidth: .infinity, alignment: .leading)
+                .frame(width: CGFloat(nameColWidth), alignment: .leading)
+                .overlay(ResizableDivider(width: $nameColWidth), alignment: .trailing)
             Text("BIC")
                 .font(.system(size: 14, weight: .semibold))
                 .foregroundColor(.gray)
-                .frame(width: 100, alignment: .leading)
+                .frame(width: CGFloat(bicColWidth), alignment: .leading)
+                .overlay(ResizableDivider(width: $bicColWidth), alignment: .trailing)
             Text("Type")
                 .font(.system(size: 14, weight: .semibold))
                 .foregroundColor(.gray)
-                .frame(width: 120, alignment: .leading)
+                .frame(width: CGFloat(typeColWidth), alignment: .leading)
+                .overlay(ResizableDivider(width: $typeColWidth), alignment: .trailing)
             Text("Cur")
                 .font(.system(size: 14, weight: .semibold))
                 .foregroundColor(.gray)
-                .frame(width: 50, alignment: .leading)
+                .frame(width: CGFloat(curColWidth), alignment: .leading)
+                .overlay(ResizableDivider(width: $curColWidth), alignment: .trailing)
             Text("Country")
                 .font(.system(size: 14, weight: .semibold))
                 .foregroundColor(.gray)
-                .frame(width: 70, alignment: .leading)
+                .frame(width: CGFloat(countryColWidth), alignment: .leading)
+                .overlay(ResizableDivider(width: $countryColWidth), alignment: .trailing)
             Text("Status")
                 .font(.system(size: 14, weight: .semibold))
                 .foregroundColor(.gray)
-                .frame(width: 80, alignment: .center)
+                .frame(width: CGFloat(statusColWidth), alignment: .center)
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
@@ -633,15 +651,21 @@ struct ModernInstitutionRowView: View {
     let institution: DatabaseManager.InstitutionData
     let isSelected: Bool
     let rowPadding: CGFloat
+    let nameWidth: CGFloat
+    let bicWidth: CGFloat
+    let typeWidth: CGFloat
+    let curWidth: CGFloat
+    let countryWidth: CGFloat
+    let statusWidth: CGFloat
     let onTap: () -> Void
     let onEdit: () -> Void
 
     var body: some View {
-        HStack {
+        HStack(spacing: 0) {
             Text(institution.name)
                 .font(.system(size: 15, weight: .medium))
                 .foregroundColor(.primary)
-                .frame(maxWidth: .infinity, alignment: .leading)
+                .frame(width: nameWidth, alignment: .leading)
 
             Text(institution.bic ?? "")
                 .font(.system(size: 13, design: .monospaced))
@@ -650,21 +674,21 @@ struct ModernInstitutionRowView: View {
                 .padding(.vertical, 2)
                 .background(Color.gray.opacity(0.1))
                 .clipShape(RoundedRectangle(cornerRadius: 4))
-                .frame(width: 100, alignment: .leading)
+                .frame(width: bicWidth, alignment: .leading)
 
             Text(institution.type ?? "")
                 .font(.system(size: 14))
                 .foregroundColor(.secondary)
-                .frame(width: 120, alignment: .leading)
+                .frame(width: typeWidth, alignment: .leading)
 
             Text(institution.defaultCurrency ?? "")
                 .font(.system(size: 13, design: .monospaced))
                 .foregroundColor(.secondary)
-                .frame(width: 50, alignment: .leading)
+                .frame(width: curWidth, alignment: .leading)
 
             Text(institution.countryCode.map { "\(flagEmoji($0)) \($0)" } ?? "")
                 .font(.system(size: 13))
-                .frame(width: 70, alignment: .leading)
+                .frame(width: countryWidth, alignment: .leading)
 
             HStack(spacing: 4) {
                 Circle()
@@ -674,7 +698,7 @@ struct ModernInstitutionRowView: View {
                     .font(.system(size: 12, weight: .medium))
                     .foregroundColor(institution.isActive ? .green : .orange)
             }
-            .frame(width: 80, alignment: .center)
+            .frame(width: statusWidth, alignment: .center)
         }
         .padding(.horizontal, 16)
         .padding(.vertical, rowPadding)
@@ -705,6 +729,36 @@ struct ModernInstitutionRowView: View {
             }
         }
         .animation(.easeInOut(duration: 0.2), value: isSelected)
+    }
+}
+
+struct ResizableDivider: View {
+    @Binding var width: Double
+    private let minWidth: Double = 40
+    private let maxWidth: Double = 600
+    @State private var startWidth: Double = 0
+
+    var body: some View {
+        Rectangle()
+            .fill(Color.gray.opacity(0.3))
+            .frame(width: 2)
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        if startWidth == 0 { startWidth = width }
+                        let proposed = startWidth + Double(value.translation.width)
+                        width = min(max(proposed, minWidth), maxWidth)
+                    }
+                    .onEnded { _ in startWidth = 0 }
+            )
+            .onHover { hovering in
+                if hovering {
+                    NSCursor.resizeLeftRight.push()
+                } else {
+                    NSCursor.pop()
+                }
+            }
     }
 }
 

--- a/DragonShield/helpers/UserDefaultsKeys.swift
+++ b/DragonShield/helpers/UserDefaultsKeys.swift
@@ -27,4 +27,11 @@ struct UserDefaultsKeys {
     static let portfolioAttachmentsEnabled = "portfolioAttachmentsEnabled"
     /// Persist window frame for import value report.
     static let importReportWindowFrame = "importReport.windowFrame"
+    /// Persist column widths in Institutions maintenance view.
+    static let institutionsNameColWidth = "institutionsNameColWidth"
+    static let institutionsBicColWidth = "institutionsBicColWidth"
+    static let institutionsTypeColWidth = "institutionsTypeColWidth"
+    static let institutionsCurColWidth = "institutionsCurColWidth"
+    static let institutionsCountryColWidth = "institutionsCountryColWidth"
+    static let institutionsStatusColWidth = "institutionsStatusColWidth"
 }

--- a/DragonShieldTests/InstitutionsColumnWidthTests.swift
+++ b/DragonShieldTests/InstitutionsColumnWidthTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import DragonShield
+
+final class InstitutionsColumnWidthTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: UserDefaultsKeys.institutionsNameColWidth)
+        defaults.removeObject(forKey: UserDefaultsKeys.institutionsBicColWidth)
+        defaults.removeObject(forKey: UserDefaultsKeys.institutionsTypeColWidth)
+        defaults.removeObject(forKey: UserDefaultsKeys.institutionsCurColWidth)
+        defaults.removeObject(forKey: UserDefaultsKeys.institutionsCountryColWidth)
+        defaults.removeObject(forKey: UserDefaultsKeys.institutionsStatusColWidth)
+    }
+
+    func testWidthsRestoredFromDefaults() {
+        let defaults = UserDefaults.standard
+        defaults.set(310.0, forKey: UserDefaultsKeys.institutionsNameColWidth)
+        defaults.set(111.0, forKey: UserDefaultsKeys.institutionsBicColWidth)
+        defaults.set(133.0, forKey: UserDefaultsKeys.institutionsTypeColWidth)
+        defaults.set(44.0, forKey: UserDefaultsKeys.institutionsCurColWidth)
+        defaults.set(88.0, forKey: UserDefaultsKeys.institutionsCountryColWidth)
+        defaults.set(99.0, forKey: UserDefaultsKeys.institutionsStatusColWidth)
+
+        let view = InstitutionsView()
+        let mirror = Mirror(reflecting: view)
+
+        XCTAssertEqual(mirror.descendant("nameColWidth") as? Double, 310.0)
+        XCTAssertEqual(mirror.descendant("bicColWidth") as? Double, 111.0)
+        XCTAssertEqual(mirror.descendant("typeColWidth") as? Double, 133.0)
+        XCTAssertEqual(mirror.descendant("curColWidth") as? Double, 44.0)
+        XCTAssertEqual(mirror.descendant("countryColWidth") as? Double, 88.0)
+        XCTAssertEqual(mirror.descendant("statusColWidth") as? Double, 99.0)
+    }
+}


### PR DESCRIPTION
## Summary
- persist institution column widths in UserDefaults
- enable resizing of institution table headers
- cover column width persistence with unit test

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_68ac3e3540748323aaec36f910c0593d