### PR TITLE
Persist Portfolio Themes table column widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 - Add repository for strict unused instruments report (#PR_NUMBER)
 - Expose strict unused instruments report from Instruments view (#PR_NUMBER)
 - Show note icon for institutions with notes in overview table (#PR_NUMBER)
+- Persist Portfolio Themes table column widths (#PR_NUMBER)
 
 ### Changed
 - Replace status alerts with SwiftUI windows (#PR_NUMBER)

--- a/DragonShield/Views/AutosaveTableView.swift
+++ b/DragonShield/Views/AutosaveTableView.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+import AppKit
+
+struct AutosaveTableView: NSViewRepresentable {
+    let name: String
+
+    func makeNSView(context: Context) -> NSView {
+        NSView()
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        DispatchQueue.main.async {
+            guard let table = findTableView(from: nsView) else { return }
+            if table.autosaveName?.rawValue != name {
+                Self.configure(table, name: name)
+            }
+        }
+    }
+
+    static func configure(_ table: NSTableView, name: String) {
+        table.autosaveName = NSUserInterfaceItemIdentifier(name)
+        for (index, column) in table.tableColumns.enumerated() {
+            column.identifier = NSUserInterfaceItemIdentifier("col\(index)")
+        }
+        table.sizeToFit()
+    }
+
+    private func findTableView(from view: NSView) -> NSTableView? {
+        if let table = view as? NSTableView { return table }
+        for sub in view.subviews {
+            if let table = findTableView(from: sub) { return table }
+        }
+        if let superview = view.superview {
+            return findTableView(from: superview)
+        }
+        return nil
+    }
+}

--- a/DragonShield/Views/PortfolioThemesListView.swift
+++ b/DragonShield/Views/PortfolioThemesListView.swift
@@ -168,6 +168,7 @@ struct PortfolioThemesListView: View {
             })
             .width(30)
         }
+        .background(AutosaveTableView(name: "PortfolioThemesTable"))
         .onChange(of: sortOrder) { _, newOrder in
             guard let comparator = newOrder.first else { return }
             persistSortOrder()

--- a/DragonShield/helpers/UserDefaultsKeys.swift
+++ b/DragonShield/helpers/UserDefaultsKeys.swift
@@ -24,4 +24,6 @@ struct UserDefaultsKeys {
     static let portfolioThemeDetailLastTab = "portfolioThemeDetailLastTab"
     /// Persist window frame for import value report.
     static let importReportWindowFrame = "importReport.windowFrame"
+    /// Persist column widths for Portfolio Themes list.
+    static let portfolioThemesColumnWidths = "portfolioThemesColumnWidths"
 }

--- a/DragonShieldTests/AutosaveTableViewTests.swift
+++ b/DragonShieldTests/AutosaveTableViewTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import DragonShield
+import AppKit
+
+final class AutosaveTableViewTests: XCTestCase {
+    func testConfigureSetsAutosaveAndIdentifiers() {
+        let table = NSTableView()
+        table.addTableColumn(NSTableColumn())
+        table.addTableColumn(NSTableColumn())
+        AutosaveTableView.configure(table, name: "TestTable")
+        XCTAssertEqual(table.autosaveName?.rawValue, "TestTable")
+        XCTAssertEqual(table.tableColumns[0].identifier.rawValue, "col0")
+        XCTAssertEqual(table.tableColumns[1].identifier.rawValue, "col1")
+    }
+}


### PR DESCRIPTION
## Summary
- autosave Portfolio Themes table columns with NSTableView
- add UserDefaults key for table column widths
- cover autosave helper with unit test

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -project DragonShield.xcodeproj -scheme DragonShield -configuration Debug build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4cc06c70832385ea6324fee82049