### PR TITLE
Re-engineer Portfolio Themes: Phase 1 — Tabbed Workspace

### DIFF
--- a/DragonShield/Views/PortfolioThemeWorkspaceView.swift
+++ b/DragonShield/Views/PortfolioThemeWorkspaceView.swift
@@ -1,0 +1,430 @@
+// DragonShield/Views/PortfolioThemeWorkspaceView.swift
+// New Tabbed Workspace for Portfolio Theme details (Option 2)
+
+import SwiftUI
+#if canImport(Charts)
+import Charts
+#endif
+
+struct PortfolioThemeWorkspaceView: View {
+    @EnvironmentObject var dbManager: DatabaseManager
+    let themeId: Int
+    let origin: String
+
+    enum WorkspaceTab: String, CaseIterable, Identifiable {
+        case overview
+        case holdings
+        case analytics
+        case updates
+        case settings
+
+        var id: String { rawValue }
+        var label: String {
+            switch self {
+            case .overview: return "Overview"
+            case .holdings: return "Holdings"
+            case .analytics: return "Analytics"
+            case .updates: return "Updates"
+            case .settings: return "Settings"
+            }
+        }
+        var systemImage: String {
+            switch self {
+            case .overview: return "rectangle.grid.2x2"
+            case .holdings: return "list.bullet.rectangle"
+            case .analytics: return "chart.bar"
+            case .updates: return "doc.text"
+            case .settings: return "gearshape"
+            }
+        }
+    }
+
+    @AppStorage(UserDefaultsKeys.portfolioThemeWorkspaceLastTab) private var lastTabRaw: String = WorkspaceTab.overview.rawValue
+    @State private var selectedTab: WorkspaceTab = .overview
+
+    @State private var theme: PortfolioTheme?
+    @State private var valuation: ValuationSnapshot?
+    @State private var loadingValuation = false
+    @State private var showClassicDetail = false
+
+    // Meta editing (Settings tab)
+    @State private var name: String = ""
+    @State private var code: String = ""
+    @State private var statusId: Int = 0
+    @State private var statuses: [PortfolioThemeStatus] = []
+    @State private var descriptionText: String = ""
+    @State private var institutionId: Int? = nil
+    @State private var institutions: [DatabaseManager.InstitutionData] = []
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                // Header strip
+                header
+                Divider()
+                // Tabs content
+                TabView(selection: $selectedTab) {
+                    overviewTab
+                        .tag(WorkspaceTab.overview)
+                        .tabItem { Label(WorkspaceTab.overview.label, systemImage: WorkspaceTab.overview.systemImage) }
+                    holdingsTab
+                        .tag(WorkspaceTab.holdings)
+                        .tabItem { Label(WorkspaceTab.holdings.label, systemImage: WorkspaceTab.holdings.systemImage) }
+                    analyticsTab
+                        .tag(WorkspaceTab.analytics)
+                        .tabItem { Label(WorkspaceTab.analytics.label, systemImage: WorkspaceTab.analytics.systemImage) }
+                    updatesTab
+                        .tag(WorkspaceTab.updates)
+                        .tabItem { Label(WorkspaceTab.updates.label, systemImage: WorkspaceTab.updates.systemImage) }
+                    settingsTab
+                        .tag(WorkspaceTab.settings)
+                        .tabItem { Label(WorkspaceTab.settings.label, systemImage: WorkspaceTab.settings.systemImage) }
+                }
+            }
+            .navigationTitle("Theme Workspace: \(name)")
+        }
+        .frame(minWidth: 1200, idealWidth: 1400, minHeight: 720, idealHeight: 800)
+        .onAppear {
+            selectedTab = WorkspaceTab(rawValue: lastTabRaw) ?? .overview
+            loadTheme()
+            runValuation()
+        }
+        .onChange(of: selectedTab) { _, newValue in
+            lastTabRaw = newValue.rawValue
+            if newValue == .overview || newValue == .analytics || newValue == .holdings { runValuation() }
+        }
+        .sheet(isPresented: $showClassicDetail) {
+            PortfolioThemeDetailView(themeId: themeId, origin: origin) { _ in } onArchive: {} onUnarchive: { _ in } onSoftDelete: {}
+                .environmentObject(dbManager)
+        }
+    }
+
+    // MARK: - Header
+    private var header: some View {
+        HStack(alignment: .center) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(name.isEmpty ? "—" : name)
+                    .font(.title2).bold()
+                HStack(spacing: 12) {
+                    Tag(text: code)
+                    if let t = theme, let archived = t.archivedAt {
+                        Tag(text: "Archived: \(archived)", color: .orange)
+                    }
+                }
+            }
+            Spacer()
+            HStack(spacing: 16) {
+                Button(role: .none) { runValuation() } label: {
+                    Label("Refresh", systemImage: "arrow.clockwise")
+                }
+                Button { showClassicDetail = true } label: {
+                    Label("Open Classic", systemImage: "square.on.square")
+                }
+                .help("Open the classic detail editor for full controls")
+            }
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+    }
+
+    // MARK: - Tabs
+    private var overviewTab: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                kpiRow
+                #if canImport(Charts)
+                HStack(alignment: .top, spacing: 16) {
+                    actualAllocationDonut
+                    deltasBar
+                }
+                #endif
+            }
+            .padding(20)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var holdingsTab: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Holdings").font(.headline)
+                Spacer()
+                Button { showClassicDetail = true } label: { Label("Edit in Classic", systemImage: "pencil") }
+            }
+            HoldingsTable(themeId: themeId)
+                .environmentObject(dbManager)
+        }
+        .padding(20)
+    }
+
+    private var analyticsTab: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Analytics").font(.headline)
+                Text("Early preview: basic allocation analytics below. More coming soon (currency exposure, contribution, factor buckets).")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                #if canImport(Charts)
+                actualAllocationDonut
+                #endif
+            }
+            .padding(20)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var updatesTab: some View {
+        PortfolioThemeUpdatesView(themeId: themeId, initialSearchText: nil, searchHint: nil)
+            .environmentObject(dbManager)
+    }
+
+    private var settingsTab: some View {
+        Form {
+            Section(header: Text("Theme")) {
+                HStack { Text("Name"); Spacer(); TextField("", text: $name).frame(width: 320) }
+                HStack { Text("Code"); Spacer(); Text(code).foregroundColor(.secondary) }
+                HStack {
+                    Text("Status"); Spacer()
+                    Picker("", selection: $statusId) {
+                        ForEach(statuses) { s in Text(s.name).tag(s.id) }
+                    }
+                    .labelsHidden().frame(width: 240)
+                }
+                HStack {
+                    Text("Institution"); Spacer()
+                    Picker("", selection: $institutionId) {
+                        Text("None").tag(nil as Int?)
+                        ForEach(institutions) { inst in Text(inst.name).tag(inst.id as Int?) }
+                    }
+                    .labelsHidden().frame(width: 240)
+                }
+                VStack(alignment: .leading) {
+                    Text("Description")
+                    TextEditor(text: $descriptionText)
+                        .frame(minHeight: 100)
+                        .overlay(RoundedRectangle(cornerRadius: 6).stroke(Color.gray.opacity(0.2)))
+                }
+                HStack {
+                    Spacer()
+                    Button("Save Changes") { saveTheme() }.keyboardShortcut(.defaultAction)
+                }
+            }
+            if let t = theme, t.archivedAt == nil {
+                Section(header: Text("Actions")) {
+                    Button("Archive in Classic…", role: .destructive) { showClassicDetail = true }
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .padding(.vertical, 8)
+        .padding(.horizontal, 12)
+    }
+
+    // MARK: - Overview widgets
+    private var kpiRow: some View {
+        HStack(spacing: 12) {
+            KPI(title: "Total Value (\(dbManager.baseCurrency))", value: currency(valuation?.totalValueBase))
+            KPI(title: "Instruments", value: String(theme?.instrumentCount ?? 0))
+            KPI(title: "Positions as of", value: dateStr(valuation?.positionsAsOf))
+            KPI(title: "FX as of", value: dateStr(valuation?.fxAsOf))
+            if let v = valuation, v.excludedFxCount > 0 || v.excludedPriceCount > 0 {
+                KPI(title: "Excluded", value: "FX \(v.excludedFxCount) / Price \(v.excludedPriceCount)", accent: .orange)
+            }
+        }
+    }
+
+    #if canImport(Charts)
+    private var actualAllocationDonut: some View {
+        let rows = (valuation?.rows ?? []).filter { $0.status == .ok && $0.actualPct > 0 }
+        let data = rows.map { (name: $0.instrumentName, value: $0.actualPct) }
+        let names = data.map { $0.name }
+        let palette: [Color] = [.blue, .green, .orange, .pink, .purple, .teal, .red, .mint, .indigo, .brown, .cyan, .yellow]
+        let colors: [Color] = names.enumerated().map { palette[$0.offset % palette.count] }
+        return VStack(alignment: .leading, spacing: 8) {
+            Text("Allocation by Actual %").font(.title3).bold()
+            HStack(alignment: .top, spacing: 16) {
+                Chart(data, id: \.name) { row in
+                    SectorMark(angle: .value("Actual %", row.value), innerRadius: .ratio(0.55), angularInset: 1.5)
+                        .foregroundStyle(by: .value("Instrument", row.name))
+                }
+                .chartForegroundStyleScale(domain: names, range: colors)
+                .chartXAxis(.hidden)
+                .chartYAxis(.hidden)
+                .chartLegend(.hidden)
+                .frame(height: 320)
+                VStack(alignment: .leading, spacing: 6) {
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 6) {
+                            ForEach(Array(names.enumerated()), id: \.0) { idx, name in
+                                HStack(spacing: 8) {
+                                    Circle().fill(colors[idx]).frame(width: 10, height: 10)
+                                    Text(shortName(name, max: 18)).font(.caption).lineLimit(1).help(name)
+                                }
+                            }
+                        }
+                    }
+                }
+                .frame(width: 220)
+            }
+        }
+    }
+
+    private var deltasBar: some View {
+        let items = (valuation?.rows ?? []).map { (name: $0.instrumentName, delta: ($0.deltaUserPct ?? 0)) }
+        return VStack(alignment: .leading, spacing: 8) {
+            Text("Delta (Actual − User %)").font(.title3).bold()
+            Chart(items, id: \.name) { it in
+                BarMark(x: .value("Delta", it.delta), y: .value("Instrument", it.name))
+                    .foregroundStyle(it.delta >= 0 ? Color.green.opacity(0.7) : Color.red.opacity(0.7))
+            }
+            .chartXAxisLabel("%", alignment: .trailing)
+            .frame(minWidth: 360, maxWidth: .infinity, minHeight: 320)
+        }
+    }
+    #endif
+
+    // MARK: - Data
+    private func loadTheme() {
+        guard let fetched = dbManager.getPortfolioTheme(id: themeId) else { return }
+        theme = fetched
+        name = fetched.name
+        code = fetched.code
+        statusId = fetched.statusId
+        descriptionText = fetched.description ?? ""
+        institutionId = fetched.institutionId
+        statuses = dbManager.fetchPortfolioThemeStatuses()
+        institutions = dbManager.fetchInstitutions()
+    }
+
+    private func runValuation() {
+        loadingValuation = true
+        Task {
+            let fxService = FXConversionService(dbManager: dbManager)
+            let service = PortfolioValuationService(dbManager: dbManager, fxService: fxService)
+            let snap = service.snapshot(themeId: themeId)
+            await MainActor.run {
+                self.valuation = snap
+                self.loadingValuation = false
+            }
+        }
+    }
+
+    private func saveTheme() {
+        guard var current = theme else { return }
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        current.name = trimmedName
+        current.statusId = statusId
+        let desc = descriptionText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if dbManager.updatePortfolioTheme(id: current.id, name: current.name, description: desc.isEmpty ? nil : desc, institutionId: institutionId, statusId: current.statusId, archivedAt: current.archivedAt) {
+            loadTheme()
+        }
+    }
+
+    // MARK: - Utils
+    private func currency(_ value: Double?) -> String {
+        guard let v = value else { return "—" }
+        return v.formatted(.currency(code: dbManager.baseCurrency).precision(.fractionLength(2)))
+    }
+
+    private func dateStr(_ date: Date?) -> String {
+        guard let d = date else { return "—" }
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd HH:mm"
+        f.timeZone = .current
+        return f.string(from: d)
+    }
+
+    private func shortName(_ s: String, max: Int) -> String {
+        if s.count <= max { return s }
+        let head = s.prefix(max - 1)
+        return head + "…"
+    }
+}
+
+// MARK: - Simple KPI view
+private struct KPI: View {
+    let title: String
+    let value: String
+    var accent: Color = .accentColor
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title).font(.caption).foregroundColor(.secondary)
+            Text(value).font(.system(size: 22, weight: .bold)).foregroundColor(accent)
+        }
+        .padding(12)
+        .frame(minWidth: 200, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Color.gray.opacity(0.06)))
+    }
+}
+
+// MARK: - Simple Tag view
+private struct Tag: View {
+    let text: String
+    var color: Color = .secondary
+    var body: some View {
+        Text(text)
+            .font(.caption)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(Capsule().stroke(color.opacity(0.8)))
+    }
+}
+
+// MARK: - Holdings Table (read-only summary)
+private struct HoldingsTable: View {
+    @EnvironmentObject var dbManager: DatabaseManager
+    let themeId: Int
+    @State private var rows: [ValuationRow] = []
+    @State private var total: Double = 0
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if rows.isEmpty {
+                Text("No holdings").foregroundColor(.secondary)
+            } else {
+                header
+                ScrollView {
+                    LazyVStack(spacing: 4) {
+                        ForEach(rows) { r in
+                            HStack(spacing: 8) {
+                                Text(r.instrumentName).frame(maxWidth: .infinity, alignment: .leading).lineLimit(1).truncationMode(.middle)
+                                Text(fmtPct(r.researchTargetPct)).frame(width: 80, alignment: .trailing)
+                                Text(fmtPct(r.userTargetPct)).frame(width: 80, alignment: .trailing)
+                                Text(fmtPct(r.actualPct)).frame(width: 80, alignment: .trailing)
+                                Text(fmtPct(r.deltaUserPct)).frame(width: 80, alignment: .trailing).foregroundColor((r.deltaUserPct ?? 0) >= 0 ? .green : .red)
+                            }
+                            .font(.system(.body, design: .monospaced))
+                        }
+                    }
+                }
+            }
+        }
+        .onAppear(perform: load)
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Text("Instrument").frame(maxWidth: .infinity, alignment: .leading)
+            Text("Research %").frame(width: 80, alignment: .trailing)
+            Text("User %").frame(width: 80, alignment: .trailing)
+            Text("Actual %").frame(width: 80, alignment: .trailing)
+            Text("Δ Actual-User").frame(width: 80, alignment: .trailing)
+        }
+        .font(.caption)
+        .foregroundColor(.secondary)
+    }
+
+    private func load() {
+        let fx = FXConversionService(dbManager: dbManager)
+        let service = PortfolioValuationService(dbManager: dbManager, fxService: fx)
+        let snap = service.snapshot(themeId: themeId)
+        rows = snap.rows.sorted { $0.instrumentName < $1.instrumentName }
+        total = snap.totalValueBase
+    }
+
+    private func fmtPct(_ v: Double?) -> String {
+        guard let x = v else { return "—" }
+        return String(format: "%.2f", x)
+    }
+}

