### PR TITLE
Replace update type enums with reference table

### DIFF
--- a/DragonShield/DatabaseManager+UpdateTypes.swift
+++ b/DragonShield/DatabaseManager+UpdateTypes.swift
@@ -1,0 +1,116 @@
+import Foundation
+import SQLite3
+
+extension DatabaseManager {
+    func ensureUpdateTypeTable() {
+        let sql = """
+        CREATE TABLE IF NOT EXISTS UpdateType (
+            id INTEGER PRIMARY KEY,
+            code TEXT NOT NULL UNIQUE,
+            name TEXT NOT NULL
+        );
+        """
+        if sqlite3_exec(db, sql, nil, nil, nil) != SQLITE_OK {
+            LoggingService.shared.log("ensureUpdateTypeTable failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+    }
+
+    func fetchUpdateTypes() -> [UpdateType] {
+        var items: [UpdateType] = []
+        let sql = "SELECT id, code, name FROM UpdateType ORDER BY id"
+        var stmt: OpaquePointer?
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                let id = Int(sqlite3_column_int(stmt, 0))
+                let code = String(cString: sqlite3_column_text(stmt, 1))
+                let name = String(cString: sqlite3_column_text(stmt, 2))
+                items.append(UpdateType(id: id, code: code, name: name))
+            }
+        } else {
+            LoggingService.shared.log("fetchUpdateTypes prepare failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+        sqlite3_finalize(stmt)
+        return items
+    }
+
+    func getUpdateType(id: Int) -> UpdateType? {
+        let sql = "SELECT id, code, name FROM UpdateType WHERE id = ?"
+        var stmt: OpaquePointer?
+        var item: UpdateType?
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            sqlite3_bind_int(stmt, 1, Int32(id))
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                let id = Int(sqlite3_column_int(stmt, 0))
+                let code = String(cString: sqlite3_column_text(stmt, 1))
+                let name = String(cString: sqlite3_column_text(stmt, 2))
+                item = UpdateType(id: id, code: code, name: name)
+            }
+        } else {
+            LoggingService.shared.log("getUpdateType prepare failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+        sqlite3_finalize(stmt)
+        return item
+    }
+
+    func createUpdateType(code: String, name: String) -> UpdateType? {
+        let sql = "INSERT INTO UpdateType (code, name) VALUES (?, ?)"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            LoggingService.shared.log("createUpdateType prepare failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            return nil
+        }
+        let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        sqlite3_bind_text(stmt, 1, code, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 2, name, -1, SQLITE_TRANSIENT)
+        guard sqlite3_step(stmt) == SQLITE_DONE else {
+            LoggingService.shared.log("createUpdateType step failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            sqlite3_finalize(stmt)
+            return nil
+        }
+        sqlite3_finalize(stmt)
+        let newId = Int(sqlite3_last_insert_rowid(db))
+        return UpdateType(id: newId, code: code, name: name)
+    }
+
+    func updateUpdateType(id: Int, code: String?, name: String?) -> UpdateType? {
+        var sets: [String] = []
+        if code != nil { sets.append("code = ?") }
+        if name != nil { sets.append("name = ?") }
+        guard !sets.isEmpty else { return getUpdateType(id: id) }
+        let sql = "UPDATE UpdateType SET \(sets.joined(separator: ", ")) WHERE id = ?"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            LoggingService.shared.log("updateUpdateType prepare failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            return nil
+        }
+        let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        var idx: Int32 = 1
+        if let c = code {
+            sqlite3_bind_text(stmt, idx, c, -1, SQLITE_TRANSIENT); idx += 1
+        }
+        if let n = name {
+            sqlite3_bind_text(stmt, idx, n, -1, SQLITE_TRANSIENT); idx += 1
+        }
+        sqlite3_bind_int(stmt, idx, Int32(id))
+        guard sqlite3_step(stmt) == SQLITE_DONE else {
+            LoggingService.shared.log("updateUpdateType step failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            sqlite3_finalize(stmt)
+            return nil
+        }
+        sqlite3_finalize(stmt)
+        return getUpdateType(id: id)
+    }
+
+    func deleteUpdateType(id: Int) -> Bool {
+        let sql = "DELETE FROM UpdateType WHERE id = ?"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            LoggingService.shared.log("deleteUpdateType prepare failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            return false
+        }
+        sqlite3_bind_int(stmt, 1, Int32(id))
+        let ok = sqlite3_step(stmt) == SQLITE_DONE
+        sqlite3_finalize(stmt)
+        return ok
+    }
+}

--- a/DragonShield/DatabaseManager.swift
+++ b/DragonShield/DatabaseManager.swift
@@ -77,6 +77,7 @@ class DatabaseManager: ObservableObject {
         
         openDatabase()
         ensurePortfolioThemeStatusDefault()
+        ensureUpdateTypeTable()
         ensurePortfolioThemeTable()
         ensurePortfolioThemeAssetTable()
         ensurePortfolioThemeUpdateTable()

--- a/DragonShield/Models/PortfolioThemeAssetUpdate.swift
+++ b/DragonShield/Models/PortfolioThemeAssetUpdate.swift
@@ -1,19 +1,13 @@
 // DragonShield/Models/PortfolioThemeAssetUpdate.swift
-// MARK: - Version 1.1
+// MARK: - Version 1.2
 // MARK: - History
 // - 1.0: Initial instrument-level update model for Step 7A.
 // - 1.0 -> 1.1: Add Markdown body and pin flag for Phase 7B.
+// - 1.1 -> 1.2: Replace enum type with UpdateType reference.
 
 import Foundation
 
 struct PortfolioThemeAssetUpdate: Identifiable, Codable {
-    enum UpdateType: String, CaseIterable, Codable {
-        case General
-        case Research
-        case Rebalance
-        case Risk
-    }
-
     let id: Int
     let themeId: Int
     let instrumentId: Int
@@ -38,4 +32,3 @@ struct PortfolioThemeAssetUpdate: Identifiable, Codable {
         return count >= 1 && count <= 5000
     }
 }
-

--- a/DragonShield/Models/PortfolioThemeUpdate.swift
+++ b/DragonShield/Models/PortfolioThemeUpdate.swift
@@ -1,19 +1,13 @@
 // DragonShield/Models/PortfolioThemeUpdate.swift
-// MARK: - Version 1.2
+// MARK: - Version 1.3
 // MARK: - History
 // - 1.0 -> 1.1: Add Markdown body and pin flag for Phase 6B updates.
 // - 1.1 -> 1.2: Track soft deletion metadata for Phase 6C.
+// - 1.2 -> 1.3: Replace enum type with UpdateType reference.
 
 import Foundation
 
 struct PortfolioThemeUpdate: Identifiable, Codable {
-    enum UpdateType: String, CaseIterable, Codable {
-        case General
-        case Research
-        case Rebalance
-        case Risk
-    }
-
     let id: Int
     let themeId: Int
     var title: String

--- a/DragonShield/Models/UpdateType.swift
+++ b/DragonShield/Models/UpdateType.swift
@@ -1,0 +1,12 @@
+// DragonShield/Models/UpdateType.swift
+// MARK: - Version 1.0
+// MARK: - History
+// - 1.0: Initial model for update type reference table.
+
+import Foundation
+
+struct UpdateType: Identifiable, Codable, Hashable {
+    let id: Int
+    let code: String
+    let name: String
+}

--- a/DragonShield/Views/InstrumentNotesView.swift
+++ b/DragonShield/Views/InstrumentNotesView.swift
@@ -112,7 +112,7 @@ struct InstrumentNotesView: View {
                 ForEach(updates) { update in
                     VStack(alignment: .leading, spacing: 4) {
                         HStack {
-                            Text("\(DateFormatting.userFriendly(update.createdAt)) • \(update.author) • \(update.type.rawValue)")
+                            Text("\(DateFormatting.userFriendly(update.createdAt)) • \(update.author) • \(update.type.code)")
                             Spacer()
                             Text(update.pinned ? "★" : "☆")
                         }
@@ -141,7 +141,7 @@ struct InstrumentNotesView: View {
                 ForEach(mentions) { mention in
                     VStack(alignment: .leading, spacing: 4) {
                         HStack {
-                            Text("\(DateFormatting.userFriendly(mention.createdAt)) • Theme: \(themeName(for: mention.themeId)) • Type: \(mention.type.rawValue)")
+                            Text("\(DateFormatting.userFriendly(mention.createdAt)) • Theme: \(themeName(for: mention.themeId)) • Type: \(mention.type.code)")
                             if isThemeArchived(mention.themeId) {
                                 Text("Archived").font(.caption).foregroundColor(.secondary)
                             }

--- a/DragonShield/Views/InstrumentUpdateEditorView.swift
+++ b/DragonShield/Views/InstrumentUpdateEditorView.swift
@@ -23,7 +23,8 @@ struct InstrumentUpdateEditorView: View {
 
     @State private var title: String
     @State private var bodyMarkdown: String
-    @State private var type: PortfolioThemeAssetUpdate.UpdateType
+    @State private var type: UpdateType
+    @State private var availableTypes: [UpdateType] = []
     @State private var pinned: Bool
     @State private var mode: Mode = .write
     @State private var breadcrumb: (positionsAsOf: String?, valueChf: Double?, actualPercent: Double?)?
@@ -42,7 +43,7 @@ struct InstrumentUpdateEditorView: View {
         self.onCancel = onCancel
         _title = State(initialValue: existing?.title ?? "")
         _bodyMarkdown = State(initialValue: existing?.bodyMarkdown ?? "")
-        _type = State(initialValue: existing?.type ?? .General)
+        _type = State(initialValue: existing?.type ?? UpdateType(id: 1, code: "General", name: "General"))
         _pinned = State(initialValue: existing?.pinned ?? false)
     }
 
@@ -54,8 +55,8 @@ struct InstrumentUpdateEditorView: View {
                 .font(.subheadline)
             TextField("Title (1–120)", text: $title)
             Picker("Type", selection: $type) {
-                ForEach(PortfolioThemeAssetUpdate.UpdateType.allCases, id: \.self) { t in
-                    Text(t.rawValue).tag(t)
+                ForEach(availableTypes, id: \.id) { t in
+                    Text(t.name).tag(t)
                 }
             }
             Toggle("Pin this update", isOn: $pinned)
@@ -104,7 +105,15 @@ struct InstrumentUpdateEditorView: View {
         }
         .padding(24)
         .frame(minWidth: 520, minHeight: 360)
-        .onAppear { loadBreadcrumb() }
+        .onAppear {
+            availableTypes = dbManager.fetchUpdateTypes()
+            if let existing = existing {
+                type = existing.type
+            } else if let first = availableTypes.first {
+                type = first
+            }
+            loadBreadcrumb()
+        }
     }
 
     private var valid: Bool {

--- a/DragonShield/Views/InstrumentUpdatesView.swift
+++ b/DragonShield/Views/InstrumentUpdatesView.swift
@@ -57,7 +57,7 @@ struct InstrumentUpdatesView: View {
                 ForEach(updates) { update in
                     VStack(alignment: .leading, spacing: 4) {
                         HStack {
-                            Text("\(DateFormatting.userFriendly(update.createdAt)) • \(update.author) • \(update.type.rawValue)\(update.updatedAt > update.createdAt ? " • edited" : "")")
+                            Text("\(DateFormatting.userFriendly(update.createdAt)) • \(update.author) • \(update.type.code)\(update.updatedAt > update.createdAt ? " • edited" : "")")
                                 .font(.subheadline)
                             Spacer()
                             Text(update.pinned ? "★ Pinned" : "☆")

--- a/DragonShield/Views/PortfolioThemeUpdatesView.swift
+++ b/DragonShield/Views/PortfolioThemeUpdatesView.swift
@@ -12,7 +12,8 @@ struct PortfolioThemeUpdatesView: View {
     @State private var editingUpdate: PortfolioThemeUpdate?
     @State private var showEditor = false
     @State private var searchText: String = ""
-    @State private var selectedType: PortfolioThemeUpdate.UpdateType? = nil
+    @State private var selectedType: UpdateType? = nil
+    @State private var availableTypes: [UpdateType] = []
     @State private var pinnedFirst: Bool = true
     @State private var sortOrder: SortOrder = .newest
     @State private var dateFilter: UpdateDateFilter = .last30d
@@ -49,6 +50,7 @@ struct PortfolioThemeUpdatesView: View {
         }
         .padding(12)
         .onAppear {
+            availableTypes = dbManager.fetchUpdateTypes()
             if let s = initialSearchText, searchText.isEmpty { searchText = s }
             load()
         }
@@ -87,9 +89,9 @@ struct PortfolioThemeUpdatesView: View {
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.15, execute: task)
                 }
             Picker("Type", selection: $selectedType) {
-                Text("All").tag(nil as PortfolioThemeUpdate.UpdateType?)
-                ForEach(PortfolioThemeUpdate.UpdateType.allCases, id: \.self) { t in
-                    Text(t.rawValue).tag(Optional(t))
+                Text("All").tag(nil as UpdateType?)
+                ForEach(availableTypes, id: \.id) { t in
+                    Text(t.name).tag(Optional(t))
                 }
             }
             .onChange(of: selectedType) { _, _ in load() }
@@ -137,7 +139,7 @@ struct PortfolioThemeUpdatesView: View {
                                 .buttonStyle(.link)
                         }
                     }
-                    Text("\(DateFormatting.userFriendly(update.createdAt)) · \(update.author) · [\(update.type.rawValue)]")
+                    Text("\(DateFormatting.userFriendly(update.createdAt)) · \(update.author) · [\(update.type.code)]")
                         .font(.caption)
                     if expandedId == update.id {
                         Text(MarkdownRenderer.attributedString(from: update.bodyMarkdown))

--- a/DragonShield/Views/ThemeUpdateEditorView.swift
+++ b/DragonShield/Views/ThemeUpdateEditorView.swift
@@ -20,7 +20,8 @@ struct ThemeUpdateEditorView: View {
 
     @State private var title: String
     @State private var bodyMarkdown: String
-    @State private var type: PortfolioThemeUpdate.UpdateType
+    @State private var type: UpdateType
+    @State private var availableTypes: [UpdateType] = []
     @State private var pinned: Bool
     @State private var mode: Mode = .write
     @State private var positionsAsOf: String?
@@ -46,7 +47,7 @@ struct ThemeUpdateEditorView: View {
         self.logSource = logSource
         _title = State(initialValue: existing?.title ?? "")
         _bodyMarkdown = State(initialValue: existing?.bodyMarkdown ?? "")
-        _type = State(initialValue: existing?.type ?? .General)
+        _type = State(initialValue: existing?.type ?? UpdateType(id: 1, code: "General", name: "General"))
         _pinned = State(initialValue: existing?.pinned ?? false)
     }
 
@@ -56,8 +57,8 @@ struct ThemeUpdateEditorView: View {
                 .font(.headline)
             TextField("Title", text: $title)
             Picker("Type", selection: $type) {
-                ForEach(PortfolioThemeUpdate.UpdateType.allCases, id: \.self) { t in
-                    Text(t.rawValue).tag(t)
+                ForEach(availableTypes, id: \.id) { t in
+                    Text(t.name).tag(t)
                 }
             }
             Toggle("Pin this update", isOn: $pinned)
@@ -107,7 +108,15 @@ struct ThemeUpdateEditorView: View {
         }
         .padding(24)
         .frame(minWidth: 520, minHeight: 360)
-        .onAppear { loadSnapshot() }
+        .onAppear {
+            availableTypes = dbManager.fetchUpdateTypes()
+            if let existing = existing {
+                type = existing.type
+            } else if let first = availableTypes.first {
+                type = first
+            }
+            loadSnapshot()
+        }
     }
 
     private var valid: Bool {

--- a/DragonShield/db/migrations/023_update_type.sql
+++ b/DragonShield/db/migrations/023_update_type.sql
@@ -1,0 +1,116 @@
+-- migrate:up
+-- Purpose: Add UpdateType table and replace text type columns with foreign keys
+-- Assumptions: Existing PortfolioThemeUpdate and PortfolioThemeAssetUpdate tables use string type values
+-- Idempotency: creates new table with seed data and rebuilds affected tables
+CREATE TABLE IF NOT EXISTS UpdateType (
+  id INTEGER PRIMARY KEY,
+  code TEXT NOT NULL UNIQUE,
+  name TEXT NOT NULL
+);
+INSERT INTO UpdateType (code, name) VALUES
+  ('General','General'),
+  ('Research','Research'),
+  ('Rebalance','Rebalance'),
+  ('Risk','Risk')
+ON CONFLICT(code) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS PortfolioThemeUpdate_new (
+  id INTEGER PRIMARY KEY,
+  theme_id INTEGER NOT NULL REFERENCES PortfolioTheme(id) ON DELETE CASCADE,
+  title TEXT NOT NULL CHECK (LENGTH(title) BETWEEN 1 AND 120),
+  body_text TEXT NOT NULL CHECK (LENGTH(body_text) BETWEEN 1 AND 5000),
+  body_markdown TEXT NOT NULL CHECK (LENGTH(body_markdown) BETWEEN 1 AND 5000),
+  type_id INTEGER NOT NULL REFERENCES UpdateType(id),
+  author TEXT NOT NULL,
+  pinned INTEGER NOT NULL DEFAULT 0 CHECK (pinned IN (0,1)),
+  positions_asof TEXT NULL,
+  total_value_chf REAL NULL,
+  created_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
+  updated_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
+  soft_delete INTEGER NOT NULL DEFAULT 0 CHECK (soft_delete IN (0,1)),
+  deleted_at TEXT NULL,
+  deleted_by TEXT NULL
+);
+INSERT INTO PortfolioThemeUpdate_new (id, theme_id, title, body_text, body_markdown, type_id, author, pinned, positions_asof, total_value_chf, created_at, updated_at, soft_delete, deleted_at, deleted_by)
+  SELECT u.id, u.theme_id, u.title, u.body_text, u.body_markdown, t.id, u.author, u.pinned, u.positions_asof, u.total_value_chf, u.created_at, u.updated_at, u.soft_delete, u.deleted_at, u.deleted_by
+  FROM PortfolioThemeUpdate u JOIN UpdateType t ON t.code = u.type;
+DROP TABLE PortfolioThemeUpdate;
+ALTER TABLE PortfolioThemeUpdate_new RENAME TO PortfolioThemeUpdate;
+CREATE INDEX IF NOT EXISTS idx_ptu_theme_active_order ON PortfolioThemeUpdate(theme_id, soft_delete, pinned, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_ptu_theme_deleted_order ON PortfolioThemeUpdate(theme_id, soft_delete, deleted_at DESC);
+
+CREATE TABLE IF NOT EXISTS PortfolioThemeAssetUpdate_new (
+  id INTEGER PRIMARY KEY,
+  theme_id INTEGER NOT NULL REFERENCES PortfolioTheme(id) ON DELETE CASCADE,
+  instrument_id INTEGER NOT NULL REFERENCES Instruments(instrument_id) ON DELETE SET NULL,
+  title TEXT NOT NULL CHECK (LENGTH(title) BETWEEN 1 AND 120),
+  body_text TEXT NOT NULL CHECK (LENGTH(body_text) BETWEEN 1 AND 5000),
+  body_markdown TEXT NOT NULL CHECK (LENGTH(body_markdown) BETWEEN 1 AND 5000),
+  type_id INTEGER NOT NULL REFERENCES UpdateType(id),
+  author TEXT NOT NULL,
+  pinned INTEGER NOT NULL DEFAULT 0 CHECK (pinned IN (0,1)),
+  positions_asof TEXT NULL,
+  value_chf REAL NULL,
+  actual_percent REAL NULL,
+  created_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
+  updated_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+INSERT INTO PortfolioThemeAssetUpdate_new (id, theme_id, instrument_id, title, body_text, body_markdown, type_id, author, pinned, positions_asof, value_chf, actual_percent, created_at, updated_at)
+  SELECT u.id, u.theme_id, u.instrument_id, u.title, u.body_text, u.body_markdown, t.id, u.author, u.pinned, u.positions_asof, u.value_chf, u.actual_percent, u.created_at, u.updated_at
+  FROM PortfolioThemeAssetUpdate u JOIN UpdateType t ON t.code = u.type;
+DROP TABLE PortfolioThemeAssetUpdate;
+ALTER TABLE PortfolioThemeAssetUpdate_new RENAME TO PortfolioThemeAssetUpdate;
+CREATE INDEX IF NOT EXISTS idx_ptau_theme_instr_order ON PortfolioThemeAssetUpdate(theme_id, instrument_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_ptau_theme_instr_pinned_order ON PortfolioThemeAssetUpdate(theme_id, instrument_id, pinned DESC, created_at DESC);
+
+-- migrate:down
+CREATE TABLE IF NOT EXISTS PortfolioThemeUpdate_old (
+  id INTEGER PRIMARY KEY,
+  theme_id INTEGER NOT NULL REFERENCES PortfolioTheme(id) ON DELETE CASCADE,
+  title TEXT NOT NULL CHECK (LENGTH(title) BETWEEN 1 AND 120),
+  body_text TEXT NOT NULL CHECK (LENGTH(body_text) BETWEEN 1 AND 5000),
+  body_markdown TEXT NOT NULL CHECK (LENGTH(body_markdown) BETWEEN 1 AND 5000),
+  type TEXT NOT NULL CHECK (type IN ('General','Research','Rebalance','Risk')),
+  author TEXT NOT NULL,
+  pinned INTEGER NOT NULL DEFAULT 0 CHECK (pinned IN (0,1)),
+  positions_asof TEXT NULL,
+  total_value_chf REAL NULL,
+  created_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
+  updated_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
+  soft_delete INTEGER NOT NULL DEFAULT 0 CHECK (soft_delete IN (0,1)),
+  deleted_at TEXT NULL,
+  deleted_by TEXT NULL
+);
+INSERT INTO PortfolioThemeUpdate_old (id, theme_id, title, body_text, body_markdown, type, author, pinned, positions_asof, total_value_chf, created_at, updated_at, soft_delete, deleted_at, deleted_by)
+  SELECT u.id, u.theme_id, u.title, u.body_text, u.body_markdown, t.code, u.author, u.pinned, u.positions_asof, u.total_value_chf, u.created_at, u.updated_at, u.soft_delete, u.deleted_at, u.deleted_by
+  FROM PortfolioThemeUpdate u JOIN UpdateType t ON t.id = u.type_id;
+DROP TABLE PortfolioThemeUpdate;
+ALTER TABLE PortfolioThemeUpdate_old RENAME TO PortfolioThemeUpdate;
+CREATE INDEX IF NOT EXISTS idx_ptu_theme_active_order ON PortfolioThemeUpdate(theme_id, soft_delete, pinned, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_ptu_theme_deleted_order ON PortfolioThemeUpdate(theme_id, soft_delete, deleted_at DESC);
+
+CREATE TABLE IF NOT EXISTS PortfolioThemeAssetUpdate_old (
+  id INTEGER PRIMARY KEY,
+  theme_id INTEGER NOT NULL REFERENCES PortfolioTheme(id) ON DELETE CASCADE,
+  instrument_id INTEGER NOT NULL REFERENCES Instruments(instrument_id) ON DELETE SET NULL,
+  title TEXT NOT NULL CHECK (LENGTH(title) BETWEEN 1 AND 120),
+  body_text TEXT NOT NULL CHECK (LENGTH(body_text) BETWEEN 1 AND 5000),
+  body_markdown TEXT NOT NULL CHECK (LENGTH(body_markdown) BETWEEN 1 AND 5000),
+  type TEXT NOT NULL CHECK (type IN ('General','Research','Rebalance','Risk')),
+  author TEXT NOT NULL,
+  pinned INTEGER NOT NULL DEFAULT 0 CHECK (pinned IN (0,1)),
+  positions_asof TEXT NULL,
+  value_chf REAL NULL,
+  actual_percent REAL NULL,
+  created_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
+  updated_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+INSERT INTO PortfolioThemeAssetUpdate_old (id, theme_id, instrument_id, title, body_text, body_markdown, type, author, pinned, positions_asof, value_chf, actual_percent, created_at, updated_at)
+  SELECT u.id, u.theme_id, u.instrument_id, u.title, u.body_text, u.body_markdown, t.code, u.author, u.pinned, u.positions_asof, u.value_chf, u.actual_percent, u.created_at, u.updated_at
+  FROM PortfolioThemeAssetUpdate u JOIN UpdateType t ON t.id = u.type_id;
+DROP TABLE PortfolioThemeAssetUpdate;
+ALTER TABLE PortfolioThemeAssetUpdate_old RENAME TO PortfolioThemeAssetUpdate;
+CREATE INDEX IF NOT EXISTS idx_ptau_theme_instr_order ON PortfolioThemeAssetUpdate(theme_id, instrument_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_ptau_theme_instr_pinned_order ON PortfolioThemeAssetUpdate(theme_id, instrument_id, pinned DESC, created_at DESC);
+
+DROP TABLE IF EXISTS UpdateType;


### PR DESCRIPTION
## Summary
- add `UpdateType` table with seed rows and migrate update tables
- introduce `UpdateType` model and database helpers
- update update editing views to load types from database
- make `UpdateType` conform to `Hashable` for use in pickers

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make fmt` *(fails: No rule to make target 'fmt')*
- `make lint` *(fails: No rule to make target 'lint')*
- `make migrate` *(fails: No rule to make target 'migrate')*
- `make build` *(fails: No rule to make target 'build')*
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68af665e92b0832384578c333ac151d0