### PR TITLE
feat: resize themes table columns and show short dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 - Slim valuation table research and user columns in Portfolio Theme Detail view (#PR_NUMBER)
 - Enlarge Portfolio Theme Detail window to fit valuation columns (#PR_NUMBER)
 - Use shared DashboardTileLayout for compact dashboard list tiles (#PR_NUMBER)
+- Resize Portfolio Themes list columns, move open indicator to front, and show short dates (#PR_NUMBER)
 
 ### Fixed
 

--- a/DragonShield/Core/DateFormatting.swift
+++ b/DragonShield/Core/DateFormatting.swift
@@ -14,8 +14,20 @@ enum DateFormatting {
         return f
     }()
 
+    private static let swissShortFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "d.M.yy"
+        f.timeZone = .current
+        return f
+    }()
+
     static func userFriendly(_ isoString: String?) -> String {
         guard let isoString = isoString, let date = isoFormatter.date(from: isoString) else { return "—" }
         return displayFormatter.string(from: date)
+    }
+
+    static func swissShort(_ isoString: String?) -> String {
+        guard let isoString = isoString, let date = isoFormatter.date(from: isoString) else { return "—" }
+        return swissShortFormatter.string(from: date)
     }
 }

--- a/DragonShield/Views/PortfolioThemesListView.swift
+++ b/DragonShield/Views/PortfolioThemesListView.swift
@@ -132,18 +132,35 @@ struct PortfolioThemesListView: View {
 
     private var themesTable: some View {
         Table(themes, selection: $selectedThemeId, sortOrder: $sortOrder) {
+            TableColumn("", content: { theme in
+                Button {
+                    open(theme)
+                } label: {
+                    Text("\u25B6\uFE0F")
+                        .foregroundColor(isArchived(theme) ? .secondary : .primary)
+                }
+                .buttonStyle(.plain)
+                .help("Open Theme Details")
+                .accessibilityLabel("Open details for \(theme.name)")
+            })
+            .width(30)
+
             TableColumn(headerLabel("Name", field: .name), value: \.name) { theme in
                 Text(theme.name).foregroundStyle(isArchived(theme) ? .secondary : .primary)
             }
+            .width(min: 200)
             TableColumn(headerLabel("Code", field: .code), value: \.code) { theme in
                 Text(theme.code).foregroundStyle(isArchived(theme) ? .secondary : .primary)
             }
+            .width(min: 80)
             TableColumn(headerLabel("Status", field: .status), sortUsing: KeyPathComparator(\.statusId)) { theme in
                 Text(statusName(for: theme.statusId)).foregroundStyle(isArchived(theme) ? .secondary : .primary)
             }
+            .width(min: 80)
             TableColumn(headerLabel("Last Updated", field: .updatedAt), value: \.updatedAt) { theme in
-                Text(theme.updatedAt).foregroundStyle(isArchived(theme) ? .secondary : .primary)
+                Text(DateFormatting.swissShort(theme.updatedAt)).foregroundStyle(isArchived(theme) ? .secondary : .primary)
             }
+            .width(min: 120)
             TableColumn(headerLabel("Total Value", field: .totalValue), sortUsing: KeyPathComparator(\.totalValueBase)) { theme in
                 totalValueCell(for: theme)
             }
@@ -155,18 +172,6 @@ struct PortfolioThemesListView: View {
                     .foregroundStyle(isArchived(theme) ? .secondary : .primary)
             }
             .width(min: 80)
-            TableColumn("", content: { theme in
-                Button {
-                    open(theme)
-                } label: {
-                    Image(systemName: "chevron.right")
-                        .foregroundColor(isArchived(theme) ? .secondary : .primary)
-                }
-                .buttonStyle(.plain)
-                .help("Open Theme Details")
-                .accessibilityLabel("Open details for \(theme.name)")
-            })
-            .width(30)
         }
         .onChange(of: sortOrder) { _, newOrder in
             guard let comparator = newOrder.first else { return }

--- a/DragonShieldTests/DateFormattingTests.swift
+++ b/DragonShieldTests/DateFormattingTests.swift
@@ -10,4 +10,13 @@ final class DateFormattingTests: XCTestCase {
         XCTAssertEqual(DateFormatting.userFriendly(iso), "2025-08-22 15:39")
         XCTAssertEqual(DateFormatting.userFriendly(nil), "—")
     }
+
+    func testSwissShort() {
+        let prev = NSTimeZone.default
+        NSTimeZone.default = TimeZone(secondsFromGMT: 0)!
+        defer { NSTimeZone.default = prev }
+        let iso = "2025-08-24T00:00:00Z"
+        XCTAssertEqual(DateFormatting.swissShort(iso), "24.8.25")
+        XCTAssertEqual(DateFormatting.swissShort(nil), "—")
+    }
 }


### PR DESCRIPTION
## Summary
- resize Portfolio Themes list columns and place open indicator first
- show Last Updated dates in short format
- cover short date format with unit test

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6537ad448323a41e0d807fa88a5a