### PR TITLE
Instrument Dashboard: new tile + window, UI polish, autosave targets

### DIFF
--- a/DragonShield/DragonShieldApp.swift
+++ b/DragonShield/DragonShieldApp.swift
@@ -62,5 +62,16 @@ struct DragonShieldApp: App {
         }
         .defaultSize(width: 800, height: 600)
         .windowResizability(.contentSize)
+
+        WindowGroup(id: "instrumentDashboard", for: Int.self) { $instrumentId in
+            if let iid = instrumentId {
+                InstrumentDashboardWindowView(instrumentId: iid)
+                    .environmentObject(databaseManager)
+            } else {
+                Text("Instrument not found")
+            }
+        }
+        .defaultSize(width: 1080, height: 720)
+        .windowResizability(.contentSize)
     }
 }

--- a/DragonShield/Views/DashboardTiles/DashboardTiles.swift
+++ b/DragonShield/Views/DashboardTiles/DashboardTiles.swift
@@ -619,7 +619,8 @@ enum TileRegistry {
         TileInfo(id: MapTile.tileID, name: MapTile.tileName, icon: MapTile.iconName) { AnyView(MapTile()) },
         TileInfo(id: AccountsNeedingUpdateTile.tileID, name: AccountsNeedingUpdateTile.tileName, icon: AccountsNeedingUpdateTile.iconName) { AnyView(AccountsNeedingUpdateTile()) },
         TileInfo(id: MissingPricesTile.tileID, name: MissingPricesTile.tileName, icon: MissingPricesTile.iconName) { AnyView(MissingPricesTile()) },
-        TileInfo(id: AllNotesTile.tileID, name: AllNotesTile.tileName, icon: AllNotesTile.iconName) { AnyView(AllNotesTile()) }
+        TileInfo(id: AllNotesTile.tileID, name: AllNotesTile.tileName, icon: AllNotesTile.iconName) { AnyView(AllNotesTile()) },
+        TileInfo(id: InstrumentDashboardTile.tileID, name: InstrumentDashboardTile.tileName, icon: InstrumentDashboardTile.iconName) { AnyView(InstrumentDashboardTile()) }
     ]
 
     static func view(for id: String) -> AnyView? {

--- a/DragonShield/Views/DashboardTiles/InstrumentDashboardTile.swift
+++ b/DragonShield/Views/DashboardTiles/InstrumentDashboardTile.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+struct InstrumentDashboardTile: DashboardTile {
+    init() {}
+    static let tileID = "instrument_dashboard"
+    static let tileName = "Instrument Dashboard"
+    static let iconName = "square.grid.3x1.folder.badge.plus"
+
+    @EnvironmentObject var dbManager: DatabaseManager
+    @Environment(\.openWindow) private var openWindow
+
+    @State private var instruments: [DatabaseManager.InstrumentRow] = []
+    @State private var instrumentQuery: String = ""
+    @State private var selectedInstrumentId: Int? = nil
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 8) {
+                Text(Self.tileName)
+                    .font(.system(size: 18, weight: .bold))
+                Spacer()
+            }
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Select Instrument").font(.caption).foregroundColor(.secondary)
+                MacComboBox(
+                    items: instrumentDisplayItems(),
+                    text: $instrumentQuery,
+                    onSelectIndex: { originalIndex in
+                        guard originalIndex >= 0 && originalIndex < instruments.count else { return }
+                        let ins = instruments[originalIndex]
+                        selectedInstrumentId = ins.id
+                        openInstrument(ins.id)
+                    }
+                )
+                .frame(minWidth: 360)
+                .accessibilityLabel("Instrument Selector")
+                // When focused, MacComboBox already opens the popup and filters as you type.
+                // Ensure we start from a full list view.
+                .onAppear { instrumentQuery = "" }
+                HStack(spacing: 8) {
+                    Spacer()
+                    Button {
+                        if let id = selectedInstrumentId { openInstrument(id) }
+                    } label: {
+                        Label("Open Dashboard", systemImage: "arrow.up.right.square")
+                    }
+                    .buttonStyle(PrimaryButtonStyle())
+                    .disabled(selectedInstrumentId == nil)
+                }
+            }
+        }
+        .padding(DashboardTileLayout.tilePadding)
+        .background(Color.white)
+        .cornerRadius(16)
+        .shadow(color: .black.opacity(0.1), radius: 3, x: 0, y: 2)
+        .onAppear(perform: loadInstruments)
+        .accessibilityElement(children: .combine)
+    }
+
+    private func loadInstruments() {
+        instruments = dbManager.fetchAssets()
+    }
+
+    private func instrumentDisplayItems() -> [String] {
+        instruments.map(displayString(for:))
+    }
+
+    private func displayString(for ins: DatabaseManager.InstrumentRow) -> String {
+        var parts: [String] = [ins.name]
+        if let t = ins.tickerSymbol, !t.isEmpty { parts.append(t.uppercased()) }
+        if let i = ins.isin, !i.isEmpty { parts.append(i.uppercased()) }
+        return parts.joined(separator: " • ")
+    }
+
+    private func openInstrument(_ id: Int) {
+        openWindow(id: "instrumentDashboard", value: id)
+    }
+}

