### PR TITLE
Persist column widths in unused instruments report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 - Add repository for strict unused instruments report (#PR_NUMBER)
 - Expose strict unused instruments report from Instruments view (#PR_NUMBER)
 - Show note icon for institutions with notes in overview table (#PR_NUMBER)
+- Preserve column widths in Unused Instruments report between sessions (#PR_NUMBER)
 
 ### Changed
 - Replace status alerts with SwiftUI windows (#PR_NUMBER)

--- a/DragonShieldTests/UnusedInstrumentsReportViewTests.swift
+++ b/DragonShieldTests/UnusedInstrumentsReportViewTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import DragonShield
+import AppKit
 
 final class UnusedInstrumentsReportViewTests: XCTestCase {
     func testExportStringIncludesHeadersAndRows() {
@@ -11,5 +12,22 @@ final class UnusedInstrumentsReportViewTests: XCTestCase {
         XCTAssertTrue(csv.contains("Instrument,Type,Currency,Last Activity,Themes,Refs"))
         XCTAssertTrue(csv.contains("A,Stock,USD,—,0,0"))
         XCTAssertTrue(csv.contains("B,Bond,CHF,2024-11-03,1,0"))
+    }
+
+    func testColumnResizeUpdatesStoredWidth() {
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: "unusedInstrumentInstrumentWidth")
+        var view = PersistentUnusedInstrumentsTable(items: [], sortOrder: .constant([]))
+        let coordinator = view.makeCoordinator()
+        let tableView = NSTableView()
+        coordinator.tableView = tableView
+        let column = NSTableColumn(identifier: NSTableColumn.Identifier("Instrument"))
+        column.width = 222
+        let exp = expectation(description: "width updated")
+        coordinator.columnDidResize(Notification(name: NSTableView.columnDidResizeNotification, object: tableView, userInfo: ["NSTableViewColumn": column]))
+        DispatchQueue.main.async { exp.fulfill() }
+        wait(for: [exp], timeout: 1)
+        XCTAssertEqual(defaults.double(forKey: "unusedInstrumentInstrumentWidth"), 222)
+        defaults.removeObject(forKey: "unusedInstrumentInstrumentWidth")
     }
 }


### PR DESCRIPTION
## Summary
- remember each unused instrument report column width via AppStorage
- apply stored widths on table creation and update on resize
- test width persistence in UnusedInstrumentsReportView

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ac72bb05148323a30987ace2292478