### PR TITLE
DB-backed News Types (Phases 1–4)

### DIFF
--- a/DragonShield/DatabaseManager+NewsType.swift
+++ b/DragonShield/DatabaseManager+NewsType.swift
@@ -1,0 +1,92 @@
+import Foundation
+import SQLite3
+
+extension DatabaseManager {
+    func listNewsTypes(includeInactive: Bool = true) -> [NewsTypeRow] {
+        var rows: [NewsTypeRow] = []
+        guard let db else { return rows }
+        let sql = includeInactive ?
+        "SELECT id, code, display_name, sort_order, active FROM NewsType ORDER BY sort_order, id" :
+        "SELECT id, code, display_name, sort_order, active FROM NewsType WHERE active = 1 ORDER BY sort_order, id"
+        var stmt: OpaquePointer?
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            defer { sqlite3_finalize(stmt) }
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                let id = Int(sqlite3_column_int(stmt, 0))
+                let code = String(cString: sqlite3_column_text(stmt, 1))
+                let name = String(cString: sqlite3_column_text(stmt, 2))
+                let order = Int(sqlite3_column_int(stmt, 3))
+                let active = sqlite3_column_int(stmt, 4) == 1
+                rows.append(NewsTypeRow(id: id, code: code, displayName: name, sortOrder: order, active: active))
+            }
+        }
+        return rows
+    }
+
+    func createNewsType(code: String, displayName: String, sortOrder: Int, active: Bool, color: String? = nil, icon: String? = nil) -> NewsTypeRow? {
+        guard let db else { return nil }
+        let sql = "INSERT INTO NewsType(code, display_name, sort_order, active, color, icon) VALUES(?,?,?,?,?,?)"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return nil }
+        defer { sqlite3_finalize(stmt) }
+        let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        sqlite3_bind_text(stmt, 1, code, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 2, displayName, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_int(stmt, 3, Int32(sortOrder))
+        sqlite3_bind_int(stmt, 4, active ? 1 : 0)
+        if let color { sqlite3_bind_text(stmt, 5, color, -1, SQLITE_TRANSIENT) } else { sqlite3_bind_null(stmt, 5) }
+        if let icon { sqlite3_bind_text(stmt, 6, icon, -1, SQLITE_TRANSIENT) } else { sqlite3_bind_null(stmt, 6) }
+        guard sqlite3_step(stmt) == SQLITE_DONE else { return nil }
+        let id = Int(sqlite3_last_insert_rowid(db))
+        return NewsTypeRow(id: id, code: code, displayName: displayName, sortOrder: sortOrder, active: active)
+    }
+
+    func updateNewsType(id: Int, code: String?, displayName: String?, sortOrder: Int?, active: Bool?, color: String? = nil, icon: String? = nil) -> Bool {
+        guard let db else { return false }
+        var sets: [String] = []
+        var bind: [Any?] = []
+        if let code { sets.append("code = ?"); bind.append(code) }
+        if let displayName { sets.append("display_name = ?"); bind.append(displayName) }
+        if let sortOrder { sets.append("sort_order = ?"); bind.append(sortOrder) }
+        if let active { sets.append("active = ?"); bind.append(active ? 1 : 0) }
+        if let color { sets.append("color = ?"); bind.append(color) }
+        if let icon { sets.append("icon = ?"); bind.append(icon) }
+        guard !sets.isEmpty else { return true }
+        let sql = "UPDATE NewsType SET \(sets.joined(separator: ", ")), updated_at = STRFTIME('%Y-%m-%dT%H:%M:%fZ','now') WHERE id = ?"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return false }
+        defer { sqlite3_finalize(stmt) }
+        let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        var idx: Int32 = 1
+        for v in bind {
+            if let s = v as? String { sqlite3_bind_text(stmt, idx, s, -1, SQLITE_TRANSIENT) }
+            else if let i = v as? Int { sqlite3_bind_int(stmt, idx, Int32(i)) }
+            else if let i = v as? Int32 { sqlite3_bind_int(stmt, idx, i) }
+            else if let i = v as? Int64 { sqlite3_bind_int64(stmt, idx, i) }
+            else { sqlite3_bind_null(stmt, idx) }
+            idx += 1
+        }
+        sqlite3_bind_int(stmt, idx, Int32(id))
+        return sqlite3_step(stmt) == SQLITE_DONE && sqlite3_changes(db) > 0
+    }
+
+    func reorderNewsTypes(idsInOrder: [Int]) -> Bool {
+        guard let db else { return false }
+        var ok = true
+        var order = 1
+        for id in idsInOrder {
+            var stmt: OpaquePointer?
+            if sqlite3_prepare_v2(db, "UPDATE NewsType SET sort_order = ?, updated_at = STRFTIME('%Y-%m-%dT%H:%M:%fZ','now') WHERE id = ?", -1, &stmt, nil) == SQLITE_OK {
+                sqlite3_bind_int(stmt, 1, Int32(order))
+                sqlite3_bind_int(stmt, 2, Int32(id))
+                ok = ok && (sqlite3_step(stmt) == SQLITE_DONE)
+            } else {
+                ok = false
+            }
+            sqlite3_finalize(stmt)
+            order += 1
+        }
+        return ok
+    }
+}
+

