### PR TITLE
docs: note removal of debug db overwrite setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 - Remove redundant Portfolio Theme Overview tab and associated view (#PR_NUMBER)
 - Remove default timezone setting and base currency placeholder from Settings (#PR_NUMBER)
 - Remove obsolete feature flag 'Enable Attachments for Theme Updates'; attachments now always enabled (#PR_NUMBER)
-- Remove debug preference for forcing database overwrite (#PR_NUMBER)
+- Remove debug-only force database overwrite setting (#PR_NUMBER)
 
 ### Security
 


### PR DESCRIPTION
## Summary
- document removal of debug-only force database overwrite setting in changelog

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68ad41d97c1c83238c4c6a610b8dea8a