### PR TITLE
feat: add unused instruments dashboard tile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 
 
 ### Added
+- Add dashboard tile for strict unused instruments (#PR_NUMBER)
 - Restructure changelog and archive history (#PR_NUMBER)
 - Introduce bank-specific import cards with filename hints and instructions (#PR_NUMBER)
 - Allow sorting Composition table by Instrument, Research %, and User % (#PR_NUMBER)

--- a/DragonShield/Views/DashboardTiles/DashboardTiles.swift
+++ b/DragonShield/Views/DashboardTiles/DashboardTiles.swift
@@ -280,6 +280,7 @@ enum TileRegistry {
         TileInfo(id: TopPositionsTile.tileID, name: TopPositionsTile.tileName, icon: TopPositionsTile.iconName) { AnyView(TopPositionsTile()) },
         TileInfo(id: CryptoTop5Tile.tileID, name: CryptoTop5Tile.tileName, icon: CryptoTop5Tile.iconName) { AnyView(CryptoTop5Tile()) },
         TileInfo(id: InstitutionsAUMTile.tileID, name: InstitutionsAUMTile.tileName, icon: InstitutionsAUMTile.iconName) { AnyView(InstitutionsAUMTile()) },
+        TileInfo(id: UnusedInstrumentsTile.tileID, name: UnusedInstrumentsTile.tileName, icon: UnusedInstrumentsTile.iconName) { AnyView(UnusedInstrumentsTile()) },
 
         TileInfo(id: CurrencyExposureTile.tileID, name: CurrencyExposureTile.tileName, icon: CurrencyExposureTile.iconName) { AnyView(CurrencyExposureTile()) },
         TileInfo(id: RiskBucketsTile.tileID, name: RiskBucketsTile.tileName, icon: RiskBucketsTile.iconName) { AnyView(RiskBucketsTile()) },

--- a/DragonShield/Views/DashboardTiles/UnusedInstrumentsTile.swift
+++ b/DragonShield/Views/DashboardTiles/UnusedInstrumentsTile.swift
@@ -1,0 +1,121 @@
+import SwiftUI
+
+final class UnusedInstrumentsTileViewModel: ObservableObject {
+    @Published var items: [UnusedInstrument] = []
+    @Published var totalCount: Int? = nil
+    @Published var errorMessage: String? = nil
+    private static let limit = 500
+
+    func load(db: DatabaseManager) {
+        DispatchQueue.global().async {
+            let repo = InstrumentUsageRepository(dbManager: db)
+            do {
+                let all = try repo.unusedStrict()
+                DispatchQueue.main.async {
+                    self.process(all: all)
+                    self.errorMessage = nil
+                }
+            } catch InstrumentUsageRepositoryError.noSnapshot {
+                DispatchQueue.main.async {
+                    self.items = []
+                    self.totalCount = nil
+                    self.errorMessage = "No snapshot available"
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    self.items = []
+                    self.totalCount = nil
+                    self.errorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    func process(all: [UnusedInstrument]) {
+        let limited = Self.sortedLimited(all)
+        self.items = limited
+        self.totalCount = all.count
+    }
+
+    static func sortedLimited(_ list: [UnusedInstrument]) -> [UnusedInstrument] {
+        let sorted = list.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        return Array(sorted.prefix(limit))
+    }
+
+    var hasMore: Bool {
+        if let count = totalCount {
+            return count > Self.limit
+        }
+        return false
+    }
+}
+
+struct UnusedInstrumentsTile: DashboardTile {
+    init() {}
+    static let tileID = "unusedInstruments"
+    static let tileName = "Unused Instruments"
+    static let iconName = "tray"
+
+    @EnvironmentObject var dbManager: DatabaseManager
+    @StateObject private var viewModel = UnusedInstrumentsTileViewModel()
+    @State private var showReport = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text(Self.tileName)
+                    .font(.system(size: 17, weight: .semibold))
+                Spacer()
+                Text(viewModel.totalCount.map(String.init) ?? "—")
+                    .font(.system(size: 24, weight: .bold))
+                    .foregroundColor(Theme.primaryAccent)
+            }
+            .contentShape(Rectangle())
+            .onTapGesture { showReport = true }
+
+            if let message = viewModel.errorMessage {
+                Text(message)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            } else if viewModel.totalCount == 0 {
+                Text("No unused instruments 🎉")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: DashboardTileLayout.rowSpacing) {
+                        ForEach(viewModel.items) { item in
+                            Text(item.name)
+                                .lineLimit(1)
+                                .truncationMode(.tail)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .frame(height: DashboardTileLayout.rowHeight, alignment: .leading)
+                                .help(item.name)
+                        }
+                        if viewModel.hasMore {
+                            Text("+ more…")
+                                .foregroundColor(.secondary)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .frame(height: DashboardTileLayout.rowHeight, alignment: .leading)
+                        }
+                    }
+                    .padding(.vertical, DashboardTileLayout.rowSpacing)
+                }
+                .frame(maxHeight: viewModel.items.count > 12 ? 220 : .infinity)
+                .scrollIndicators(.visible)
+                .textSelection(.disabled)
+            }
+        }
+        .padding(DashboardTileLayout.tilePadding)
+        .background(Color.white)
+        .cornerRadius(12)
+        .shadow(color: .black.opacity(0.1), radius: 3, x: 0, y: 2)
+        .onAppear { viewModel.load(db: dbManager) }
+        .sheet(isPresented: $showReport) {
+            UnusedInstrumentsReportView {
+                showReport = false
+            }
+        }
+    }
+}
+

--- a/DragonShieldTests/UnusedInstrumentsTileViewModelTests.swift
+++ b/DragonShieldTests/UnusedInstrumentsTileViewModelTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import DragonShield
+
+final class UnusedInstrumentsTileViewModelTests: XCTestCase {
+    func testSortsAndLimitsResults() {
+        var sample: [UnusedInstrument] = []
+        for i in 0..<600 {
+            let name = i % 2 == 0 ? "b\(i)" : "A\(i)"
+            sample.append(UnusedInstrument(instrumentId: i, name: name, type: "", currency: "", lastActivity: nil, themesCount: 0, refsCount: 0))
+        }
+        let vm = UnusedInstrumentsTileViewModel()
+        vm.process(all: sample)
+        XCTAssertEqual(vm.items.count, 500)
+        XCTAssertTrue(vm.hasMore)
+        let names = vm.items.map { $0.name }
+        XCTAssertEqual(names, names.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending })
+    }
+}
+


### PR DESCRIPTION
## Summary
- add dashboard tile listing strict-unused instruments with count and scrollable list
- register tile in dashboard registry and document changelog
- test view model sorting and limit logic

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7330f5c883239a544ee447194b50