--- a/DragonShield/Views/InstrumentDashboardWindowView.swift
+++ b/DragonShield/Views/InstrumentDashboardWindowView.swift
@@ -1,0 +1,434 @@
+import SwiftUI
+
+struct InstrumentDashboardWindowView: View {
+    @EnvironmentObject var dbManager: DatabaseManager
+    @Environment(\.dismiss) private var dismiss
+    let instrumentId: Int
+
+    @State private var details: DatabaseManager.InstrumentDetails?
+    @State private var latestPrice: (price: Double, currency: String, asOf: String)?
+    @State private var themes: [(themeId: Int, themeName: String, isArchived: Bool, updatesCount: Int, mentionsCount: Int)] = []
+    @State private var allocations: [AllocationRow] = []
+    @State private var accountHoldings: [AccountHolding] = []
+    @State private var totalValueCHF: Double = 0
+    @State private var instrumentCode: String = ""
+    @State private var instrumentName: String = ""
+
+    // Layout constants
+    private let minRowsToShow: Int = 4
+    private let tileRowHeight: CGFloat = 36
+
+    struct AllocationRow: Identifiable {
+        let id = UUID()
+        let themeId: Int
+        let themeName: String
+        let researchPct: Double
+        let userPct: Double
+        let isArchived: Bool
+    }
+
+    struct AccountHolding: Identifiable {
+        let id = UUID()
+        let accountName: String
+        let institutionName: String
+        let quantity: Double
+        let valueCHF: Double
+    }
+
+    @State private var openThemeId: Int? = nil
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            content
+            Divider()
+            HStack {
+                Spacer()
+                Button(role: .cancel) { dismiss() } label: {
+                    Label("Close", systemImage: "xmark")
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(Color.gray)
+                .foregroundColor(.white)
+                .keyboardShortcut("w", modifiers: .command)
+            }
+            .padding(12)
+        }
+        .frame(minWidth: 980, minHeight: 680)
+        .onAppear(perform: load)
+        .sheet(item: Binding(get: {
+            openThemeId.map { Ident(value: $0) }
+        }, set: { newVal in openThemeId = newVal?.value })) { ident in
+            PortfolioThemeWorkspaceView(
+                themeId: ident.value,
+                origin: "instrument_dashboard",
+                initialTab: .updates
+            )
+            .environmentObject(dbManager)
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .center) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Instrument Dashboard")
+                    .font(.title3).bold()
+                if let d = details {
+                    Text(d.name)
+                        .font(.system(size: 24, weight: .bold))
+                        .foregroundColor(Theme.textPrimary)
+                    HStack(spacing: 8) {
+                        Tag("Currency: \(d.currency)")
+                        if let t = d.tickerSymbol, !t.isEmpty { Tag("Ticker: \(t.uppercased())") }
+                        if let i = d.isin, !i.isEmpty { Tag("ISIN: \(i.uppercased())") }
+                        if let v = d.valorNr, !v.isEmpty { Tag("Valor: \(v)") }
+                        if let s = d.sector, !s.isEmpty { Tag("Sector: \(s)") }
+                    }
+                } else {
+                    EmptyView()
+                }
+            }
+            Spacer()
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(formatCHFNoDecimalsPrefix(totalValueCHF))
+                    .font(.system(size: 36, weight: .bold))
+                    .foregroundColor(Theme.primaryAccent)
+                Text("Total Position")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding(16)
+        .background(Theme.surface)
+    }
+
+    private var content: some View {
+        TabView {
+            overviewTab
+                .tabItem { Text("Overview") }
+            notesTab
+                .tabItem { Text("Notes") }
+        }
+    }
+
+    private var overviewTab: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                topCards
+                allocationsSection
+                holdingsSection
+            }
+            .padding(16)
+        }
+    }
+
+    private var topCards: some View {
+        let cols = [GridItem(.flexible()), GridItem(.flexible())]
+        return LazyVGrid(columns: cols, spacing: 16) {
+            infoCard(title: "Details") {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        VStack(alignment: .leading, spacing: 6) {
+                            rowKV("Currency", details?.currency)
+                            rowKV("Ticker", details?.tickerSymbol?.uppercased())
+                            rowKV("ISIN", details?.isin?.uppercased())
+                        }
+                        Spacer()
+                        VStack(alignment: .leading, spacing: 6) {
+                            rowKV("Valor", details?.valorNr)
+                            rowKV("Sector", details?.sector)
+                        }
+                    }
+                }
+            }
+
+            infoCard(title: "Price & Value") {
+                VStack(alignment: .leading, spacing: 8) {
+                    if let p = latestPrice {
+                        rowKV("Latest Price", String(format: "%.2f %@", p.price, p.currency))
+                        rowKV("As Of", DateFormatting.userFriendly(p.asOf))
+                    } else {
+                        rowKV("Latest Price", "—")
+                        rowKV("As Of", "—")
+                    }
+                    Divider().padding(.vertical, 4)
+                    rowKV("Total Position (\(dbManager.baseCurrency))", formatCHFNoDecimalsSuffix(totalValueCHF))
+                }
+            }
+            infoCard(title: "Portfolios") {
+                VStack(alignment: .leading, spacing: 8) {
+                    if themes.isEmpty {
+                        Text("Not included in any portfolios")
+                            .foregroundColor(.secondary)
+                    } else {
+                        ForEach(themes, id: \.themeId) { t in
+                            HStack {
+                                Button(action: { openThemeId = t.themeId }) {
+                                    Text(t.themeName)
+                                        .fontWeight(.semibold)
+                                        .foregroundColor(t.isArchived ? .secondary : .primary)
+                                }
+                                .buttonStyle(.plain)
+                                Spacer()
+                                Text("Updates: \(t.updatesCount) • Mentions: \(t.mentionsCount)")
+                                    .font(.caption).foregroundColor(.secondary)
+                            }
+                            if t.themeId != themes.last?.themeId { Divider() }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var allocationsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Allocation Targets").font(.headline)
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
+                .background(Color.white)
+                .overlay(
+                    VStack(alignment: .leading, spacing: 0) {
+                        HStack {
+                            Text("Portfolio Theme").frame(maxWidth: .infinity, alignment: .leading)
+                            Text("Research %").frame(width: 120, alignment: .trailing)
+                            Text("User %").frame(width: 100, alignment: .trailing)
+                        }
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .padding(.horizontal, 12)
+                        .padding(.top, 8)
+                        Divider()
+                        if allocations.isEmpty {
+                            Text("currently no targets available")
+                                .foregroundColor(.secondary)
+                                .padding(12)
+                        } else {
+                            ForEach(allocations) { row in
+                                HStack {
+                                    HStack(spacing: 6) {
+                                        Text(row.themeName)
+                                        if row.isArchived { Text("Archived").font(.caption).foregroundColor(.secondary) }
+                                    }
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    Text(String(format: "%.1f%%", row.researchPct))
+                                        .frame(width: 120, alignment: .trailing)
+                                        .monospacedDigit()
+                                    Text(String(format: "%.1f%%", row.userPct))
+                                        .frame(width: 100, alignment: .trailing)
+                                        .monospacedDigit()
+                                }
+                                .padding(.horizontal, 12)
+                                .frame(height: 36)
+                                if row.id != allocations.last?.id { Divider() }
+                            }
+                        }
+                    }
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+                .frame(maxWidth: .infinity,
+                       minHeight: tileRowHeight * CGFloat(minRowsToShow) + 48)
+        }
+    }
+
+    private var holdingsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Holdings by Account").font(.headline)
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
+                .background(Color.white)
+                .overlay(
+                    VStack(alignment: .leading, spacing: 0) {
+                        headerRow()
+                        Divider()
+                        if accountHoldings.isEmpty {
+                            Text("No holdings found in current positions snapshot.")
+                                .foregroundColor(.secondary)
+                                .padding(12)
+                        } else {
+                            ForEach(accountHoldings) { r in
+                                HStack {
+                                    Text(r.accountName)
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                    Text(String(format: "%.2f", r.quantity))
+                                        .frame(width: 140, alignment: .trailing)
+                                        .monospacedDigit()
+                                    Text(formatCHFNoDecimalsSuffix(r.valueCHF))
+                                        .frame(width: 180, alignment: .trailing)
+                                        .monospacedDigit()
+                                }
+                                .padding(.horizontal, 12)
+                                .frame(height: 36)
+                                if r.id != accountHoldings.last?.id { Divider() }
+                            }
+                        }
+                    }
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+                .frame(minHeight: tileRowHeight * CGFloat(minRowsToShow) + 48)
+        }
+    }
+
+    private func headerRow() -> some View {
+        HStack {
+            Text("Account").frame(maxWidth: .infinity, alignment: .leading)
+            Text("Amount").frame(width: 140, alignment: .trailing)
+            Text("Value").frame(width: 180, alignment: .trailing)
+        }
+        .font(.caption)
+        .foregroundColor(.secondary)
+        .padding(.horizontal, 12)
+        .padding(.top, 8)
+    }
+
+    private var notesTab: some View {
+        VStack(spacing: 0) {
+            if instrumentName.isEmpty {
+                Text("Loading…").padding()
+            } else {
+                InstrumentNotesView(
+                    instrumentId: instrumentId,
+                    instrumentCode: instrumentCode,
+                    instrumentName: instrumentName,
+                    initialTab: .updates,
+                    initialThemeId: nil,
+                    onClose: {}
+                )
+                .environmentObject(dbManager)
+            }
+        }
+    }
+
+    private func infoCard<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title).font(.headline)
+            content()
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity)
+        .background(Color.white)
+        .cornerRadius(10)
+        .shadow(color: .black.opacity(0.06), radius: 3, x: 0, y: 2)
+    }
+
+    private func rowKV(_ key: String, _ value: String?) -> some View {
+        HStack {
+            Text(key).foregroundColor(.secondary)
+            Spacer()
+            Text(value ?? "—")
+        }
+        .font(.system(size: 13))
+    }
+
+    private func load() {
+        // Details
+        details = dbManager.fetchInstrumentDetails(id: instrumentId)
+        instrumentName = details?.name ?? (dbManager.getInstrumentName(id: instrumentId) ?? "#\(instrumentId)")
+        // Prefer ticker as code; fallback to ISIN/Valor if needed
+        if let t = details?.tickerSymbol, !t.isEmpty {
+            instrumentCode = t
+        } else if let i = details?.isin, !i.isEmpty {
+            instrumentCode = i
+        } else if let v = details?.valorNr, !v.isEmpty {
+            instrumentCode = v
+        } else {
+            instrumentCode = ""
+        }
+
+        // Latest price
+        latestPrice = dbManager.getLatestPrice(instrumentId: instrumentId)
+
+        // Portfolios
+        let trows = dbManager.listThemesForInstrumentWithUpdateCounts(
+            instrumentId: instrumentId,
+            instrumentCode: instrumentCode,
+            instrumentName: instrumentName
+        )
+        themes = trows
+        allocations = trows.compactMap { t in
+            if let asset = dbManager.getThemeAsset(themeId: t.themeId, instrumentId: instrumentId) {
+                return AllocationRow(themeId: t.themeId, themeName: t.themeName, researchPct: asset.researchTargetPct, userPct: asset.userTargetPct, isArchived: t.isArchived)
+            }
+            return nil
+        }
+
+        // Positions snapshot -> account holdings and total CHF
+        computeHoldings()
+    }
+
+    private func computeHoldings() {
+        // Build per-account aggregation based on latest price and FX to CHF.
+        let reports = dbManager.fetchPositionReports()
+        let filtered = reports.filter { $0.instrumentId == instrumentId }
+        guard !filtered.isEmpty else {
+            self.accountHoldings = []
+            self.totalValueCHF = 0
+            return
+        }
+        // Determine price and currency
+        let priceInfo = dbManager.getLatestPrice(instrumentId: instrumentId)
+        // Group by (accountName, institutionName)
+        var byAccount: [String: (qty: Double, valueCHF: Double, acc: String)] = [:]
+        for p in filtered {
+            let key = p.accountName
+            let qty = p.quantity
+            // Value in instrument currency
+            var value = 0.0
+            if let pi = priceInfo {
+                value = qty * pi.price
+                // FX to CHF if needed
+                if pi.currency.uppercased() != dbManager.baseCurrency.uppercased() {
+                    if let rate = dbManager.fetchExchangeRates(currencyCode: pi.currency, upTo: nil).first?.rateToChf {
+                        value *= rate
+                    } else {
+                        // No rate, fallback to 0 for CHF value
+                        value = 0
+                    }
+                }
+            }
+            let prev = byAccount[key] ?? (0, 0, p.accountName)
+            byAccount[key] = (prev.qty + qty, prev.valueCHF + value, p.accountName)
+        }
+        let rows = byAccount.values.map { AccountHolding(accountName: $0.acc, institutionName: "", quantity: $0.qty, valueCHF: $0.valueCHF) }
+        self.accountHoldings = rows.sorted { $0.valueCHF > $1.valueCHF }
+        self.totalValueCHF = rows.reduce(0) { $0 + $1.valueCHF }
+    }
+
+    private func formatCHFNoDecimalsPrefix(_ v: Double) -> String {
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        f.groupingSeparator = "'"
+        f.usesGroupingSeparator = true
+        f.maximumFractionDigits = 0
+        f.minimumFractionDigits = 0
+        let base = f.string(from: NSNumber(value: v)) ?? String(format: "%.0f", v)
+        return "CHF " + base
+    }
+
+    private func formatCHFNoDecimalsSuffix(_ v: Double) -> String {
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        f.groupingSeparator = "'"
+        f.usesGroupingSeparator = true
+        f.maximumFractionDigits = 0
+        f.minimumFractionDigits = 0
+        let base = f.string(from: NSNumber(value: v)) ?? String(format: "%.0f", v)
+        return base + " CHF"
+    }
+
+    private struct Ident: Identifiable { let value: Int; var id: Int { value } }
+}
+
+private struct Tag: View {
+    let text: String
+    init(_ text: String) { self.text = text }
+    var body: some View {
+        Text(text)
+            .font(.caption)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(Color.gray.opacity(0.12))
+            .cornerRadius(6)
+    }
+}

