### PR TITLE
Instruments: Soft delete/restore + show soft-deleted in Instruments view

### DIFF
--- a/DragonShield/AssetManager.swift
+++ b/DragonShield/AssetManager.swift
@@ -8,6 +8,8 @@ struct DragonAsset: Identifiable {
     var valorNr: String?
     var tickerSymbol: String?
     var isin: String?
+    var isDeleted: Bool
+    var isActive: Bool
 }
 
 class AssetManager: ObservableObject {
@@ -19,7 +21,8 @@ class AssetManager: ObservableObject {
     }
     
     func loadAssets() {
-        let instrumentData = dbManager.fetchAssets()
+        // Include all instruments (active + soft-deleted) for the Instruments screen
+        let instrumentData = dbManager.fetchAssets(includeDeleted: true, includeInactive: true)
         let assetTypeData = dbManager.fetchAssetTypes()
         
         print("🔍 AssetManager loading: \(instrumentData.count) instruments, \(assetTypeData.count) types")
@@ -36,7 +39,9 @@ class AssetManager: ObservableObject {
                 currency: instrument.currency,
                 valorNr: instrument.valorNr,
                 tickerSymbol: instrument.tickerSymbol,
-                isin: instrument.isin
+                isin: instrument.isin,
+                isDeleted: instrument.isDeleted,
+                isActive: instrument.isActive
             )
         }
         

--- a/DragonShield/DatabaseManager+InstrumentPrice.swift
+++ b/DragonShield/DatabaseManager+InstrumentPrice.swift
@@ -39,7 +39,7 @@ extension DatabaseManager {
         staleDays: Int? = nil
     ) -> [InstrumentLatestPriceRow] {
         var rows: [InstrumentLatestPriceRow] = []
-        var clauses: [String] = ["(i.is_active = 1 OR i.is_deleted = 1)"]
+        var clauses: [String] = ["i.is_active = 1", "i.is_deleted = 0"]
         var binds: [Any] = []
         if let s = search?.trimmingCharacters(in: .whitespacesAndNewlines), !s.isEmpty {
             clauses.append("(LOWER(i.instrument_name) LIKE ? OR LOWER(i.ticker_symbol) LIKE ? OR LOWER(i.isin) LIKE ? OR LOWER(i.valor_nr) LIKE ?)")

--- a/DragonShield/DatabaseManager+InstrumentPrice.swift
+++ b/DragonShield/DatabaseManager+InstrumentPrice.swift
@@ -22,6 +22,8 @@ extension DatabaseManager {
         var valorNr: String?
         var className: String?
         var subClassName: String?
+        var isDeleted: Bool
+        var isActive: Bool
     }
 
     /// Lists instruments with their latest price (if any), with optional filters.
@@ -37,7 +39,7 @@ extension DatabaseManager {
         staleDays: Int? = nil
     ) -> [InstrumentLatestPriceRow] {
         var rows: [InstrumentLatestPriceRow] = []
-        var clauses: [String] = ["i.is_active = 1"]
+        var clauses: [String] = ["(i.is_active = 1 OR i.is_deleted = 1)"]
         var binds: [Any] = []
         if let s = search?.trimmingCharacters(in: .whitespacesAndNewlines), !s.isEmpty {
             clauses.append("(LOWER(i.instrument_name) LIKE ? OR LOWER(i.ticker_symbol) LIKE ? OR LOWER(i.isin) LIKE ? OR LOWER(i.valor_nr) LIKE ?)")
@@ -68,7 +70,9 @@ extension DatabaseManager {
                    i.isin,
                    i.valor_nr,
                    ac.class_name,
-                   asc.sub_class_name
+                   asc.sub_class_name,
+                   i.is_deleted,
+                   i.is_active
               FROM Instruments i
               LEFT JOIN InstrumentPriceLatest ipl ON ipl.instrument_id = i.instrument_id
               JOIN AssetSubClasses asc ON i.sub_class_id = asc.sub_class_id
@@ -103,7 +107,23 @@ extension DatabaseManager {
             let valor = sqlite3_column_text(stmt, 8).map { String(cString: $0) }
             let className = sqlite3_column_text(stmt, 9).map { String(cString: $0) }
             let subClassName = sqlite3_column_text(stmt, 10).map { String(cString: $0) }
-            rows.append(InstrumentLatestPriceRow(id: id, name: name, currency: cur, latestPrice: price, asOf: asOf, source: source, ticker: ticker, isin: isin, valorNr: valor, className: className, subClassName: subClassName))
+            let isDeleted = sqlite3_column_int(stmt, 11) == 1
+            let isActive = sqlite3_column_int(stmt, 12) == 1
+            rows.append(InstrumentLatestPriceRow(
+                id: id,
+                name: name,
+                currency: cur,
+                latestPrice: price,
+                asOf: asOf,
+                source: source,
+                ticker: ticker,
+                isin: isin,
+                valorNr: valor,
+                className: className,
+                subClassName: subClassName,
+                isDeleted: isDeleted,
+                isActive: isActive
+            ))
         }
         return rows
     }

--- a/DragonShield/Views/InstrumentPricesMaintenanceView.swift
+++ b/DragonShield/Views/InstrumentPricesMaintenanceView.swift
@@ -213,9 +213,19 @@ struct InstrumentPricesMaintenanceView: View {
                                 HStack(spacing: 6) {
                                     Text(r.name)
                                         .fontWeight(.semibold)
+                                        .foregroundColor(r.isDeleted ? .secondary : .primary)
                                         .lineLimit(1)
                                         .truncationMode(.middle)
                                         .help(r.name)
+                                    if r.isDeleted {
+                                        Text("Soft-deleted")
+                                            .font(.caption2)
+                                            .foregroundColor(.secondary)
+                                            .padding(.horizontal, 6)
+                                            .padding(.vertical, 2)
+                                            .background(Color.gray.opacity(0.12))
+                                            .clipShape(Capsule())
+                                    }
                                     if r.latestPrice == nil { missingPriceChip }
                                 }
                                 HStack(spacing: 6) {

--- a/DragonShield/Views/PortfolioView.swift
+++ b/DragonShield/Views/PortfolioView.swift
@@ -644,9 +644,21 @@ struct ModernAssetRowView: View {
 
     var body: some View {
         HStack {
-            Text(asset.name)
-                .font(.system(size: 15, weight: .medium))
-                .foregroundColor(.primary)
+            HStack(spacing: 6) {
+                Text(asset.name)
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundColor(asset.isDeleted ? .secondary : .primary)
+                if asset.isDeleted {
+                    Text("Soft-deleted")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Color.gray.opacity(0.12))
+                        .clipShape(Capsule())
+                        .help("This instrument is soft-deleted. Double-click to open and restore.")
+                }
+            }
                 .frame(maxWidth: .infinity, alignment: .leading)
             
             Text(asset.type)


### PR DESCRIPTION
This PR implements soft delete/reactivation for Instruments and improves visibility in maintenance views.

Highlights:
- DB helpers: fetchInstrumentDetails returns isActive/isDeleted; add softDeleteInstrument/restoreInstrument; usage checks (positions & portfolio memberships)
- Instrument editor: new Status & Lifecycle panel with clear guidance, soft delete button (guarded), restore button, and status badges
- Instruments View: lists all instruments (active + soft-deleted), greys out soft-deleted with badge
- Prices Maintenance: reverts to active, non-deleted instruments only

No schema changes (uses existing is_active, is_deleted, deleted_at, deleted_reason).