### PR TITLE
Theme handling + Settings UI: stricter edit rules, clearer errors, and Danger Zone toggles

### DIFF
--- a/DragonShield/Views/PortfolioThemeUpdatesView.swift
+++ b/DragonShield/Views/PortfolioThemeUpdatesView.swift
@@ -225,7 +225,7 @@ struct PortfolioThemeUpdatesView: View {
         extras = map
         if let theme = dbManager.getPortfolioTheme(id: themeId) {
             themeName = theme.name
-            isArchived = theme.archivedAt != nil
+            isArchived = (theme.archivedAt != nil) || theme.softDelete
         }
     }
 


### PR DESCRIPTION
This PR simplifies and tightens Portfolio Theme handling and improves the Theme Workspace Settings UI.\n\nHighlights:\n- Enforce: no edits when theme is archived or soft-deleted (DB guards)\n- Clear error: 'no changes possible, restore theme first'\n- Remove 'New Update' and 'Edit Theme' from themes list\n- Settings UI: white backgrounds for inputs & dropdowns; right-aligned, bold Name\n- Danger Zone: separate lines — Soft Deleted toggle, Archived Theme toggle, Full Restore button\n- Updates UI: disable '+ New Update' when theme is soft-deleted as well as archived\n\nFiles touched:\n- DatabaseManager+PortfolioThemeAssets.swift\n- DatabaseManager+PortfolioThemes.swift\n- DatabaseManager+PortfolioThemeUpdates.swift\n- Views/PortfolioThemesListView.swift\n- Views/PortfolioThemeWorkspaceView.swift\n- Views/PortfolioThemeUpdatesView.swift\n\nMerges cleanly against main.