--- a/DragonShield/Views/PortfolioThemeWorkspaceView.swift
+++ b/DragonShield/Views/PortfolioThemeWorkspaceView.swift
@@ -874,6 +874,7 @@ private struct HoldingsTable: View {
                                         .frame(width: width(for: .research))
                                         .disabled(isArchived)
                                         .onSubmit { saveRow(r.instrumentId) }
+                                        .onChange(of: editableResearch(r.instrumentId)) { _, _ in saveRow(r.instrumentId) }
                                         .overlay(RoundedRectangle(cornerRadius: 6).stroke(invalidKeys.contains(key(for: r.instrumentId, field: .research)) ? Color.red.opacity(0.6) : Color.gray.opacity(0.25)))
                                         .help("0–100")
                                 }
@@ -884,6 +885,7 @@ private struct HoldingsTable: View {
                                         .frame(width: width(for: .user))
                                         .disabled(isArchived)
                                         .onSubmit { saveRow(r.instrumentId) }
+                                        .onChange(of: editableUser(r.instrumentId)) { _, _ in saveRow(r.instrumentId) }
                                         .overlay(RoundedRectangle(cornerRadius: 6).stroke(invalidKeys.contains(key(for: r.instrumentId, field: .user)) ? Color.red.opacity(0.6) : Color.gray.opacity(0.25)))
                                         .help("0–100")
                                 }


### PR DESCRIPTION
This PR introduces the Instrument Dashboard feature:

- Dashboard tile with combo-box selector that filters as you type
- New Instrument Dashboard window (read-only) with:
  - Header: large instrument name + total position (CHF) emphasized
  - Details card: currency, ticker, ISIN, Valor, sector
  - Price & Value card: latest price info (smaller), aligned with Details
  - Portfolios card: archived shown in grey, names clickable to open theme workspace
  - Allocation Targets card: shows current Research/User targets or empty state
  - Holdings by Account: Account | Amount | Value with Swiss formatting
  - Notes tab embeds InstrumentNotesView
- Minimum tile heights (>= 4 rows) for Allocation Targets and Holdings
- Theme Workspace: autosave Research% and User% edits (on-change + on-submit)

No DB schema changes. Safe to ship; UI-only + reads existing queries.\n