### PR TITLE
Refactor: centralize update types

### DIFF
--- a/DragonShield/DatabaseManager+PortfolioThemeAssetUpdates.swift
+++ b/DragonShield/DatabaseManager+PortfolioThemeAssetUpdates.swift
@@ -11,7 +11,7 @@ extension DatabaseManager {
             title TEXT NOT NULL CHECK (LENGTH(title) BETWEEN 1 AND 120),
             body_text TEXT NOT NULL CHECK (LENGTH(body_text) BETWEEN 1 AND 5000),
             body_markdown TEXT NOT NULL CHECK (LENGTH(body_markdown) BETWEEN 1 AND 5000),
-            type TEXT NOT NULL CHECK (type IN ('General','Research','Rebalance','Risk')),
+            type TEXT NOT NULL CHECK (type IN (\(PortfolioUpdateType.allowedSQLList))),
             author TEXT NOT NULL,
             pinned INTEGER NOT NULL DEFAULT 0 CHECK (pinned IN (0,1)),
             positions_asof TEXT NULL,

--- a/DragonShield/DatabaseManager+PortfolioThemeUpdates.swift
+++ b/DragonShield/DatabaseManager+PortfolioThemeUpdates.swift
@@ -26,7 +26,7 @@ extension DatabaseManager {
             title TEXT NOT NULL CHECK (LENGTH(title) BETWEEN 1 AND 120),
             body_text TEXT NOT NULL CHECK (LENGTH(body_text) BETWEEN 1 AND 5000),
             body_markdown TEXT NOT NULL CHECK (LENGTH(body_markdown) BETWEEN 1 AND 5000),
-            type TEXT NOT NULL CHECK (type IN ('General','Research','Rebalance','Risk')),
+            type TEXT NOT NULL CHECK (type IN (\(PortfolioUpdateType.allowedSQLList))),
             author TEXT NOT NULL,
             pinned INTEGER NOT NULL DEFAULT 0 CHECK (pinned IN (0,1)),
             positions_asof TEXT NULL,

--- a/DragonShield/Models/PortfolioThemeAssetUpdate.swift
+++ b/DragonShield/Models/PortfolioThemeAssetUpdate.swift
@@ -7,12 +7,7 @@
 import Foundation
 
 struct PortfolioThemeAssetUpdate: Identifiable, Codable {
-    enum UpdateType: String, CaseIterable, Codable {
-        case General
-        case Research
-        case Rebalance
-        case Risk
-    }
+    typealias UpdateType = PortfolioUpdateType
 
     let id: Int
     let themeId: Int
@@ -38,4 +33,3 @@ struct PortfolioThemeAssetUpdate: Identifiable, Codable {
         return count >= 1 && count <= 5000
     }
 }
-

--- a/DragonShield/Models/PortfolioThemeUpdate.swift
+++ b/DragonShield/Models/PortfolioThemeUpdate.swift
@@ -7,12 +7,7 @@
 import Foundation
 
 struct PortfolioThemeUpdate: Identifiable, Codable {
-    enum UpdateType: String, CaseIterable, Codable {
-        case General
-        case Research
-        case Rebalance
-        case Risk
-    }
+    typealias UpdateType = PortfolioUpdateType
 
     let id: Int
     let themeId: Int

--- a/DragonShield/Models/PortfolioUpdateType.swift
+++ b/DragonShield/Models/PortfolioUpdateType.swift
@@ -1,0 +1,17 @@
+// DragonShield/Models/PortfolioUpdateType.swift
+
+import Foundation
+
+enum PortfolioUpdateType: String, CaseIterable, Codable {
+    case General
+    case Research
+    case Rebalance
+    case Risk
+}
+
+extension PortfolioUpdateType {
+    static var allowedSQLList: String {
+        allCases.map { "'\($0.rawValue)'" }.joined(separator: ",")
+    }
+}
+


### PR DESCRIPTION
This PR centralizes update/news types to avoid duplication and drift.

Changes
- Add shared enum: PortfolioUpdateType (String, CaseIterable, Codable)
- Replace nested enums with typealias in:
  - PortfolioThemeUpdate
  - PortfolioThemeAssetUpdate
- Generate DB CHECK constraints from the enum via PortfolioUpdateType.allowedSQLList in:
  - DatabaseManager+PortfolioThemeUpdates.ensurePortfolioThemeUpdateTable
  - DatabaseManager+PortfolioThemeAssetUpdates.ensurePortfolioThemeAssetUpdateTable

Notes
- No migration files changed; historical migrations remain intact.
- Existing API remains: PortfolioThemeUpdate.UpdateType and PortfolioThemeAssetUpdate.UpdateType still resolve via typealias.

Impact
- Reduces maintenance overhead when adding new update types.
- Prevents DB/runtime drift for allowed values in new environments.