### PR TITLE
Remove debug database overwrite setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 - Remove redundant Portfolio Theme Overview tab and associated view (#PR_NUMBER)
 - Remove default timezone setting and base currency placeholder from Settings (#PR_NUMBER)
 - Remove obsolete feature flag 'Enable Attachments for Theme Updates'; attachments now always enabled (#PR_NUMBER)
+- Remove debug-only force database overwrite setting (#PR_NUMBER)
 
 ### Security
 

--- a/DragonShield/DatabaseManager.swift
+++ b/DragonShield/DatabaseManager.swift
@@ -59,17 +59,6 @@ class DatabaseManager: ObservableObject {
         self.dbMode = mode
         self.dbPath = appDir.appendingPathComponent(DatabaseManager.fileName(for: mode)).path
         
-        #if DEBUG
-        let shouldForceReCopy = UserDefaults.standard.bool(forKey: UserDefaultsKeys.forceOverwriteDatabaseOnDebug)
-        if shouldForceReCopy && FileManager.default.fileExists(atPath: dbPath) {
-            do {
-                try FileManager.default.removeItem(atPath: dbPath)
-                print("🗑️ [DEBUG] Deleted existing database at: \(dbPath) (Force Re-Copy Setting is ON)")
-            } catch {
-                print("⚠️ [DEBUG] Could not delete existing database for re-copy: \(error)")
-            }
-        }
-        #endif
         
         if !FileManager.default.fileExists(atPath: dbPath) {
             if let bundlePath = Bundle.main.path(forResource: "dragonshield", ofType: "sqlite") {

--- a/DragonShield/Views/SettingsView.swift
+++ b/DragonShield/Views/SettingsView.swift
@@ -13,9 +13,6 @@ struct SettingsView: View {
     @EnvironmentObject var dbManager: DatabaseManager
     @EnvironmentObject var runner: HealthCheckRunner
 
-    @AppStorage(UserDefaultsKeys.forceOverwriteDatabaseOnDebug)
-    private var forceOverwriteDatabaseOnDebug: Bool = false
-
     @AppStorage(UserDefaultsKeys.enableParsingCheckpoints)
     private var enableParsingCheckpoints: Bool = false
 
@@ -112,14 +109,7 @@ struct SettingsView: View {
 
             #if DEBUG
             Section(header: Text("Development / Debug Options")) {
-                VStack(alignment: .leading) {
-                    Toggle("Force Re-copy Database on Next Launch", isOn: $forceOverwriteDatabaseOnDebug)
-                    Text("Enable this to delete the current database and copy a fresh version from the bundle on next app start. Only for Debug builds.")
-                        .font(.caption)
-                        .foregroundColor(.gray)
-                    Toggle("Enable Parsing Checkpoints", isOn: $enableParsingCheckpoints)
-                        .padding(.top, 4)
-                }
+                Toggle("Enable Parsing Checkpoints", isOn: $enableParsingCheckpoints)
             }
             #endif
 
@@ -146,8 +136,7 @@ struct SettingsView: View {
 
 struct SettingsView_Previews: PreviewProvider {
     static var previews: some View {
-        // NOTE: You must have a `UserDefaultsKeys` struct with the appropriate key defined for this preview to work.
-        UserDefaults.standard.set(true, forKey: "forceOverwriteDatabaseOnDebug")
+        // NOTE: Configure UserDefaults defaults for preview.
         UserDefaults.standard.set(false, forKey: "enableParsingCheckpoints")
         let dbManager = DatabaseManager() // Create a preview instance
         let runner = HealthCheckRunner()

--- a/DragonShield/helpers/UserDefaultsKeys.swift
+++ b/DragonShield/helpers/UserDefaultsKeys.swift
@@ -6,7 +6,6 @@
 import Foundation
 
 struct UserDefaultsKeys {
-    static let forceOverwriteDatabaseOnDebug = "forceOverwriteDatabaseOnDebug"
     static let enableParsingCheckpoints = "enableParsingCheckpoints"
     static let automaticBackupsEnabled = "automaticBackupsEnabled"
     static let automaticBackupTime = "automaticBackupTime"


### PR DESCRIPTION
## Summary
- delete unused `forceOverwriteDatabaseOnDebug` user defaults key
- remove debug toggle for forcing database copy
- drop database overwrite logic tied to removed flag

## Testing
- `make setup` (fails: No rule to make target 'setup')
- `make fmt` (fails: No rule to make target 'fmt')
- `make lint` (fails: No rule to make target 'lint')
- `make migrate` (fails: No rule to make target 'migrate')
- `make build` (fails: No rule to make target 'build')
- `make test` (fails: No rule to make target 'test')


------
https://chatgpt.com/codex/tasks/task_e_68acb6895ea4832385af0cda79f9837f