### PR TITLE
Re-engineer Portfolio Themes: Phase 2C — Workspace Shortcuts

### DIFF
--- a/DragonShield/Views/PortfolioThemeWorkspaceView.swift
+++ b/DragonShield/Views/PortfolioThemeWorkspaceView.swift
@@ -117,10 +117,12 @@ struct PortfolioThemeWorkspaceView: View {
                 Button(role: .none) { runValuation() } label: {
                     Label("Refresh", systemImage: "arrow.clockwise")
                 }
+                .keyboardShortcut("r", modifiers: .command)
                 Button { showClassicDetail = true } label: {
                     Label("Open Classic", systemImage: "square.on.square")
                 }
                 .help("Open the classic detail editor for full controls")
+                .keyboardShortcut("k", modifiers: .command)
             }
         }
         .padding(.horizontal, 20)
@@ -145,6 +147,7 @@ struct PortfolioThemeWorkspaceView: View {
     }
 
     @State private var holdingsSearch: String = ""
+    @FocusState private var focusHoldingsSearch: Bool
     private var holdingsTab: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack {
@@ -155,11 +158,16 @@ struct PortfolioThemeWorkspaceView: View {
             HStack(spacing: 8) {
                 TextField("Search instruments or notes", text: $holdingsSearch)
                     .textFieldStyle(.roundedBorder)
+                    .focused($focusHoldingsSearch)
                 if !holdingsSearch.isEmpty {
                     Button("Clear") { holdingsSearch = "" }
                         .buttonStyle(.link)
                 }
             }
+            // Hidden shortcut to focus search (Cmd-F)
+            Button("") { focusHoldingsSearch = true }
+                .keyboardShortcut("f", modifiers: .command)
+                .hidden()
             HoldingsTable(themeId: themeId, isArchived: theme?.archivedAt != nil, search: holdingsSearch)
                 .environmentObject(dbManager)
         }

--- a/DragonShield/Views/PortfolioThemeWorkspaceView.swift
+++ b/DragonShield/Views/PortfolioThemeWorkspaceView.swift
@@ -397,6 +397,7 @@ private struct HoldingsTable: View {
     @State private var rows: [ValuationRow] = []
     @State private var total: Double = 0
     @State private var saving: Set<Int> = [] // instrumentId currently saving
+    @State private var edits: [Int: Edit] = [:] // instrumentId -> current editable fields
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -410,13 +411,13 @@ private struct HoldingsTable: View {
                             HStack(spacing: 8) {
                                 Text(r.instrumentName).frame(maxWidth: .infinity, alignment: .leading).lineLimit(1).truncationMode(.middle)
                                 // Inline edit Research %
-                                TextField("", value: binding(for: r.instrumentId, keyPath: \.researchTargetPct), format: .number)
+                                TextField("", value: bindingDouble(for: r.instrumentId, field: .research), format: .number)
                                     .multilineTextAlignment(.trailing)
                                     .frame(width: 80)
                                     .disabled(isArchived)
                                     .onSubmit { saveRow(r.instrumentId) }
                                 // Inline edit User %
-                                TextField("", value: binding(for: r.instrumentId, keyPath: \.userTargetPct), format: .number)
+                                TextField("", value: bindingDouble(for: r.instrumentId, field: .user), format: .number)
                                     .multilineTextAlignment(.trailing)
                                     .frame(width: 80)
                                     .disabled(isArchived)
@@ -424,17 +425,10 @@ private struct HoldingsTable: View {
                                 Text(fmtPct(r.actualPct)).frame(width: 80, alignment: .trailing)
                                 Text(fmtPct(r.deltaUserPct)).frame(width: 80, alignment: .trailing).foregroundColor((r.deltaUserPct ?? 0) >= 0 ? .green : .red)
                                 // Notes inline (single-line)
-                                TextField("Notes", text: Binding(
-                                    get: { rows.first(where: { $0.instrumentId == r.instrumentId })?.notes ?? "" },
-                                    set: { newVal in
-                                        if let idx = rows.firstIndex(where: { $0.instrumentId == r.instrumentId }) {
-                                            rows[idx] = mutated(rows[idx]) { $0.notes = newVal }
-                                        }
-                                    }
-                                ))
-                                .textFieldStyle(.roundedBorder)
-                                .disabled(isArchived)
-                                .onSubmit { saveRow(r.instrumentId) }
+                                TextField("Notes", text: bindingNotes(for: r.instrumentId))
+                                    .textFieldStyle(.roundedBorder)
+                                    .disabled(isArchived)
+                                    .onSubmit { saveRow(r.instrumentId) }
                                 if saving.contains(r.instrumentId) { ProgressView().controlSize(.small) }
                             }
                             .font(.system(.body, design: .monospaced))
@@ -463,6 +457,12 @@ private struct HoldingsTable: View {
         let service = PortfolioValuationService(dbManager: dbManager, fxService: fx)
         let snap = service.snapshot(themeId: themeId)
         rows = snap.rows.sorted { $0.instrumentName < $1.instrumentName }
+        // seed editable fields from valuation rows
+        var dict: [Int: Edit] = [:]
+        for r in rows {
+            dict[r.instrumentId] = Edit(research: r.researchTargetPct, user: r.userTargetPct, notes: r.notes ?? "")
+        }
+        edits = dict
         total = snap.totalValueBase
     }
 
@@ -482,36 +482,42 @@ private struct HoldingsTable: View {
     }
 
     // MARK: - Editing helpers
-    private func binding(for instrumentId: Int, keyPath: WritableKeyPath<ValuationRow, Double>) -> Binding<Double> {
+    private enum Field { case research, user }
+    private func bindingDouble(for instrumentId: Int, field: Field) -> Binding<Double> {
         Binding<Double>(
             get: {
-                rows.first(where: { $0.instrumentId == instrumentId })?[keyPath: keyPath] ?? 0
+                if let e = edits[instrumentId] { return field == .research ? e.research : e.user }
+                return 0
             },
             set: { newValue in
                 let clamped = max(0, min(100, newValue))
-                if let idx = rows.firstIndex(where: { $0.instrumentId == instrumentId }) {
-                    rows[idx] = mutated(rows[idx]) { $0[keyPath: keyPath] = clamped }
-                }
+                var e = edits[instrumentId] ?? Edit(research: 0, user: 0, notes: "")
+                if field == .research { e.research = clamped } else { e.user = clamped }
+                edits[instrumentId] = e
+            }
+        )
+    }
+    private func bindingNotes(for instrumentId: Int) -> Binding<String> {
+        Binding<String>(
+            get: { edits[instrumentId]?.notes ?? "" },
+            set: { newValue in
+                var e = edits[instrumentId] ?? Edit(research: 0, user: 0, notes: "")
+                e.notes = String(newValue.prefix(NoteEditorView.maxLength))
+                edits[instrumentId] = e
             }
         )
     }
 
-    private func mutated(_ row: ValuationRow, mutate: (inout ValuationRow) -> Void) -> ValuationRow {
-        var copy = row
-        mutate(&copy)
-        return copy
-    }
-
     private func saveRow(_ instrumentId: Int) {
-        guard let row = rows.first(where: { $0.instrumentId == instrumentId }) else { return }
+        guard let e = edits[instrumentId] else { return }
         saving.insert(instrumentId)
         DispatchQueue.global(qos: .userInitiated).async {
             _ = dbManager.updateThemeAsset(
                 themeId: themeId,
                 instrumentId: instrumentId,
-                researchPct: row.researchTargetPct,
-                userPct: row.userTargetPct,
-                notes: (row.notes?.isEmpty == true) ? nil : row.notes
+                researchPct: e.research,
+                userPct: e.user,
+                notes: e.notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : e.notes
             )
             DispatchQueue.main.async {
                 saving.remove(instrumentId)
@@ -519,4 +525,6 @@ private struct HoldingsTable: View {
             }
         }
     }
+
+    private struct Edit { var research: Double; var user: Double; var notes: String }
 }


### PR DESCRIPTION
Adds basic keyboard shortcuts in the Theme Workspace:\n- Cmd-R: Refresh valuation\n- Cmd-K: Open classic editor\n- Cmd-F: Focus Holdings search field\n\nStacked on Phase 2B.