--- a/DragonShield/Views/PortfolioThemesListView.swift
+++ b/DragonShield/Views/PortfolioThemesListView.swift
@@ -112,8 +112,13 @@ struct PortfolioThemesListView: View {
             .environmentObject(dbManager)
         }
         .sheet(item: $themeToOpen, onDismiss: loadData) { theme in
-            PortfolioThemeDetailView(themeId: theme.id, origin: detailOrigin, initialTab: detailInitialTab)
-                .environmentObject(dbManager)
+            if UserDefaults.standard.bool(forKey: UserDefaultsKeys.portfolioThemeWorkspaceEnabled) {
+                PortfolioThemeWorkspaceView(themeId: theme.id, origin: detailOrigin)
+                    .environmentObject(dbManager)
+            } else {
+                PortfolioThemeDetailView(themeId: theme.id, origin: detailOrigin, initialTab: detailInitialTab)
+                    .environmentObject(dbManager)
+            }
         }
         .alert("Delete Theme", isPresented: $showArchiveAlert) {
             Button("Archive and Delete") { archiveAndDelete() }

--- a/DragonShield/Views/SettingsView.swift
+++ b/DragonShield/Views/SettingsView.swift
@@ -20,6 +20,8 @@ struct SettingsView: View {
     private var runStartupHealthChecks: Bool = true
     @AppStorage("coingeckoPreferFree")
     private var coingeckoPreferFree: Bool = false
+    @AppStorage(UserDefaultsKeys.portfolioThemeWorkspaceEnabled)
+    private var portfolioThemeWorkspaceEnabled: Bool = false
 
 
     private var okCount: Int {
@@ -89,6 +91,11 @@ struct SettingsView: View {
                             }
                         ),
                         in: 0...8)
+            }
+
+            Section(header: Text("UI Experiments")) {
+                Toggle("Use new Portfolio Theme Workspace (beta)", isOn: $portfolioThemeWorkspaceEnabled)
+                    .help("Opens the new tabbed theme details view instead of the classic editor.")
             }
             
             Section(header: Text("Table Display Settings")) {

--- a/DragonShield/helpers/UserDefaultsKeys.swift
+++ b/DragonShield/helpers/UserDefaultsKeys.swift
@@ -22,6 +22,10 @@ struct UserDefaultsKeys {
     static let currenciesFxSegment = "currenciesFxSegment"
     /// Remember last-used tab in Portfolio Theme Details.
     static let portfolioThemeDetailLastTab = "portfolioThemeDetailLastTab"
+    /// Toggle to use the new Portfolio Theme Workspace (beta).
+    static let portfolioThemeWorkspaceEnabled = "portfolioThemeWorkspaceEnabled"
+    /// Remember last-used tab in the new Portfolio Theme Workspace.
+    static let portfolioThemeWorkspaceLastTab = "portfolioThemeWorkspaceLastTab"
     /// Persist window frame for import value report.
     static let importReportWindowFrame = "importReport.windowFrame"
 }


### PR DESCRIPTION
feat(theme-workspace): Phase 1 — new tabbed Portfolio Theme Workspace, feature toggle, and routing

Summary
- Adds a new tabbed Workspace for Portfolio Themes with Overview, Holdings, Analytics, Updates, and Settings.
- Introduces a Settings toggle to opt-in (keeps the classic detail editor intact).
- Routes from Themes list and Dashboard tiles respect the toggle.

Why
- Improve clarity and navigation (Option 2 — Tabbed Workspace) while preserving the existing flow for safety.

What’s Included
- New: `PortfolioThemeWorkspaceView` with KPI strip and basic Charts (allocation donut; delta bar).
- Holdings: Read-only summary table (edit actions still in classic for now).
- Updates: Reuses existing `PortfolioThemeUpdatesView`.
- Settings: Name, status, institution, description editing.
- Feature flag: `UserDefaultsKeys.portfolioThemeWorkspaceEnabled` + last tab persistence.

How to enable
- Settings → UI Experiments → “Use new Portfolio Theme Workspace (beta)”.
- Open any theme from Themes list or Dashboard → opens Workspace when enabled.
- Use “Open Classic” in header to jump back to the classic editor.

Testing notes
- Navigate themes with toggle on/off and ensure no regressions.
- Charts render only when the `Charts` framework is available.
- Confirm Updates tab behavior (create/edit/delete) unchanged.

Follow-ups (tracked for Phase 2)
- Inline editing & column controls in Holdings.
- Analytics: contribution by sector/asset class, currency exposure.
- Saved views, filters, keyboard shortcuts.

Checklist
- [x] New workspace view behind a toggle
- [x] Routing respects the toggle
- [x] Classic editor remains fully functional
- [ ] QA: navigation and basic charts
- [ ] QA: updates tab behavior parity
- [ ] Docs: brief note in README/Settings help

Notes
- This PR also contains current changes from the work-in-progress branch that Phase 1 was branched from.