### PR TITLE
feat(db): add instrument user notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 
 
 ### Added
+- Allow storing user notes for instruments (#PR_NUMBER)
 - Restructure changelog and archive history (#PR_NUMBER)
 - Introduce bank-specific import cards with filename hints and instructions (#PR_NUMBER)
 - Allow sorting Composition table by Instrument, Research %, and User % (#PR_NUMBER)

--- a/DragonShield/db/migrations/023_instrument_user_notes.sql
+++ b/DragonShield/db/migrations/023_instrument_user_notes.sql
@@ -1,0 +1,8 @@
+-- migrate:up
+-- Purpose: allow storing optional user-specific notes for each instrument
+-- Assumptions: Instruments table exists and lacks user_note column
+-- Idempotency: SQLite does not support IF NOT EXISTS for ADD COLUMN; ensure column is absent before migration
+ALTER TABLE Instruments ADD COLUMN user_note TEXT DEFAULT NULL;
+
+-- migrate:down
+ALTER TABLE Instruments DROP COLUMN user_note;

--- a/DragonShield/db/post_migration_verification.sql
+++ b/DragonShield/db/post_migration_verification.sql
@@ -1,0 +1,5 @@
+-- Verify Instruments has user_note column
+SELECT name FROM pragma_table_info('Instruments') WHERE name='user_note';
+
+-- Ensure existing rows have NULL user_note
+SELECT COUNT(*) AS user_note_non_null FROM Instruments WHERE user_note IS NOT NULL;

--- a/DragonShield/db/schema.sql
+++ b/DragonShield/db/schema.sql
@@ -78,6 +78,7 @@ CREATE TABLE Instruments (
     include_in_portfolio BOOLEAN DEFAULT 1,
     is_active BOOLEAN DEFAULT 1,
     notes TEXT,
+    user_note TEXT,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP, isin_original TEXT, valor_original TEXT, validation_status TEXT DEFAULT 'valid'
     CHECK(validation_status IN ('valid', 'invalid', 'pending_validation')), restore_source TEXT DEFAULT 'original', restore_timestamp DATETIME, is_deleted BOOLEAN DEFAULT 0, deleted_at DATETIME, deleted_reason TEXT,
@@ -1272,4 +1273,19 @@ INSERT INTO "schema_migrations" (version) VALUES
   ('005'),
   ('006'),
   ('007'),
-  ('008');
+  ('008'),
+  ('009'),
+  ('010'),
+  ('011'),
+  ('012'),
+  ('013'),
+  ('014'),
+  ('015'),
+  ('016'),
+  ('017'),
+  ('018'),
+  ('019'),
+  ('020'),
+  ('021'),
+  ('022'),
+  ('023');


### PR DESCRIPTION
## Summary
- add user_note column to Instruments for optional user-specific notes
- update schema dump and verification queries

## Testing
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `sqlite3 "$DBFILE" < DragonShield/db/post_migration_verification.sql`


------
https://chatgpt.com/codex/tasks/task_e_68ac41e696648323b6ea7f54af97f682