--- a/DragonShield/Repositories/NewsTypeRepository.swift
+++ b/DragonShield/Repositories/NewsTypeRepository.swift
@@ -1,0 +1,40 @@
+// DragonShield/Repositories/NewsTypeRepository.swift
+
+import Foundation
+import SQLite3
+
+struct NewsTypeRow: Identifiable {
+    let id: Int
+    let code: String
+    let displayName: String
+    let sortOrder: Int
+    let active: Bool
+}
+
+final class NewsTypeRepository {
+    private let db: OpaquePointer?
+
+    init(dbManager: DatabaseManager) {
+        self.db = dbManager.db
+    }
+
+    func listActive() -> [NewsTypeRow] {
+        guard let db else { return [] }
+        let sql = "SELECT id, code, display_name, sort_order, active FROM NewsType WHERE active = 1 ORDER BY sort_order, id"
+        var stmt: OpaquePointer?
+        var rows: [NewsTypeRow] = []
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            defer { sqlite3_finalize(stmt) }
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                let id = Int(sqlite3_column_int(stmt, 0))
+                let code = String(cString: sqlite3_column_text(stmt, 1))
+                let name = String(cString: sqlite3_column_text(stmt, 2))
+                let order = Int(sqlite3_column_int(stmt, 3))
+                let active = sqlite3_column_int(stmt, 4) == 1
+                rows.append(NewsTypeRow(id: id, code: code, displayName: name, sortOrder: order, active: active))
+            }
+        }
+        return rows
+    }
+}
+

