### PR TITLE
chore: add version bump automation

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,24 @@
+name: Bump Version
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  bump:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Bump version
+        run: scripts/bump_version.zsh
+      - name: Push changes
+        run: |
+          git push origin main
+          git push origin --tags

--- a/.github/workflows/docs-manifest.yml
+++ b/.github/workflows/docs-manifest.yml
@@ -15,3 +15,5 @@ jobs:
           python-version: '3.x'
       - name: Verify manifest
         run: python DragonShield/docs/update_manifest.py --check
+      - name: Verify root docs manifest
+        run: python docs/update_manifest.py --check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Each pull request must add a one-line, user-facing entry under **Unreleased** in
 - Add repository for strict unused instruments report (#PR_NUMBER)
 - Expose strict unused instruments report from Instruments view (#PR_NUMBER)
 - Show note icon for institutions with notes in overview table (#PR_NUMBER)
+- Introduce version bump script and CI workflow (#PR_NUMBER)
 
 ### Changed
 - Replace status alerts with SwiftUI windows (#PR_NUMBER)

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,0 +1,8 @@
+{
+  "docs": [
+    {
+      "path": "release_versioning.md",
+      "sha": "5fa4510e6b6df184a0b7dda00e8418b169a8bc58"
+    }
+  ]
+}

--- a/docs/release_versioning.md
+++ b/docs/release_versioning.md
@@ -1,0 +1,17 @@
+# Release Versioning
+
+This document describes how the project version is automatically incremented after merges to `main`.
+
+## Process
+
+1. `scripts/bump_version.zsh` reads the latest tag, increments the patch number, and updates the Xcode project using `xcrun agvtool new-marketing-version` and `new-version -all`.
+2. The script commits the modified `DragonShield.xcodeproj/project.pbxproj` and creates a new tag with the updated version.
+3. A GitHub Actions workflow runs this script on pushes to `main` and pushes the commit and tag back to the repository.
+
+## Manual Usage
+
+Run the script locally when needed:
+
+```
+scripts/bump_version.zsh
+```

--- a/docs/update_manifest.py
+++ b/docs/update_manifest.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import json
+import subprocess
+from pathlib import Path
+import sys
+
+DOCS_DIR = Path(__file__).parent
+MANIFEST_FILE = DOCS_DIR / "manifest.json"
+
+
+def list_markdown_files():
+    return sorted(p.relative_to(DOCS_DIR) for p in DOCS_DIR.rglob("*.md"))
+
+
+def blob_sha1(file_path: Path) -> str:
+    result = subprocess.run(
+        ["git", "hash-object", str(file_path)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def build_manifest() -> dict:
+    docs = [
+        {
+            "path": str(rel).replace("\\", "/"),
+            "sha": blob_sha1(DOCS_DIR / rel),
+        }
+        for rel in list_markdown_files()
+    ]
+    return {"docs": docs}
+
+
+def write_manifest(data: dict) -> None:
+    MANIFEST_FILE.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    check_mode = "--check" in sys.argv
+    manifest = build_manifest()
+    if check_mode:
+        if not MANIFEST_FILE.exists():
+            print("docs/manifest.json is missing", file=sys.stderr)
+            sys.exit(1)
+        existing = json.loads(MANIFEST_FILE.read_text(encoding="utf-8"))
+        if existing != manifest:
+            print("docs/manifest.json is out of date. Run update_manifest.py.", file=sys.stderr)
+            sys.exit(1)
+    else:
+        write_manifest(manifest)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bump_version.zsh
+++ b/scripts/bump_version.zsh
@@ -1,0 +1,17 @@
+#!/usr/bin/env zsh -f
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+latest_tag="$(git describe --tags --abbrev=0)"
+version="${latest_tag#v}"
+IFS='.' read -r major minor patch <<<"$version"
+next_version="$major.$minor.$((patch + 1))"
+
+xcrun agvtool new-marketing-version "$next_version"
+xcrun agvtool new-version -all
+
+git add "$repo_root/DragonShield.xcodeproj/project.pbxproj"
+git commit -m "Bump version to $next_version"
+git tag "v$next_version"


### PR DESCRIPTION
## Summary
- add bump_version.zsh to increment patch tag and update Xcode project
- run bump script on pushes to main via GitHub Actions
- document release versioning and maintain docs manifest

## Testing
- `python docs/update_manifest.py --check`
- `python DragonShield/docs/update_manifest.py --check`
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt && make lint` *(fails: No rule to make target 'fmt')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68ae119d488c832395d3753d43a17228