### PR TITLE
Persist Portfolio Themes column widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 - Add repository for strict unused instruments report (#PR_NUMBER)
 - Expose strict unused instruments report from Instruments view (#PR_NUMBER)
 - Show note icon for institutions with notes in overview table (#PR_NUMBER)
+- Persist Portfolio Themes list column widths (#PR_NUMBER)
 
 ### Changed
 - Replace status alerts with SwiftUI windows (#PR_NUMBER)

--- a/DragonShield/Views/PortfolioThemesListView.swift
+++ b/DragonShield/Views/PortfolioThemesListView.swift
@@ -14,6 +14,19 @@ struct PortfolioThemesListView: View {
 
     private enum SortField: String { case name, code, status, updatedAt, totalValue, instruments }
     private let sortDefaultsKey = "PortfolioThemesListView.sort"
+
+    @AppStorage(UserDefaultsKeys.portfolioThemesNameWidth) private var nameWidth: Double = 150
+    @AppStorage(UserDefaultsKeys.portfolioThemesCodeWidth) private var codeWidth: Double = 80
+    @AppStorage(UserDefaultsKeys.portfolioThemesStatusWidth) private var statusWidth: Double = 120
+    @AppStorage(UserDefaultsKeys.portfolioThemesUpdatedAtWidth) private var updatedAtWidth: Double = 150
+    @AppStorage(UserDefaultsKeys.portfolioThemesTotalValueWidth) private var totalValueWidth: Double = 120
+    @AppStorage(UserDefaultsKeys.portfolioThemesInstrumentsWidth) private var instrumentsWidth: Double = 80
+    @AppStorage(UserDefaultsKeys.portfolioThemesOpenWidth) private var openWidth: Double = 30
+
+    private func widthBinding(_ value: Binding<Double>) -> Binding<CGFloat> {
+        Binding(get: { CGFloat(value.wrappedValue) },
+                set: { value.wrappedValue = Double($0) })
+    }
     
     // Local state for the data
     @State var themes: [PortfolioTheme] = []
@@ -132,30 +145,28 @@ struct PortfolioThemesListView: View {
 
     private var themesTable: some View {
         Table(themes, selection: $selectedThemeId, sortOrder: $sortOrder) {
-            TableColumn(headerLabel("Name", field: .name), value: \.name) { theme in
+            TableColumn(headerLabel("Name", field: .name), value: \.name, width: widthBinding($nameWidth)) { theme in
                 Text(theme.name).foregroundStyle(isArchived(theme) ? .secondary : .primary)
             }
-            TableColumn(headerLabel("Code", field: .code), value: \.code) { theme in
+            TableColumn(headerLabel("Code", field: .code), value: \.code, width: widthBinding($codeWidth)) { theme in
                 Text(theme.code).foregroundStyle(isArchived(theme) ? .secondary : .primary)
             }
-            TableColumn(headerLabel("Status", field: .status), sortUsing: KeyPathComparator(\.statusId)) { theme in
+            TableColumn(headerLabel("Status", field: .status), sortUsing: KeyPathComparator(\.statusId), width: widthBinding($statusWidth)) { theme in
                 Text(statusName(for: theme.statusId)).foregroundStyle(isArchived(theme) ? .secondary : .primary)
             }
-            TableColumn(headerLabel("Last Updated", field: .updatedAt), value: \.updatedAt) { theme in
+            TableColumn(headerLabel("Last Updated", field: .updatedAt), value: \.updatedAt, width: widthBinding($updatedAtWidth)) { theme in
                 Text(theme.updatedAt).foregroundStyle(isArchived(theme) ? .secondary : .primary)
             }
-            TableColumn(headerLabel("Total Value", field: .totalValue), sortUsing: KeyPathComparator(\.totalValueBase)) { theme in
+            TableColumn(headerLabel("Total Value", field: .totalValue), sortUsing: KeyPathComparator(\.totalValueBase), width: widthBinding($totalValueWidth)) { theme in
                 totalValueCell(for: theme)
             }
-            .width(min: 120)
-            TableColumn(headerLabel("Instruments", field: .instruments), value: \.instrumentCount) { theme in
+            TableColumn(headerLabel("Instruments", field: .instruments), value: \.instrumentCount, width: widthBinding($instrumentsWidth)) { theme in
                 Text("\(theme.instrumentCount)")
                     .monospacedDigit()
                     .frame(maxWidth: .infinity, alignment: .trailing)
                     .foregroundStyle(isArchived(theme) ? .secondary : .primary)
             }
-            .width(min: 80)
-            TableColumn("", content: { theme in
+            TableColumn("", width: widthBinding($openWidth)) { theme in
                 Button {
                     open(theme)
                 } label: {
@@ -165,8 +176,7 @@ struct PortfolioThemesListView: View {
                 .buttonStyle(.plain)
                 .help("Open Theme Details")
                 .accessibilityLabel("Open details for \(theme.name)")
-            })
-            .width(30)
+            }
         }
         .onChange(of: sortOrder) { _, newOrder in
             guard let comparator = newOrder.first else { return }

--- a/DragonShield/helpers/UserDefaultsKeys.swift
+++ b/DragonShield/helpers/UserDefaultsKeys.swift
@@ -24,4 +24,13 @@ struct UserDefaultsKeys {
     static let portfolioThemeDetailLastTab = "portfolioThemeDetailLastTab"
     /// Persist window frame for import value report.
     static let importReportWindowFrame = "importReport.windowFrame"
+
+    /// Column widths for Portfolio Themes list.
+    static let portfolioThemesNameWidth = "portfolioThemes.nameWidth"
+    static let portfolioThemesCodeWidth = "portfolioThemes.codeWidth"
+    static let portfolioThemesStatusWidth = "portfolioThemes.statusWidth"
+    static let portfolioThemesUpdatedAtWidth = "portfolioThemes.updatedAtWidth"
+    static let portfolioThemesTotalValueWidth = "portfolioThemes.totalValueWidth"
+    static let portfolioThemesInstrumentsWidth = "portfolioThemes.instrumentsWidth"
+    static let portfolioThemesOpenWidth = "portfolioThemes.openWidth"
 }

--- a/DragonShieldTests/PortfolioThemesListColumnWidthTests.swift
+++ b/DragonShieldTests/PortfolioThemesListColumnWidthTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import DragonShield
+
+final class PortfolioThemesListColumnWidthTests: XCTestCase {
+    @MainActor
+    func testNameWidthPersists() {
+        let defaults = UserDefaults.standard
+        let key = UserDefaultsKeys.portfolioThemesNameWidth
+        defaults.removeObject(forKey: key)
+        defaults.set(210, forKey: key)
+        let view = PortfolioThemesListView()
+        let mirror = Mirror(reflecting: view)
+        let width = mirror.descendant("nameWidth") as? Double
+        XCTAssertEqual(width, 210)
+        defaults.removeObject(forKey: key)
+    }
+}


### PR DESCRIPTION
## Summary
- persist Portfolio Themes list column widths with UserDefaults/AppStorage
- bind table columns to stored widths for user-resizable columns
- cover width persistence with a UI smoke test

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4cb072288323beb5aff5192ebc7e