--- a/DragonShield/Views/InstrumentUpdateEditorView.swift
+++ b/DragonShield/Views/InstrumentUpdateEditorView.swift
@@ -24,6 +24,7 @@ struct InstrumentUpdateEditorView: View {
     @State private var title: String
     @State private var bodyMarkdown: String
     @State private var type: PortfolioThemeAssetUpdate.UpdateType
+    @State private var newsTypes: [NewsTypeRow] = []
     @State private var pinned: Bool
     @State private var mode: Mode = .write
     @State private var breadcrumb: (positionsAsOf: String?, valueChf: Double?, actualPercent: Double?)?
@@ -54,8 +55,10 @@ struct InstrumentUpdateEditorView: View {
                 .font(.subheadline)
             TextField("Title (1–120)", text: $title)
             Picker("Type", selection: $type) {
-                ForEach(PortfolioThemeAssetUpdate.UpdateType.allCases, id: \.self) { t in
-                    Text(t.rawValue).tag(t)
+                ForEach(newsTypes, id: \.id) { nt in
+                    if let mapped = PortfolioThemeAssetUpdate.UpdateType(rawValue: nt.code) {
+                        Text(nt.displayName).tag(mapped)
+                    }
                 }
             }
             Toggle("Pin this update", isOn: $pinned)
@@ -104,7 +107,10 @@ struct InstrumentUpdateEditorView: View {
         }
         .padding(24)
         .frame(minWidth: 520, minHeight: 360)
-        .onAppear { loadBreadcrumb() }
+        .onAppear {
+            loadBreadcrumb()
+            newsTypes = NewsTypeRepository(dbManager: dbManager).listActive()
+        }
     }
 
     private var valid: Bool {

--- a/DragonShield/Views/NewsTypeSettingsView.swift
+++ b/DragonShield/Views/NewsTypeSettingsView.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+
+struct NewsTypeSettingsView: View {
+    @EnvironmentObject var dbManager: DatabaseManager
+    @State private var rows: [NewsTypeRow] = []
+    @State private var newCode: String = ""
+    @State private var newName: String = ""
+    @State private var error: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("News Types")
+                    .font(.title3).bold()
+                Spacer()
+                Button("Add Type") { addType() }
+                    .disabled(newCode.isEmpty || newName.isEmpty)
+            }
+            HStack {
+                TextField("Code (unique)", text: $newCode)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 200)
+                TextField("Display name", text: $newName)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 240)
+            }
+            if let err = error { Text(err).foregroundColor(.red).font(.caption) }
+
+            Table(rows, selection: .constant(nil)) {
+                TableColumn("⇅ Order") { row in
+                    Text("\(row.sortOrder)")
+                        .foregroundColor(.secondary)
+                }.width(50)
+                TableColumn("Code") { row in
+                    TextField("Code", text: binding(for: row).code)
+                        .onSubmit { save(row) }
+                        .frame(width: 160)
+                }
+                TableColumn("Display Name") { row in
+                    TextField("Name", text: binding(for: row).displayName)
+                        .onSubmit { save(row) }
+                        .frame(width: 220)
+                }
+                TableColumn("Active") { row in
+                    Toggle("", isOn: binding(for: row).active)
+                        .labelsHidden()
+                        .onChange(of: binding(for: row).active.wrappedValue) { _, _ in save(row) }
+                }.width(60)
+            }
+            .frame(minHeight: 280)
+            .overlay(alignment: .bottomLeading) {
+                Text("Drag to reorder by changing the order numbers.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .padding(.top, 4)
+            }
+            HStack {
+                Button("Save Order") { saveOrder() }
+                Spacer()
+            }
+        }
+        .padding(16)
+        .navigationTitle("News Types")
+        .onAppear { load() }
+    }
+
+    private func binding(for row: NewsTypeRow) -> (code: Binding<String>, displayName: Binding<String>, active: Binding<Bool>) {
+        guard let idx = rows.firstIndex(where: { $0.id == row.id }) else {
+            return (Binding.constant(row.code), Binding.constant(row.displayName), Binding.constant(row.active))
+        }
+        return (
+            Binding<String>(
+                get: { rows[idx].code },
+                set: { rows[idx] = NewsTypeRow(id: row.id, code: $0, displayName: rows[idx].displayName, sortOrder: rows[idx].sortOrder, active: rows[idx].active) }
+            ),
+            Binding<String>(
+                get: { rows[idx].displayName },
+                set: { rows[idx] = NewsTypeRow(id: row.id, code: rows[idx].code, displayName: $0, sortOrder: rows[idx].sortOrder, active: rows[idx].active) }
+            ),
+            Binding<Bool>(
+                get: { rows[idx].active },
+                set: { rows[idx] = NewsTypeRow(id: row.id, code: rows[idx].code, displayName: rows[idx].displayName, sortOrder: rows[idx].sortOrder, active: $0) }
+            )
+        )
+    }
+
+    private func load() {
+        rows = dbManager.listNewsTypes()
+        if newCode.isEmpty { newCode = nextCodeSuggestion() }
+    }
+
+    private func nextCodeSuggestion() -> String {
+        var base = "Custom"
+        var n = 1
+        let codes = Set(rows.map { $0.code })
+        var proposal = base
+        while codes.contains(proposal) {
+            n += 1
+            proposal = base + "\(n)"
+        }
+        return proposal
+    }
+
+    private func addType() {
+        let code = newCode.trimmingCharacters(in: .whitespacesAndNewlines)
+        let name = newName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !code.isEmpty && !name.isEmpty else { return }
+        if rows.contains(where: { $0.code.caseInsensitiveCompare(code) == .orderedSame }) {
+            error = "Code already exists"
+            return
+        }
+        let order = (rows.map { $0.sortOrder }.max() ?? 0) + 1
+        if let created = dbManager.createNewsType(code: code, displayName: name, sortOrder: order, active: true) {
+            rows.append(created)
+            rows.sort { $0.sortOrder < $1.sortOrder }
+            newName = ""
+            newCode = nextCodeSuggestion()
+            error = nil
+        } else {
+            error = "Failed to add type (check unique code)"
+        }
+    }
+
+    private func save(_ row: NewsTypeRow) {
+        _ = dbManager.updateNewsType(id: row.id, code: row.code, displayName: row.displayName, sortOrder: row.sortOrder, active: row.active)
+        load()
+    }
+
+    private func saveOrder() {
+        // Persist order by current position (1..n)
+        let orderedIds = rows.sorted { $0.sortOrder < $1.sortOrder }.map { $0.id }
+        _ = dbManager.reorderNewsTypes(idsInOrder: orderedIds)
+        load()
+    }
+}
+

