### PR TITLE
Add instrument notes feature flag and toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 - Add repository for strict unused instruments report (#PR_NUMBER)
 - Expose strict unused instruments report from Instruments view (#PR_NUMBER)
 - Show note icon for institutions with notes in overview table (#PR_NUMBER)
+- Add instrument notes feature flag with runtime toggle (#PR_NUMBER)
 
 ### Changed
 - Replace status alerts with SwiftUI windows (#PR_NUMBER)

--- a/DragonShield/FeatureFlags.swift
+++ b/DragonShield/FeatureFlags.swift
@@ -36,5 +36,23 @@ enum FeatureFlags {
         return false
     }
 
+    static func instrumentNotesEnabled(
+        args: [String] = CommandLine.arguments,
+        env: [String: String] = ProcessInfo.processInfo.environment,
+        defaults: UserDefaults = .standard
+    ) -> Bool {
+        if let idx = args.firstIndex(of: "--instrumentNotesEnabled"),
+           let value = args.dropFirst(idx + 1).first {
+            return value.lowercased() != "false"
+        }
+        if let value = env["INSTRUMENT_NOTES_ENABLED"] {
+            return value.lowercased() != "false"
+        }
+        if defaults.object(forKey: UserDefaultsKeys.instrumentNotesEnabled) != nil {
+            return defaults.bool(forKey: UserDefaultsKeys.instrumentNotesEnabled)
+        }
+        return false
+    }
+
 }
 

--- a/DragonShield/Views/InstrumentEditView.swift
+++ b/DragonShield/Views/InstrumentEditView.swift
@@ -417,26 +417,29 @@ struct InstrumentEditView: View {
     }
 
     private var updatesInThemesSection: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            HStack {
-                sectionHeader(title: "Updates in Themes", icon: "doc.text", color: .blue)
-                Spacer()
-                Button("Open Instrument Notes") { openInstrumentNotes() }
-                    .buttonStyle(.borderedProminent)
-                    .accessibilityLabel("Open Instrument Notes for \(instrumentName)")
+        if FeatureFlags.instrumentNotesEnabled() {
+            VStack(alignment: .leading, spacing: 16) {
+                HStack {
+                    sectionHeader(title: "Updates in Themes", icon: "doc.text", color: .blue)
+                    Spacer()
+                    Button("Open Instrument Notes") { openInstrumentNotes() }
+                        .buttonStyle(.borderedProminent)
+                        .accessibilityLabel("Open Instrument Notes for \(instrumentName)")
+                }
             }
+            .padding(24)
+            .background(editGlassMorphismBackground)
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+            .overlay(
+                RoundedRectangle(cornerRadius: 16)
+                    .stroke(Color.blue.opacity(0.2), lineWidth: 1)
+            )
+            .shadow(color: .blue.opacity(0.1), radius: 10, x: 0, y: 5)
         }
-        .padding(24)
-        .background(editGlassMorphismBackground)
-        .clipShape(RoundedRectangle(cornerRadius: 16))
-        .overlay(
-            RoundedRectangle(cornerRadius: 16)
-                .stroke(Color.blue.opacity(0.2), lineWidth: 1)
-        )
-        .shadow(color: .blue.opacity(0.1), radius: 10, x: 0, y: 5)
     }
     
     private func openInstrumentNotes() {
+        guard FeatureFlags.instrumentNotesEnabled() else { return }
         let last = UserDefaults.standard.string(forKey: "instrumentNotesLastTab")
         notesInitialTab = last == "mentions" ? .mentions : .updates
         showNotes = true

--- a/DragonShield/Views/PortfolioView.swift
+++ b/DragonShield/Views/PortfolioView.swift
@@ -683,7 +683,7 @@ struct ModernAssetRowView: View {
                 .lineLimit(1)
                 .frame(width: 140, alignment: .leading)
 
-            if FeatureFlags.portfolioInstrumentUpdatesEnabled() {
+            if FeatureFlags.portfolioInstrumentUpdatesEnabled() && FeatureFlags.instrumentNotesEnabled() {
                 NotesIconView(instrumentId: asset.id, instrumentName: asset.name, instrumentCode: asset.tickerSymbol ?? "")
                     .frame(width: 32, alignment: .center)
             }

--- a/DragonShield/Views/SettingsView.swift
+++ b/DragonShield/Views/SettingsView.swift
@@ -24,6 +24,8 @@ struct SettingsView: View {
 
     @AppStorage(UserDefaultsKeys.portfolioAttachmentsEnabled)
     private var portfolioAttachmentsEnabled: Bool = false
+    @AppStorage(UserDefaultsKeys.instrumentNotesEnabled)
+    private var instrumentNotesEnabled: Bool = false
 
 
     private var okCount: Int {
@@ -125,8 +127,12 @@ struct SettingsView: View {
                 NavigationLink("Detailed Report", destination: HealthCheckResultsView())
             }
 
-            Section(header: Text("Portfolio Management")) {
+            Section(header: Text("Feature Flags")) {
                 Toggle("Enable Attachments for Theme Updates", isOn: $portfolioAttachmentsEnabled)
+                Toggle("Enable Instrument Notes", isOn: $instrumentNotesEnabled)
+            }
+
+            Section(header: Text("Portfolio Management")) {
                 NavigationLink("Theme Statuses", destination: ThemeStatusSettingsView().environmentObject(dbManager))
             }
 

--- a/DragonShield/helpers/UserDefaultsKeys.swift
+++ b/DragonShield/helpers/UserDefaultsKeys.swift
@@ -25,6 +25,8 @@ struct UserDefaultsKeys {
     static let portfolioThemeDetailLastTab = "portfolioThemeDetailLastTab"
     /// Feature flag: enable attachments on theme updates.
     static let portfolioAttachmentsEnabled = "portfolioAttachmentsEnabled"
+    /// Feature flag: enable instrument notes.
+    static let instrumentNotesEnabled = "instrumentNotesEnabled"
     /// Persist window frame for import value report.
     static let importReportWindowFrame = "importReport.windowFrame"
 }

--- a/DragonShieldTests/FeatureFlagsTests.swift
+++ b/DragonShieldTests/FeatureFlagsTests.swift
@@ -16,4 +16,14 @@ final class FeatureFlagsTests: XCTestCase {
         XCTAssertTrue(FeatureFlags.portfolioAttachmentsEnabled(args: [], env: [:], defaults: defaults))
     }
 
+    func testInstrumentNotesDisabledByDefault() {
+        XCTAssertFalse(FeatureFlags.instrumentNotesEnabled(args: [], env: [:], defaults: .standard))
+    }
+
+    func testInstrumentNotesEnabledWhenDefaultsTrue() {
+        let defaults = UserDefaults(suiteName: "testInstrumentNotesEnabled")!
+        defaults.set(true, forKey: UserDefaultsKeys.instrumentNotesEnabled)
+        XCTAssertTrue(FeatureFlags.instrumentNotesEnabled(args: [], env: [:], defaults: defaults))
+    }
+
 }


### PR DESCRIPTION
## Summary
- add instrumentNotesEnabled flag with default off
- expose instrumentNotes toggle in settings
- gate instrument notes UI behind flag

## Testing
- `make setup` (fails: No rule to make target 'setup')
- `make fmt` (fails: No rule to make target 'fmt')
- `make lint` (fails: No rule to make target 'lint')
- `make migrate` (fails: No rule to make target 'migrate')
- `make build` (fails: No rule to make target 'build')
- `make test` (fails: No rule to make target 'test')
- `swift test` (fails: Could not find Package.swift)
- `xcodebuild -version` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68ac443c54d883238447bbd451a70988