### PR TITLE
Re-engineer Portfolio Themes: Phase 2D — Close Button + Holdings Columns

### DIFF
--- a/DragonShield/helpers/UserDefaultsKeys.swift
+++ b/DragonShield/helpers/UserDefaultsKeys.swift
@@ -26,6 +26,8 @@ struct UserDefaultsKeys {
     static let portfolioThemeWorkspaceEnabled = "portfolioThemeWorkspaceEnabled"
     /// Remember last-used tab in the new Portfolio Theme Workspace.
     static let portfolioThemeWorkspaceLastTab = "portfolioThemeWorkspaceLastTab"
+    /// Visible columns in Workspace Holdings table (comma-separated list of column ids)
+    static let portfolioThemeWorkspaceHoldingsColumns = "portfolioThemeWorkspaceHoldingsColumns"
     /// Persist window frame for import value report.
     static let importReportWindowFrame = "importReport.windowFrame"
 }


### PR DESCRIPTION
Adds a Close button (Cmd-W) and enhances the header with Status and Institution tags. Implements column visibility controls for Holdings in the Workspace, persisted in UserDefaults.\n\nScope\n- Header: Refresh (Cmd-R), Open Classic (Cmd-K), Close (Cmd-W)\n- Header tags: theme code, status (colored), institution, archived badge\n- Holdings: Column chooser (instrument, research, user, actual, delta, notes), persisted under `UserDefaultsKeys.portfolioThemeWorkspaceHoldingsColumns`\n\nQA\n- Toggle Workspace and open a theme\n- Use Close to dismiss, keyboard shortcuts to verify\n- Toggle columns and reopen view — preferences persist\n- Ensure editing and search remain functional\n\nBase: stacked on Phase 2C.