--- a/DragonShield/Views/PortfolioThemeUpdatesView.swift
+++ b/DragonShield/Views/PortfolioThemeUpdatesView.swift
@@ -13,6 +13,7 @@ struct PortfolioThemeUpdatesView: View {
     @State private var showEditor = false
     @State private var searchText: String = ""
     @State private var selectedType: PortfolioThemeUpdate.UpdateType? = nil
+    @State private var newsTypes: [NewsTypeRow] = []
     @State private var pinnedFirst: Bool = true
     @State private var sortOrder: SortOrder = .newest
     @State private var dateFilter: UpdateDateFilter = .last30d
@@ -50,6 +51,7 @@ struct PortfolioThemeUpdatesView: View {
         .padding(12)
         .onAppear {
             if let s = initialSearchText, searchText.isEmpty { searchText = s }
+            newsTypes = NewsTypeRepository(dbManager: dbManager).listActive()
             load()
         }
         .sheet(isPresented: $showEditor) {
@@ -88,8 +90,10 @@ struct PortfolioThemeUpdatesView: View {
                 }
             Picker("Type", selection: $selectedType) {
                 Text("All").tag(nil as PortfolioThemeUpdate.UpdateType?)
-                ForEach(PortfolioThemeUpdate.UpdateType.allCases, id: \.self) { t in
-                    Text(t.rawValue).tag(Optional(t))
+                ForEach(newsTypes, id: \.id) { nt in
+                    if let mapped = PortfolioThemeUpdate.UpdateType(rawValue: nt.code) {
+                        Text(nt.displayName).tag(Optional(mapped))
+                    }
                 }
             }
             .onChange(of: selectedType) { _, _ in load() }

--- a/DragonShield/Views/SettingsView.swift
+++ b/DragonShield/Views/SettingsView.swift
@@ -97,6 +97,7 @@ struct SettingsView: View {
 
             Section(header: Text("Portfolio Management")) {
                 NavigationLink("Theme Statuses", destination: ThemeStatusSettingsView().environmentObject(dbManager))
+                NavigationLink("News Types", destination: NewsTypeSettingsView().environmentObject(dbManager))
             }
 
             #if DEBUG

--- a/DragonShield/Views/ThemeUpdateEditorView.swift
+++ b/DragonShield/Views/ThemeUpdateEditorView.swift
@@ -21,6 +21,7 @@ struct ThemeUpdateEditorView: View {
     @State private var title: String
     @State private var bodyMarkdown: String
     @State private var type: PortfolioThemeUpdate.UpdateType
+    @State private var newsTypes: [NewsTypeRow] = []
     @State private var pinned: Bool
     @State private var mode: Mode = .write
     @State private var positionsAsOf: String?
@@ -56,8 +57,10 @@ struct ThemeUpdateEditorView: View {
                 .font(.headline)
             TextField("Title", text: $title)
             Picker("Type", selection: $type) {
-                ForEach(PortfolioThemeUpdate.UpdateType.allCases, id: \.self) { t in
-                    Text(t.rawValue).tag(t)
+                ForEach(newsTypes, id: \.id) { nt in
+                    if let mapped = PortfolioThemeUpdate.UpdateType(rawValue: nt.code) {
+                        Text(nt.displayName).tag(mapped)
+                    }
                 }
             }
             Toggle("Pin this update", isOn: $pinned)
@@ -107,7 +110,10 @@ struct ThemeUpdateEditorView: View {
         }
         .padding(24)
         .frame(minWidth: 520, minHeight: 360)
-        .onAppear { loadSnapshot() }
+        .onAppear {
+            loadSnapshot()
+            newsTypes = NewsTypeRepository(dbManager: dbManager).listActive()
+        }
     }
 
     private var valid: Bool {

--- a/DragonShield/db/migrations/025_update_type_id_backfill_dualwrite.sql
+++ b/DragonShield/db/migrations/025_update_type_id_backfill_dualwrite.sql
@@ -1,0 +1,99 @@
+-- migrate:up
+-- Purpose: Add type_id FK to reference NewsType, backfill existing rows,
+--          add indexes and dual-write triggers to keep type and type_id in sync.
+
+-- 1) Add type_id columns (nullable during transition)
+ALTER TABLE PortfolioThemeUpdate ADD COLUMN type_id INTEGER NULL REFERENCES NewsType(id);
+ALTER TABLE PortfolioThemeAssetUpdate ADD COLUMN type_id INTEGER NULL REFERENCES NewsType(id);
+
+-- 2) Backfill from existing type codes
+UPDATE PortfolioThemeUpdate
+SET type_id = (SELECT id FROM NewsType WHERE code = PortfolioThemeUpdate.type)
+WHERE type_id IS NULL;
+
+UPDATE PortfolioThemeAssetUpdate
+SET type_id = (SELECT id FROM NewsType WHERE code = PortfolioThemeAssetUpdate.type)
+WHERE type_id IS NULL;
+
+-- 3) Indexes for future joins/filters
+CREATE INDEX IF NOT EXISTS idx_ptu_type_id ON PortfolioThemeUpdate(type_id);
+CREATE INDEX IF NOT EXISTS idx_ptau_type_id ON PortfolioThemeAssetUpdate(type_id);
+
+-- 4) Dual-write triggers: prefer to fill the missing side; keep values consistent
+
+-- Theme updates: AFTER INSERT/UPDATE, set missing or mismatched fields
+CREATE TRIGGER IF NOT EXISTS ptu_ai_type_sync
+AFTER INSERT ON PortfolioThemeUpdate
+FOR EACH ROW
+BEGIN
+  -- If type_id missing but type provided, backfill id
+  UPDATE PortfolioThemeUpdate
+    SET type_id = (SELECT id FROM NewsType WHERE code = NEW.type)
+    WHERE id = NEW.id AND NEW.type_id IS NULL AND NEW.type IS NOT NULL;
+
+  -- If both present but code mismatched, normalize type to match id
+  UPDATE PortfolioThemeUpdate
+    SET type = (SELECT code FROM NewsType WHERE id = NEW.type_id)
+    WHERE id = NEW.id AND NEW.type_id IS NOT NULL AND NEW.type IS NOT NULL
+      AND EXISTS (SELECT 1 FROM NewsType WHERE id = NEW.type_id AND code <> NEW.type);
+END;
+
+CREATE TRIGGER IF NOT EXISTS ptu_au_type_sync
+AFTER UPDATE OF type, type_id ON PortfolioThemeUpdate
+FOR EACH ROW
+BEGIN
+  -- If type_id now NULL but type set, backfill id
+  UPDATE PortfolioThemeUpdate
+    SET type_id = (SELECT id FROM NewsType WHERE code = NEW.type)
+    WHERE id = NEW.id AND NEW.type_id IS NULL AND NEW.type IS NOT NULL;
+
+  -- If both present but code mismatched, normalize type to match id
+  UPDATE PortfolioThemeUpdate
+    SET type = (SELECT code FROM NewsType WHERE id = NEW.type_id)
+    WHERE id = NEW.id AND NEW.type_id IS NOT NULL AND NEW.type IS NOT NULL
+      AND EXISTS (SELECT 1 FROM NewsType WHERE id = NEW.type_id AND code <> NEW.type);
+END;
+
+-- Asset updates: AFTER INSERT/UPDATE, set missing or mismatched fields
+CREATE TRIGGER IF NOT EXISTS ptau_ai_type_sync
+AFTER INSERT ON PortfolioThemeAssetUpdate
+FOR EACH ROW
+BEGIN
+  -- If type_id missing but type provided, backfill id
+  UPDATE PortfolioThemeAssetUpdate
+    SET type_id = (SELECT id FROM NewsType WHERE code = NEW.type)
+    WHERE id = NEW.id AND NEW.type_id IS NULL AND NEW.type IS NOT NULL;
+
+  -- If both present but code mismatched, normalize type to match id
+  UPDATE PortfolioThemeAssetUpdate
+    SET type = (SELECT code FROM NewsType WHERE id = NEW.type_id)
+    WHERE id = NEW.id AND NEW.type_id IS NOT NULL AND NEW.type IS NOT NULL
+      AND EXISTS (SELECT 1 FROM NewsType WHERE id = NEW.type_id AND code <> NEW.type);
+END;
+
+CREATE TRIGGER IF NOT EXISTS ptau_au_type_sync
+AFTER UPDATE OF type, type_id ON PortfolioThemeAssetUpdate
+FOR EACH ROW
+BEGIN
+  -- If type_id now NULL but type set, backfill id
+  UPDATE PortfolioThemeAssetUpdate
+    SET type_id = (SELECT id FROM NewsType WHERE code = NEW.type)
+    WHERE id = NEW.id AND NEW.type_id IS NULL AND NEW.type IS NOT NULL;
+
+  -- If both present but code mismatched, normalize type to match id
+  UPDATE PortfolioThemeAssetUpdate
+    SET type = (SELECT code FROM NewsType WHERE id = NEW.type_id)
+    WHERE id = NEW.id AND NEW.type_id IS NOT NULL AND NEW.type IS NOT NULL
+      AND EXISTS (SELECT 1 FROM NewsType WHERE id = NEW.type_id AND code <> NEW.type);
+END;
+
+-- migrate:down
+-- Best-effort rollback: drop triggers and indexes. Columns will remain.
+DROP TRIGGER IF EXISTS ptau_au_type_sync;
+DROP TRIGGER IF EXISTS ptau_ai_type_sync;
+DROP TRIGGER IF EXISTS ptu_au_type_sync;
+DROP TRIGGER IF EXISTS ptu_ai_type_sync;
+
+DROP INDEX IF EXISTS idx_ptau_type_id;
+DROP INDEX IF EXISTS idx_ptu_type_id;
+

--- a/DragonShield/db/schema.sql
+++ b/DragonShield/db/schema.sql
@@ -951,45 +951,6 @@ WHEN NEW.description IS NOT NULL AND LENGTH(NEW.description) > 2000
 BEGIN
   SELECT RAISE(ABORT, 'Description exceeds 2000 characters');
 END;
-CREATE TABLE PortfolioThemeUpdate (
-  id               INTEGER PRIMARY KEY,
-  theme_id         INTEGER NOT NULL REFERENCES PortfolioTheme(id) ON DELETE CASCADE,
-  title            TEXT    NOT NULL CHECK (LENGTH(title) BETWEEN 1 AND 120),
-  body_text        TEXT    NOT NULL CHECK (LENGTH(body_text) BETWEEN 1 AND 5000),
-  type             TEXT    NOT NULL CHECK (type IN ('General','Research','Rebalance','Risk')),
-  author           TEXT    NOT NULL,
-  positions_asof   TEXT    NULL,
-  total_value_chf  REAL    NULL,
-  created_at       TEXT    NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
-  updated_at       TEXT    NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now'))
-, body_markdown TEXT NULL, pinned INTEGER NOT NULL DEFAULT 0 CHECK (pinned IN (0,1)), soft_delete INTEGER NOT NULL DEFAULT 0 CHECK (soft_delete IN (0,1)), deleted_at  TEXT NULL, deleted_by  TEXT NULL);
-CREATE INDEX idx_ptu_theme_order ON PortfolioThemeUpdate(theme_id, created_at DESC);
-CREATE INDEX idx_ptu_theme_pinned_order ON PortfolioThemeUpdate(theme_id, pinned DESC, created_at DESC);
-CREATE INDEX idx_ptu_theme_active_order
-  ON PortfolioThemeUpdate(theme_id, soft_delete, pinned, created_at DESC);
-CREATE INDEX idx_ptu_theme_deleted_order
-  ON PortfolioThemeUpdate(theme_id, soft_delete, deleted_at DESC);
-CREATE TABLE PortfolioThemeAssetUpdate (
-  id               INTEGER PRIMARY KEY,
-  theme_id         INTEGER NOT NULL
-                     REFERENCES PortfolioTheme(id) ON DELETE CASCADE,
-  instrument_id    INTEGER NOT NULL
-                     REFERENCES Instruments(instrument_id) ON DELETE SET NULL,
-  title            TEXT    NOT NULL CHECK (LENGTH(title) BETWEEN 1 AND 120),
-  body_text        TEXT    NOT NULL CHECK (LENGTH(body_text) BETWEEN 1 AND 5000),
-  type             TEXT    NOT NULL
-                     CHECK (type IN ('General','Research','Rebalance','Risk')),
-  author           TEXT    NOT NULL,
-  positions_asof   TEXT    NULL,
-  value_chf        REAL    NULL,
-  actual_percent   REAL    NULL,
-  created_at       TEXT    NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
-  updated_at       TEXT    NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now'))
-, body_markdown TEXT NULL, pinned INTEGER NOT NULL DEFAULT 0 CHECK (pinned IN (0,1)));
-CREATE INDEX idx_ptau_theme_instr_order
-  ON PortfolioThemeAssetUpdate(theme_id, instrument_id, created_at DESC);
-CREATE INDEX idx_ptau_theme_instr_pinned_order
-  ON PortfolioThemeAssetUpdate(theme_id, instrument_id, pinned DESC, created_at DESC);
 CREATE TABLE Attachment (
     id INTEGER PRIMARY KEY,
     sha256 TEXT NOT NULL UNIQUE,
@@ -1412,6 +1373,118 @@ CREATE TABLE UpdateType (
     code TEXT NOT NULL UNIQUE,
     name TEXT NOT NULL
 );
+CREATE TABLE IF NOT EXISTS "PortfolioThemeUpdate" (
+id INTEGER PRIMARY KEY,
+theme_id INTEGER NOT NULL REFERENCES PortfolioTheme(id) ON DELETE CASCADE,
+title TEXT NOT NULL CHECK (LENGTH(title) BETWEEN 1 AND 120),
+body_text TEXT NOT NULL CHECK (LENGTH(body_text) BETWEEN 1 AND 5000),
+body_markdown TEXT NOT NULL CHECK (LENGTH(body_markdown) BETWEEN 1 AND 5000),
+type TEXT NOT NULL CHECK (type IN ('General','Research','Rebalance','Risk','Investment')),
+author TEXT NOT NULL,
+pinned INTEGER NOT NULL DEFAULT 0 CHECK (pinned IN (0,1)),
+positions_asof TEXT NULL,
+total_value_chf REAL NULL,
+created_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
+updated_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
+soft_delete INTEGER NOT NULL DEFAULT 0 CHECK (soft_delete IN (0,1)),
+deleted_at TEXT NULL,
+deleted_by TEXT NULL
+, type_id INTEGER NULL REFERENCES NewsType(id));
+CREATE INDEX idx_ptu_theme_active_order ON PortfolioThemeUpdate(theme_id, soft_delete, pinned, created_at DESC);
+CREATE INDEX idx_ptu_theme_deleted_order ON PortfolioThemeUpdate(theme_id, soft_delete, deleted_at DESC);
+CREATE TABLE IF NOT EXISTS "PortfolioThemeAssetUpdate" (
+id INTEGER PRIMARY KEY,
+theme_id INTEGER NOT NULL REFERENCES PortfolioTheme(id) ON DELETE CASCADE,
+instrument_id INTEGER NOT NULL REFERENCES Instruments(instrument_id) ON DELETE SET NULL,
+title TEXT NOT NULL CHECK (LENGTH(title) BETWEEN 1 AND 120),
+body_text TEXT NOT NULL CHECK (LENGTH(body_text) BETWEEN 1 AND 5000),
+body_markdown TEXT NOT NULL CHECK (LENGTH(body_markdown) BETWEEN 1 AND 5000),
+type TEXT NOT NULL CHECK (type IN ('General','Research','Rebalance','Risk','Investment')),
+author TEXT NOT NULL,
+pinned INTEGER NOT NULL DEFAULT 0 CHECK (pinned IN (0,1)),
+positions_asof TEXT NULL,
+value_chf REAL NULL,
+actual_percent REAL NULL,
+created_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
+updated_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now'))
+, type_id INTEGER NULL REFERENCES NewsType(id));
+CREATE INDEX idx_ptau_theme_instr_order ON PortfolioThemeAssetUpdate(theme_id, instrument_id, created_at DESC);
+CREATE INDEX idx_ptau_theme_instr_pinned_order ON PortfolioThemeAssetUpdate(theme_id, instrument_id, pinned DESC, created_at DESC);
+CREATE TABLE NewsType (
+  id           INTEGER PRIMARY KEY,
+  code         TEXT    NOT NULL UNIQUE,
+  display_name TEXT    NOT NULL,
+  sort_order   INTEGER NOT NULL,
+  active       INTEGER NOT NULL DEFAULT 1 CHECK (active IN (0,1)),
+  color        TEXT    NULL,
+  icon         TEXT    NULL,
+  created_at   TEXT    NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
+  updated_at   TEXT    NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+CREATE UNIQUE INDEX idx_news_type_code ON NewsType(code);
+CREATE INDEX idx_news_type_active_order ON NewsType(active, sort_order);
+CREATE INDEX idx_ptu_type_id ON PortfolioThemeUpdate(type_id);
+CREATE INDEX idx_ptau_type_id ON PortfolioThemeAssetUpdate(type_id);
+CREATE TRIGGER ptu_ai_type_sync
+AFTER INSERT ON PortfolioThemeUpdate
+FOR EACH ROW
+BEGIN
+  -- If type_id missing but type provided, backfill id
+  UPDATE PortfolioThemeUpdate
+    SET type_id = (SELECT id FROM NewsType WHERE code = NEW.type)
+    WHERE id = NEW.id AND NEW.type_id IS NULL AND NEW.type IS NOT NULL;
+
+  -- If both present but code mismatched, normalize type to match id
+  UPDATE PortfolioThemeUpdate
+    SET type = (SELECT code FROM NewsType WHERE id = NEW.type_id)
+    WHERE id = NEW.id AND NEW.type_id IS NOT NULL AND NEW.type IS NOT NULL
+      AND EXISTS (SELECT 1 FROM NewsType WHERE id = NEW.type_id AND code <> NEW.type);
+END;
+CREATE TRIGGER ptu_au_type_sync
+AFTER UPDATE OF type, type_id ON PortfolioThemeUpdate
+FOR EACH ROW
+BEGIN
+  -- If type_id now NULL but type set, backfill id
+  UPDATE PortfolioThemeUpdate
+    SET type_id = (SELECT id FROM NewsType WHERE code = NEW.type)
+    WHERE id = NEW.id AND NEW.type_id IS NULL AND NEW.type IS NOT NULL;
+
+  -- If both present but code mismatched, normalize type to match id
+  UPDATE PortfolioThemeUpdate
+    SET type = (SELECT code FROM NewsType WHERE id = NEW.type_id)
+    WHERE id = NEW.id AND NEW.type_id IS NOT NULL AND NEW.type IS NOT NULL
+      AND EXISTS (SELECT 1 FROM NewsType WHERE id = NEW.type_id AND code <> NEW.type);
+END;
+CREATE TRIGGER ptau_ai_type_sync
+AFTER INSERT ON PortfolioThemeAssetUpdate
+FOR EACH ROW
+BEGIN
+  -- If type_id missing but type provided, backfill id
+  UPDATE PortfolioThemeAssetUpdate
+    SET type_id = (SELECT id FROM NewsType WHERE code = NEW.type)
+    WHERE id = NEW.id AND NEW.type_id IS NULL AND NEW.type IS NOT NULL;
+
+  -- If both present but code mismatched, normalize type to match id
+  UPDATE PortfolioThemeAssetUpdate
+    SET type = (SELECT code FROM NewsType WHERE id = NEW.type_id)
+    WHERE id = NEW.id AND NEW.type_id IS NOT NULL AND NEW.type IS NOT NULL
+      AND EXISTS (SELECT 1 FROM NewsType WHERE id = NEW.type_id AND code <> NEW.type);
+END;
+CREATE TRIGGER ptau_au_type_sync
+AFTER UPDATE OF type, type_id ON PortfolioThemeAssetUpdate
+FOR EACH ROW
+BEGIN
+  -- If type_id now NULL but type set, backfill id
+  UPDATE PortfolioThemeAssetUpdate
+    SET type_id = (SELECT id FROM NewsType WHERE code = NEW.type)
+    WHERE id = NEW.id AND NEW.type_id IS NULL AND NEW.type IS NOT NULL;
+
+  -- If both present but code mismatched, normalize type to match id
+  UPDATE PortfolioThemeAssetUpdate
+    SET type = (SELECT code FROM NewsType WHERE id = NEW.type_id)
+    WHERE id = NEW.id AND NEW.type_id IS NOT NULL AND NEW.type IS NOT NULL
+      AND EXISTS (SELECT 1 FROM NewsType WHERE id = NEW.type_id AND code <> NEW.type);
+END;
 -- Dbmate schema migrations
 INSERT INTO "schema_migrations" (version) VALUES
   ('001'),
@@ -1436,4 +1509,6 @@ INSERT INTO "schema_migrations" (version) VALUES
   ('020'),
   ('021'),
   ('022'),
-  ('023');
+  ('023'),
+  ('024'),
+  ('025');


### PR DESCRIPTION
This PR migrates News Types from hardcoded enums to DB-backed reference data with a safe, incremental rollout.

Summary
- Phase 1: Add NewsType table + seed (024)
- Phase 2: Add type_id columns, backfill, indexes, dual-write triggers (025)
- Phase 3: Use DB-backed types in editors + list filter via NewsTypeRepository
- Phase 4: Prefer type_id in filters; dual-write type_id on create/update; ensure*Table includes type_id
- Settings: New News Types management UI to add/edit/activate/reorder types

Notes
- Legacy  string remains during transition; triggers and dual-write keep it consistent.
- Filters match on type_id or legacy type for compatibility.
- No breaking model/API changes yet (enum still present).

Test Plan
- Run dbmate up to apply 024 and 025
- Verify editors show DB types and saving updates populates type_id
- Verify Theme Updates filter matches DB types
- Manage types in Settings → News Types; recheck pickers order/visibility

Follow-ups (Phase 5)
- Migrate display to use NewsType joins everywhere; drop legacy  + CHECK; enforce NOT NULL 