### PR TITLE
Add instrument-level notes support

### DIFF
--- a/DragonShield/DatabaseManager+Attachments.swift
+++ b/DragonShield/DatabaseManager+Attachments.swift
@@ -2,6 +2,55 @@ import SQLite3
 import Foundation
 
 extension DatabaseManager {
+    private func tableExists(_ name: String) -> Bool {
+        guard let db else { return false }
+        var stmt: OpaquePointer?
+        defer { sqlite3_finalize(stmt) }
+        let sql = "SELECT name FROM sqlite_master WHERE type='table' AND name=? LIMIT 1"
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return false }
+        let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        sqlite3_bind_text(stmt, 1, name, -1, SQLITE_TRANSIENT)
+        return sqlite3_step(stmt) == SQLITE_ROW
+    }
+
+    private func ensureInstrumentNoteAttachmentTable() {
+        let sql = """
+        CREATE TABLE IF NOT EXISTS InstrumentNoteAttachment (
+            id INTEGER PRIMARY KEY,
+            instrument_note_id INTEGER NOT NULL
+                REFERENCES InstrumentNote(id) ON DELETE CASCADE,
+            attachment_id INTEGER NOT NULL
+                REFERENCES Attachment(id) ON DELETE RESTRICT,
+            created_at TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_ina_note ON InstrumentNoteAttachment(instrument_note_id);
+        CREATE INDEX IF NOT EXISTS idx_ina_attachment ON InstrumentNoteAttachment(attachment_id);
+        """
+        if sqlite3_exec(db, sql, nil, nil, nil) != SQLITE_OK {
+            LoggingService.shared.log("ensureInstrumentNoteAttachmentTable failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+        migrateLegacyAttachmentsIfNeeded()
+    }
+
+    private func migrateLegacyAttachmentsIfNeeded() {
+        guard tableExists("ThemeAssetUpdateAttachment") else { return }
+        guard let pending = singleIntQuery("SELECT COUNT(*) FROM InstrumentNoteAttachment"), pending == 0 else { return }
+        let sql = "INSERT INTO InstrumentNoteAttachment (id, instrument_note_id, attachment_id, created_at) SELECT id, theme_asset_update_id, attachment_id, created_at FROM ThemeAssetUpdateAttachment"
+        if sqlite3_exec(db, sql, nil, nil, nil) != SQLITE_OK {
+            LoggingService.shared.log("migrateLegacyAttachmentsIfNeeded failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+    }
+
+    private func singleIntQuery(_ sql: String) -> Int? {
+        guard let db else { return nil }
+        var stmt: OpaquePointer?
+        defer { sqlite3_finalize(stmt) }
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return nil }
+        if sqlite3_step(stmt) == SQLITE_ROW {
+            return Int(sqlite3_column_int(stmt, 0))
+        }
+        return nil
+    }
     func ensureAttachmentTable() {
         let sql = """
         CREATE TABLE IF NOT EXISTS Attachment (
@@ -40,21 +89,7 @@ extension DatabaseManager {
     }
 
     func ensureThemeAssetUpdateAttachmentTable() {
-        let sql = """
-        CREATE TABLE IF NOT EXISTS ThemeAssetUpdateAttachment (
-            id INTEGER PRIMARY KEY,
-            theme_asset_update_id INTEGER NOT NULL
-                REFERENCES PortfolioThemeAssetUpdate(id) ON DELETE CASCADE,
-            attachment_id INTEGER NOT NULL
-                REFERENCES Attachment(id) ON DELETE RESTRICT,
-            created_at TEXT NOT NULL
-        );
-        CREATE INDEX IF NOT EXISTS idx_taua_update ON ThemeAssetUpdateAttachment(theme_asset_update_id);
-        CREATE INDEX IF NOT EXISTS idx_taua_attachment ON ThemeAssetUpdateAttachment(attachment_id);
-        """
-        if sqlite3_exec(db, sql, nil, nil, nil) != SQLITE_OK {
-            LoggingService.shared.log("ensureThemeAssetUpdateAttachmentTable failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
-        }
+        ensureInstrumentNoteAttachmentTable()
     }
 
     func getAttachmentCounts(for updateIds: [Int]) -> [Int: Int] {
@@ -84,7 +119,7 @@ extension DatabaseManager {
         guard let db = db else { return [:] }
         guard !updateIds.isEmpty else { return [:] }
         let placeholders = Array(repeating: "?", count: updateIds.count).joined(separator: ",")
-        let sql = "SELECT theme_asset_update_id, COUNT(*) FROM ThemeAssetUpdateAttachment WHERE theme_asset_update_id IN (\(placeholders)) GROUP BY theme_asset_update_id"
+        let sql = "SELECT instrument_note_id, COUNT(*) FROM InstrumentNoteAttachment WHERE instrument_note_id IN (\(placeholders)) GROUP BY instrument_note_id"
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
             LoggingService.shared.log("prepare getInstrumentAttachmentCounts failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)

--- a/DragonShield/DatabaseManager+PortfolioThemeAssetUpdates.swift
+++ b/DragonShield/DatabaseManager+PortfolioThemeAssetUpdates.swift
@@ -3,15 +3,46 @@ import SQLite3
 
 extension DatabaseManager {
     func ensurePortfolioThemeAssetUpdateTable() {
-        let sql = """
-        CREATE TABLE IF NOT EXISTS PortfolioThemeAssetUpdate (
+        ensureInstrumentNoteTable()
+        migrateLegacyInstrumentUpdates()
+    }
+
+    private func tableExists(_ name: String) -> Bool {
+        guard let db else { return false }
+        var stmt: OpaquePointer?
+        defer { sqlite3_finalize(stmt) }
+        let sql = "SELECT name FROM sqlite_master WHERE type='table' AND name=? LIMIT 1"
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return false }
+        let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        sqlite3_bind_text(stmt, 1, name, -1, SQLITE_TRANSIENT)
+        return sqlite3_step(stmt) == SQLITE_ROW
+    }
+
+    private func singleIntQuery(_ sql: String, bind: ((OpaquePointer) -> Void)? = nil) -> Int? {
+        guard let db else { return nil }
+        var stmt: OpaquePointer?
+        defer { sqlite3_finalize(stmt) }
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            LoggingService.shared.log("singleIntQuery prepare failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            return nil
+        }
+        bind?(stmt!)
+        if sqlite3_step(stmt) == SQLITE_ROW {
+            return Int(sqlite3_column_int(stmt, 0))
+        }
+        return nil
+    }
+
+    private func ensureInstrumentNoteTable() {
+        let createSQL = """
+        CREATE TABLE IF NOT EXISTS InstrumentNote (
             id INTEGER PRIMARY KEY,
-            theme_id INTEGER NOT NULL REFERENCES PortfolioTheme(id) ON DELETE CASCADE,
             instrument_id INTEGER NOT NULL REFERENCES Instruments(instrument_id) ON DELETE SET NULL,
+            theme_id INTEGER NULL REFERENCES PortfolioTheme(id) ON DELETE CASCADE,
             title TEXT NOT NULL CHECK (LENGTH(title) BETWEEN 1 AND 120),
             body_text TEXT NOT NULL CHECK (LENGTH(body_text) BETWEEN 1 AND 5000),
             body_markdown TEXT NOT NULL CHECK (LENGTH(body_markdown) BETWEEN 1 AND 5000),
-            type TEXT NOT NULL CHECK (type IN (\(PortfolioUpdateType.allowedSQLList))),
+            type TEXT NOT NULL DEFAULT 'General' CHECK (type IN (\(PortfolioUpdateType.allowedSQLList))),
             type_id INTEGER NULL REFERENCES NewsType(id),
             author TEXT NOT NULL,
             pinned INTEGER NOT NULL DEFAULT 0 CHECK (pinned IN (0,1)),
@@ -21,124 +52,185 @@ extension DatabaseManager {
             created_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
             updated_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now'))
         );
-        CREATE INDEX IF NOT EXISTS idx_ptau_theme_instr_order ON PortfolioThemeAssetUpdate(theme_id, instrument_id, created_at DESC);
-        CREATE INDEX IF NOT EXISTS idx_ptau_theme_instr_pinned_order ON PortfolioThemeAssetUpdate(theme_id, instrument_id, pinned DESC, created_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_instrument_note_instrument_order ON InstrumentNote(instrument_id, created_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_instrument_note_theme ON InstrumentNote(theme_id, created_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_instrument_note_pinned ON InstrumentNote(pinned, created_at DESC);
         """
-        if sqlite3_exec(db, sql, nil, nil, nil) != SQLITE_OK {
-            LoggingService.shared.log("ensurePortfolioThemeAssetUpdateTable failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        if sqlite3_exec(db, createSQL, nil, nil, nil) != SQLITE_OK {
+            LoggingService.shared.log("ensureInstrumentNoteTable failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+
+        var addedThemeColumn = false
+        if !tableHasColumn("InstrumentNote", column: "theme_id") {
+            if sqlite3_exec(db, "ALTER TABLE InstrumentNote ADD COLUMN theme_id INTEGER NULL REFERENCES PortfolioTheme(id) ON DELETE CASCADE;", nil, nil, nil) != SQLITE_OK {
+                LoggingService.shared.log("ALTER InstrumentNote add theme_id failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            } else {
+                addedThemeColumn = true
+                _ = sqlite3_exec(db, "CREATE INDEX IF NOT EXISTS idx_instrument_note_theme ON InstrumentNote(theme_id, created_at DESC);", nil, nil, nil)
+                let inferSQL = """
+                    -- Backfill legacy rows that predate the theme_id column; run only during migration.
+                    UPDATE InstrumentNote
+                    SET theme_id = (
+                        SELECT a.theme_id FROM PortfolioThemeAsset a
+                        WHERE a.instrument_id = InstrumentNote.instrument_id
+                    )
+                    WHERE theme_id IS NULL AND (
+                        SELECT COUNT(*) FROM PortfolioThemeAsset WHERE instrument_id = InstrumentNote.instrument_id
+                    ) = 1
+                """
+                if sqlite3_exec(db, inferSQL, nil, nil, nil) != SQLITE_OK {
+                    LoggingService.shared.log("InstrumentNote theme inference failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+                }
+            }
+        }
+
+        if !addedThemeColumn {
+            _ = sqlite3_exec(db, "CREATE INDEX IF NOT EXISTS idx_instrument_note_theme ON InstrumentNote(theme_id, created_at DESC);", nil, nil, nil)
+        }
+
+        if tableExists("InstrumentNoteContext") {
+            if sqlite3_exec(db, "DROP TABLE IF EXISTS InstrumentNoteContext;", nil, nil, nil) != SQLITE_OK {
+                LoggingService.shared.log("drop InstrumentNoteContext failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            }
         }
     }
 
-    func listInstrumentUpdates(themeId: Int, instrumentId: Int, pinnedFirst: Bool = true) -> [PortfolioThemeAssetUpdate] {
-        var items: [PortfolioThemeAssetUpdate] = []
-        let order = pinnedFirst ? "u.pinned DESC, u.created_at DESC" : "u.created_at DESC"
-        let sql = "SELECT u.id, u.theme_id, u.instrument_id, u.title, u.body_markdown, u.type_id, n.code, n.display_name, u.author, u.pinned, u.positions_asof, u.value_chf, u.actual_percent, u.created_at, u.updated_at FROM PortfolioThemeAssetUpdate u LEFT JOIN NewsType n ON n.id = u.type_id WHERE u.theme_id = ? AND u.instrument_id = ? ORDER BY \(order)"
+    private func migrateLegacyInstrumentUpdates() {
+        guard tableExists("PortfolioThemeAssetUpdate"),
+              tableExists("InstrumentNote"),
+              singleIntQuery("SELECT COUNT(*) FROM InstrumentNote") == 0 else { return }
+
+        LoggingService.shared.log("Migrating legacy PortfolioThemeAssetUpdate records into InstrumentNote", logger: .database)
+        let hasTypeColumn = tableHasColumn("PortfolioThemeAssetUpdate", column: "type")
+        let hasBodyMarkdown = tableHasColumn("PortfolioThemeAssetUpdate", column: "body_markdown")
+        let copySQL: String
+        if hasTypeColumn && hasBodyMarkdown {
+            copySQL = "INSERT INTO InstrumentNote (id, instrument_id, theme_id, title, body_text, body_markdown, type, type_id, author, pinned, positions_asof, value_chf, actual_percent, created_at, updated_at) SELECT id, instrument_id, theme_id, title, body_text, body_markdown, type, type_id, author, pinned, positions_asof, value_chf, actual_percent, created_at, updated_at FROM PortfolioThemeAssetUpdate"
+        } else if hasBodyMarkdown {
+            copySQL = "INSERT INTO InstrumentNote (id, instrument_id, theme_id, title, body_text, body_markdown, author, pinned, positions_asof, value_chf, actual_percent, created_at, updated_at) SELECT id, instrument_id, NULL, title, body_text, body_markdown, author, pinned, positions_asof, value_chf, actual_percent, created_at, updated_at FROM PortfolioThemeAssetUpdate"
+        } else {
+            copySQL = "INSERT INTO InstrumentNote (id, instrument_id, theme_id, title, body_text, body_markdown, author, pinned, positions_asof, value_chf, actual_percent, created_at, updated_at) SELECT id, instrument_id, NULL, title, body_text, body_text, author, pinned, positions_asof, value_chf, actual_percent, created_at, updated_at FROM PortfolioThemeAssetUpdate"
+        }
+        if sqlite3_exec(db, copySQL, nil, nil, nil) != SQLITE_OK {
+            LoggingService.shared.log("Legacy migration copy failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+        let updateThemeSQL = "UPDATE InstrumentNote SET theme_id = (SELECT theme_id FROM PortfolioThemeAssetUpdate WHERE PortfolioThemeAssetUpdate.id = InstrumentNote.id) WHERE theme_id IS NULL"
+        if sqlite3_exec(db, updateThemeSQL, nil, nil, nil) != SQLITE_OK {
+            LoggingService.shared.log("Legacy migration theme assignment failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+        }
+    }
+
+    private func fetchInstrumentNotes(sql: String, bind: (OpaquePointer) -> Void) -> [InstrumentNote] {
+        guard let db else { return [] }
         var stmt: OpaquePointer?
+        var notes: [InstrumentNote] = []
         if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
-            sqlite3_bind_int(stmt, 1, Int32(themeId))
-            sqlite3_bind_int(stmt, 2, Int32(instrumentId))
+            bind(stmt!)
             while sqlite3_step(stmt) == SQLITE_ROW {
                 let id = Int(sqlite3_column_int(stmt, 0))
-                let themeId = Int(sqlite3_column_int(stmt, 1))
-                let instrumentId = Int(sqlite3_column_int(stmt, 2))
+                let instrumentId = Int(sqlite3_column_int(stmt, 1))
+                let themeId = sqlite3_column_type(stmt, 2) == SQLITE_NULL ? nil : Int(sqlite3_column_int(stmt, 2))
                 let title = String(cString: sqlite3_column_text(stmt, 3))
                 let body = String(cString: sqlite3_column_text(stmt, 4))
                 let typeId = sqlite3_column_type(stmt, 5) == SQLITE_NULL ? nil : Int(sqlite3_column_int(stmt, 5))
-                let typeStr = sqlite3_column_text(stmt, 6).map { String(cString: $0) } ?? ""
+                let typeCode = sqlite3_column_text(stmt, 6).map { String(cString: $0) } ?? "General"
                 let typeName = sqlite3_column_text(stmt, 7).map { String(cString: $0) }
                 let author = String(cString: sqlite3_column_text(stmt, 8))
                 let pinned = sqlite3_column_int(stmt, 9) == 1
                 let positionsAsOf = sqlite3_column_text(stmt, 10).map { String(cString: $0) }
-                let value = sqlite3_column_type(stmt, 11) != SQLITE_NULL ? sqlite3_column_double(stmt, 11) : nil
-                let actual = sqlite3_column_type(stmt, 12) != SQLITE_NULL ? sqlite3_column_double(stmt, 12) : nil
+                let value = sqlite3_column_type(stmt, 11) == SQLITE_NULL ? nil : sqlite3_column_double(stmt, 11)
+                let actual = sqlite3_column_type(stmt, 12) == SQLITE_NULL ? nil : sqlite3_column_double(stmt, 12)
                 let created = String(cString: sqlite3_column_text(stmt, 13))
                 let updated = String(cString: sqlite3_column_text(stmt, 14))
-                items.append(PortfolioThemeAssetUpdate(id: id, themeId: themeId, instrumentId: instrumentId, title: title, bodyMarkdown: body, typeId: typeId, typeCode: typeStr, typeDisplayName: typeName, author: author, pinned: pinned, positionsAsOf: positionsAsOf, valueChf: value, actualPercent: actual, createdAt: created, updatedAt: updated))
+                let note = InstrumentNote(id: id, instrumentId: instrumentId, themeId: themeId, title: title, bodyMarkdown: body, typeId: typeId, typeCode: typeCode, typeDisplayName: typeName, author: author, pinned: pinned, positionsAsOf: positionsAsOf, valueChf: value, actualPercent: actual, createdAt: created, updatedAt: updated)
+                notes.append(note)
             }
         } else {
-            LoggingService.shared.log("Failed to prepare listInstrumentUpdates: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            LoggingService.shared.log("fetchInstrumentNotes prepare failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
         }
         sqlite3_finalize(stmt)
-        return items
+        return notes
     }
 
-    func getInstrumentUpdate(id: Int) -> PortfolioThemeAssetUpdate? {
-        let sql = "SELECT u.id, u.theme_id, u.instrument_id, u.title, u.body_markdown, u.type_id, n.code, n.display_name, u.author, u.pinned, u.positions_asof, u.value_chf, u.actual_percent, u.created_at, u.updated_at FROM PortfolioThemeAssetUpdate u LEFT JOIN NewsType n ON n.id = u.type_id WHERE u.id = ?"
-        var stmt: OpaquePointer?
-        var item: PortfolioThemeAssetUpdate?
-        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+    func listInstrumentUpdates(themeId: Int, instrumentId: Int, pinnedFirst: Bool = true) -> [InstrumentNote] {
+        let order = pinnedFirst ? "n.pinned DESC, n.created_at DESC" : "n.created_at DESC"
+        let sql = """
+            SELECT n.id, n.instrument_id, n.theme_id, n.title, n.body_markdown, n.type_id, nt.code, nt.display_name, n.author, n.pinned, n.positions_asof, n.value_chf, n.actual_percent, n.created_at, n.updated_at
+            FROM InstrumentNote n
+            LEFT JOIN NewsType nt ON nt.id = n.type_id
+            WHERE n.theme_id = ? AND n.instrument_id = ?
+            ORDER BY \(order)
+        """
+        return fetchInstrumentNotes(sql: sql) { stmt in
+            sqlite3_bind_int(stmt, 1, Int32(themeId))
+            sqlite3_bind_int(stmt, 2, Int32(instrumentId))
+        }
+    }
+
+    func getInstrumentUpdate(id: Int) -> InstrumentNote? {
+        let sql = """
+            SELECT n.id, n.instrument_id, n.theme_id, n.title, n.body_markdown, n.type_id, nt.code, nt.display_name, n.author, n.pinned, n.positions_asof, n.value_chf, n.actual_percent, n.created_at, n.updated_at
+            FROM InstrumentNote n
+            LEFT JOIN NewsType nt ON nt.id = n.type_id
+            WHERE n.id = ?
+        """
+        return fetchInstrumentNotes(sql: sql) { stmt in
             sqlite3_bind_int(stmt, 1, Int32(id))
-            if sqlite3_step(stmt) == SQLITE_ROW {
-                let id = Int(sqlite3_column_int(stmt, 0))
-                let themeId = Int(sqlite3_column_int(stmt, 1))
-                let instrumentId = Int(sqlite3_column_int(stmt, 2))
-                let title = String(cString: sqlite3_column_text(stmt, 3))
-                let body = String(cString: sqlite3_column_text(stmt, 4))
-                let typeId = sqlite3_column_type(stmt, 5) == SQLITE_NULL ? nil : Int(sqlite3_column_int(stmt, 5))
-                let typeStr = sqlite3_column_text(stmt, 6).map { String(cString: $0) } ?? ""
-                let typeName = sqlite3_column_text(stmt, 7).map { String(cString: $0) }
-                let author = String(cString: sqlite3_column_text(stmt, 8))
-                let pinned = sqlite3_column_int(stmt, 9) == 1
-                let positionsAsOf = sqlite3_column_text(stmt, 10).map { String(cString: $0) }
-                let value = sqlite3_column_type(stmt, 11) != SQLITE_NULL ? sqlite3_column_double(stmt, 11) : nil
-                let actual = sqlite3_column_type(stmt, 12) != SQLITE_NULL ? sqlite3_column_double(stmt, 12) : nil
-                let created = String(cString: sqlite3_column_text(stmt, 13))
-                let updated = String(cString: sqlite3_column_text(stmt, 14))
-                item = PortfolioThemeAssetUpdate(id: id, themeId: themeId, instrumentId: instrumentId, title: title, bodyMarkdown: body, typeId: typeId, typeCode: typeStr, typeDisplayName: typeName, author: author, pinned: pinned, positionsAsOf: positionsAsOf, valueChf: value, actualPercent: actual, createdAt: created, updatedAt: updated)
-            }
-        } else {
-            LoggingService.shared.log("Failed to prepare getInstrumentUpdate: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
-        }
-        sqlite3_finalize(stmt)
-        return item
+        }.first
     }
 
-    func createInstrumentUpdate(themeId: Int, instrumentId: Int, title: String, bodyMarkdown: String, newsTypeCode: String, pinned: Bool, author: String, breadcrumb: (positionsAsOf: String?, valueChf: Double?, actualPercent: Double?)? = nil, source: String? = nil) -> PortfolioThemeAssetUpdate? {
-        guard PortfolioThemeAssetUpdate.isValidTitle(title), PortfolioThemeAssetUpdate.isValidBody(bodyMarkdown) else {
+    func createInstrumentUpdate(themeId: Int, instrumentId: Int, title: String, bodyMarkdown: String, newsTypeCode: String, pinned: Bool, author: String, breadcrumb: (positionsAsOf: String?, valueChf: Double?, actualPercent: Double?)? = nil, source: String? = nil) -> InstrumentNote? {
+        guard InstrumentNote.isValidTitle(title), InstrumentNote.isValidBody(bodyMarkdown) else {
             LoggingService.shared.log("Invalid title/body for instrument update", type: .info, logger: .database)
             return nil
         }
-        let hasTypeCol = tableHasColumn("PortfolioThemeAssetUpdate", column: "type")
-        let sql = hasTypeCol
-            ? "INSERT INTO PortfolioThemeAssetUpdate (theme_id, instrument_id, title, body_text, body_markdown, type, type_id, author, pinned, positions_asof, value_chf, actual_percent) VALUES (?,?,?,?,?,?,(SELECT id FROM NewsType WHERE code = ?),?,?,?, ?,?)"
-            : "INSERT INTO PortfolioThemeAssetUpdate (theme_id, instrument_id, title, body_text, body_markdown, type_id, author, pinned, positions_asof, value_chf, actual_percent) VALUES (?,?,?,?,?, (SELECT id FROM NewsType WHERE code = ?), ?,?,?, ?,?)"
+        let sql = """
+            INSERT INTO InstrumentNote (instrument_id, theme_id, title, body_text, body_markdown, type, type_id, author, pinned, positions_asof, value_chf, actual_percent)
+            VALUES (?, ?, ?, ?, ?, ?, (SELECT id FROM NewsType WHERE code = ?), ?, ?, ?, ?, ?)
+        """
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
             LoggingService.shared.log("prepare createInstrumentUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
             return nil
         }
         let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
-        var idx: Int32 = 1
-        sqlite3_bind_int(stmt, idx, Int32(themeId)); idx += 1
-        sqlite3_bind_int(stmt, idx, Int32(instrumentId)); idx += 1
-        sqlite3_bind_text(stmt, idx, title, -1, SQLITE_TRANSIENT); idx += 1
-        sqlite3_bind_text(stmt, idx, bodyMarkdown, -1, SQLITE_TRANSIENT); idx += 1
-        sqlite3_bind_text(stmt, idx, bodyMarkdown, -1, SQLITE_TRANSIENT); idx += 1
-        if hasTypeCol {
-            sqlite3_bind_text(stmt, idx, newsTypeCode, -1, SQLITE_TRANSIENT); idx += 1
-        }
-        // bind for subselect (type code again)
-        sqlite3_bind_text(stmt, idx, newsTypeCode, -1, SQLITE_TRANSIENT); idx += 1
-        sqlite3_bind_text(stmt, idx, author, -1, SQLITE_TRANSIENT); idx += 1
-        sqlite3_bind_int(stmt, idx, pinned ? 1 : 0); idx += 1
+        sqlite3_bind_int(stmt, 1, Int32(instrumentId))
+        sqlite3_bind_int(stmt, 2, Int32(themeId))
+        sqlite3_bind_text(stmt, 3, title, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 4, bodyMarkdown, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 5, bodyMarkdown, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 6, newsTypeCode, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 7, newsTypeCode, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 8, author, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_int(stmt, 9, pinned ? 1 : 0)
         if let bc = breadcrumb {
-            if let s = bc.positionsAsOf { sqlite3_bind_text(stmt, idx, s, -1, SQLITE_TRANSIENT) } else { sqlite3_bind_null(stmt, idx) }
-            idx += 1
-            if let v = bc.valueChf { sqlite3_bind_double(stmt, idx, v) } else { sqlite3_bind_null(stmt, idx) }
-            idx += 1
-            if let a = bc.actualPercent { sqlite3_bind_double(stmt, idx, a) } else { sqlite3_bind_null(stmt, idx) }
+            if let pos = bc.positionsAsOf {
+                sqlite3_bind_text(stmt, 10, pos, -1, SQLITE_TRANSIENT)
+            } else {
+                sqlite3_bind_null(stmt, 10)
+            }
+            if let value = bc.valueChf {
+                sqlite3_bind_double(stmt, 11, value)
+            } else {
+                sqlite3_bind_null(stmt, 11)
+            }
+            if let actual = bc.actualPercent {
+                sqlite3_bind_double(stmt, 12, actual)
+            } else {
+                sqlite3_bind_null(stmt, 12)
+            }
         } else {
-            sqlite3_bind_null(stmt, idx); idx += 1
-            sqlite3_bind_null(stmt, idx); idx += 1
-            sqlite3_bind_null(stmt, idx)
+            sqlite3_bind_null(stmt, 10)
+            sqlite3_bind_null(stmt, 11)
+            sqlite3_bind_null(stmt, 12)
         }
         guard sqlite3_step(stmt) == SQLITE_DONE else {
-            LoggingService.shared.log("createInstrumentUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            LoggingService.shared.log("createInstrumentUpdate insert failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
             sqlite3_finalize(stmt)
             return nil
         }
-        let newId = Int(sqlite3_last_insert_rowid(db))
         sqlite3_finalize(stmt)
+        let newId = Int(sqlite3_last_insert_rowid(db))
         guard let item = getInstrumentUpdate(id: newId) else { return nil }
         var payload: [String: Any] = [
             "themeId": themeId,
@@ -156,28 +248,26 @@ extension DatabaseManager {
         return item
     }
 
-    func updateInstrumentUpdate(id: Int, title: String?, bodyMarkdown: String?, newsTypeCode: String?, pinned: Bool?, actor: String, expectedUpdatedAt: String, source: String? = nil) -> PortfolioThemeAssetUpdate? {
+    func updateInstrumentUpdate(id: Int, title: String?, bodyMarkdown: String?, newsTypeCode: String?, pinned: Bool?, actor: String, expectedUpdatedAt: String, source: String? = nil) -> InstrumentNote? {
         var sets: [String] = []
         if let title = title {
-            guard PortfolioThemeAssetUpdate.isValidTitle(title) else { return nil }
+            guard InstrumentNote.isValidTitle(title) else { return nil }
             sets.append("title = ?")
         }
         if let bodyMarkdown = bodyMarkdown {
-            guard PortfolioThemeAssetUpdate.isValidBody(bodyMarkdown) else { return nil }
+            guard InstrumentNote.isValidBody(bodyMarkdown) else { return nil }
             sets.append("body_text = ?")
             sets.append("body_markdown = ?")
         }
         if let _ = newsTypeCode {
-            if tableHasColumn("PortfolioThemeAssetUpdate", column: "type") {
-                sets.append("type = ?")
-            }
+            sets.append("type = ?")
             sets.append("type_id = (SELECT id FROM NewsType WHERE code = ?)")
         }
         if let _ = pinned {
             sets.append("pinned = ?")
         }
         sets.append("updated_at = STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')")
-        let sql = "UPDATE PortfolioThemeAssetUpdate SET \(sets.joined(separator: ", ")) WHERE id = ? AND updated_at = ?"
+        let sql = "UPDATE InstrumentNote SET \(sets.joined(separator: ", ")) WHERE id = ? AND updated_at = ?"
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
             LoggingService.shared.log("prepare updateInstrumentUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
@@ -193,13 +283,11 @@ extension DatabaseManager {
             sqlite3_bind_text(stmt, idx, bodyMarkdown, -1, SQLITE_TRANSIENT); idx += 1
         }
         if let code = newsTypeCode {
-            if tableHasColumn("PortfolioThemeAssetUpdate", column: "type") {
-                sqlite3_bind_text(stmt, idx, code, -1, SQLITE_TRANSIENT); idx += 1
-            }
+            sqlite3_bind_text(stmt, idx, code, -1, SQLITE_TRANSIENT); idx += 1
             sqlite3_bind_text(stmt, idx, code, -1, SQLITE_TRANSIENT); idx += 1
         }
-        if let pinned = pinned {
-            sqlite3_bind_int(stmt, idx, pinned ? 1 : 0); idx += 1
+        if let pin = pinned {
+            sqlite3_bind_int(stmt, idx, pin ? 1 : 0); idx += 1
         }
         sqlite3_bind_int(stmt, idx, Int32(id)); idx += 1
         sqlite3_bind_text(stmt, idx, expectedUpdatedAt, -1, SQLITE_TRANSIENT)
@@ -220,7 +308,7 @@ extension DatabaseManager {
             op = pinned ? "pin" : "unpin"
         }
         var payload: [String: Any] = [
-            "themeId": item.themeId,
+            "themeId": item.themeId ?? -1,
             "instrumentId": item.instrumentId,
             "updateId": id,
             "actor": actor,
@@ -236,23 +324,9 @@ extension DatabaseManager {
     }
 
     func deleteInstrumentUpdate(id: Int, actor: String, source: String? = nil) -> Bool {
-        var themeId: Int = 0
-        var instrumentId: Int = 0
-        var pinned: Int32 = 0
-        var updatedAt: String = ""
+        guard let item = getInstrumentUpdate(id: id) else { return false }
         var stmt: OpaquePointer?
-        if sqlite3_prepare_v2(db, "SELECT theme_id, instrument_id, pinned, updated_at FROM PortfolioThemeAssetUpdate WHERE id = ?", -1, &stmt, nil) == SQLITE_OK {
-            sqlite3_bind_int(stmt, 1, Int32(id))
-            if sqlite3_step(stmt) == SQLITE_ROW {
-                themeId = Int(sqlite3_column_int(stmt, 0))
-                instrumentId = Int(sqlite3_column_int(stmt, 1))
-                pinned = sqlite3_column_int(stmt, 2)
-                updatedAt = String(cString: sqlite3_column_text(stmt, 3))
-            }
-        }
-        sqlite3_finalize(stmt)
-        guard themeId != 0 else { return false }
-        if sqlite3_prepare_v2(db, "DELETE FROM PortfolioThemeAssetUpdate WHERE id = ?", -1, &stmt, nil) != SQLITE_OK {
+        if sqlite3_prepare_v2(db, "DELETE FROM InstrumentNote WHERE id = ?", -1, &stmt, nil) != SQLITE_OK {
             LoggingService.shared.log("prepare deleteInstrumentUpdate failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
             return false
         }
@@ -264,13 +338,13 @@ extension DatabaseManager {
         }
         sqlite3_finalize(stmt)
         var payload: [String: Any] = [
-            "themeId": themeId,
-            "instrumentId": instrumentId,
+            "themeId": item.themeId ?? -1,
+            "instrumentId": item.instrumentId,
             "updateId": id,
             "actor": actor,
             "op": "delete",
-            "pinned": Int(pinned),
-            "updated_at": updatedAt
+            "pinned": item.pinned ? 1 : 0,
+            "updated_at": item.updatedAt
         ]
         if let source = source { payload["source"] = source }
         if let data = try? JSONSerialization.data(withJSONObject: payload), let log = String(data: data, encoding: .utf8) {
@@ -280,23 +354,14 @@ extension DatabaseManager {
     }
 
     func countInstrumentUpdates(themeId: Int, instrumentId: Int) -> Int {
-        let sql = "SELECT COUNT(*) FROM PortfolioThemeAssetUpdate WHERE theme_id = ? AND instrument_id = ?"
-        var stmt: OpaquePointer?
-        var count = 0
-        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+        let sql = "SELECT COUNT(*) FROM InstrumentNote WHERE theme_id = ? AND instrument_id = ?"
+        return singleIntQuery(sql) { stmt in
             sqlite3_bind_int(stmt, 1, Int32(themeId))
             sqlite3_bind_int(stmt, 2, Int32(instrumentId))
-            if sqlite3_step(stmt) == SQLITE_ROW {
-                count = Int(sqlite3_column_int(stmt, 0))
-            }
-        } else {
-            LoggingService.shared.log("Failed to prepare countInstrumentUpdates: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
-        }
-        sqlite3_finalize(stmt)
-        return count
+        } ?? 0
     }
 
-    private func normalize(_ text: String) -> String {
+    private func normalizeForMentions(_ text: String) -> String {
         let lowered = text.lowercased()
         let mapped = lowered.map { $0.isLetter || $0.isNumber ? String($0) : " " }.joined()
         let collapsed = mapped.split { $0 == " " }.joined(separator: " ")
@@ -304,6 +369,7 @@ extension DatabaseManager {
     }
 
     private func mentionCount(themeId: Int, code: String, name: String) -> Int {
+        guard let db else { return 0 }
         let sql = "SELECT title, COALESCE(body_markdown, body_text) FROM PortfolioThemeUpdate WHERE theme_id = ? AND soft_delete = 0"
         var stmt: OpaquePointer?
         var count = 0
@@ -313,7 +379,7 @@ extension DatabaseManager {
                 let title = String(cString: sqlite3_column_text(stmt, 0))
                 let body = String(cString: sqlite3_column_text(stmt, 1))
                 let combined = title + " " + body
-                let norm = normalize(combined)
+                let norm = normalizeForMentions(combined)
                 var matched = false
                 if code.count >= 3 {
                     let token = " " + code.lowercased() + " "
@@ -333,7 +399,7 @@ extension DatabaseManager {
                 if matched { count += 1 }
             }
         } else {
-            LoggingService.shared.log("Failed to prepare mentionCount: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            LoggingService.shared.log("mentionCount prepare failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
         }
         sqlite3_finalize(stmt)
         return count
@@ -341,11 +407,11 @@ extension DatabaseManager {
 
     func listThemesForInstrumentWithUpdateCounts(instrumentId: Int, instrumentCode: String, instrumentName: String) -> [(themeId: Int, themeName: String, isArchived: Bool, updatesCount: Int, mentionsCount: Int)] {
         let sql = """
-            SELECT t.id, t.name, t.archived_at IS NOT NULL AS archived, COUNT(u.id) AS cnt
+            SELECT t.id, t.name, t.archived_at IS NOT NULL AS archived, COUNT(n.id) AS cnt
             FROM PortfolioThemeAsset a
             JOIN PortfolioTheme t ON a.theme_id = t.id
-            LEFT JOIN PortfolioThemeAssetUpdate u
-                ON u.theme_id = a.theme_id AND u.instrument_id = a.instrument_id
+            LEFT JOIN InstrumentNote n
+                ON n.theme_id = a.theme_id AND n.instrument_id = a.instrument_id
             WHERE a.instrument_id = ?
             GROUP BY t.id, t.name, t.archived_at
             ORDER BY t.name
@@ -363,7 +429,7 @@ extension DatabaseManager {
                 results.append((themeId, name, archived, count, mentions))
             }
         } else {
-            LoggingService.shared.log("Failed to prepare listThemesForInstrumentWithUpdateCounts: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
+            LoggingService.shared.log("listThemesForInstrumentWithUpdateCounts failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
         }
         sqlite3_finalize(stmt)
         return results
@@ -371,50 +437,31 @@ extension DatabaseManager {
 }
 
 extension DatabaseManager {
-    func listAllInstrumentUpdates(pinnedFirst: Bool = true, searchQuery: String? = nil, typeId: Int? = nil) -> [PortfolioThemeAssetUpdate] {
-        var items: [PortfolioThemeAssetUpdate] = []
+    func listAllInstrumentUpdates(pinnedFirst: Bool = true, searchQuery: String? = nil, typeId: Int? = nil) -> [InstrumentNote] {
         var clauses: [String] = []
-        var binds: [Any] = []
-        if let tid = typeId { clauses.append("u.type_id = ?"); binds.append(tid) }
+        if typeId != nil { clauses.append("n.type_id = ?") }
         if let q = searchQuery, !q.isEmpty {
-            clauses.append("(LOWER(u.title) LIKE '%' || LOWER(?) || '%' OR LOWER(COALESCE(u.body_markdown, u.body_text)) LIKE '%' || LOWER(?) || '%')")
-            binds.append(q)
-            binds.append(q)
+            clauses.append("(LOWER(n.title) LIKE '%' || LOWER(?) || '%' OR LOWER(n.body_markdown) LIKE '%' || LOWER(?) || '%')")
         }
         let whereClause = clauses.isEmpty ? "1=1" : clauses.joined(separator: " AND ")
-        let order = pinnedFirst ? "u.pinned DESC, u.created_at DESC" : "u.created_at DESC"
-        let sql = "SELECT u.id, u.theme_id, u.instrument_id, u.title, u.body_markdown, u.type_id, n.code, n.display_name, u.author, u.pinned, u.positions_asof, u.value_chf, u.actual_percent, u.created_at, u.updated_at FROM PortfolioThemeAssetUpdate u LEFT JOIN NewsType n ON n.id = u.type_id WHERE \(whereClause) ORDER BY \(order)"
-        var stmt: OpaquePointer?
-        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+        let order = pinnedFirst ? "n.pinned DESC, n.created_at DESC" : "n.created_at DESC"
+        let sql = """
+            SELECT n.id, n.instrument_id, n.theme_id, n.title, n.body_markdown, n.type_id, nt.code, nt.display_name, n.author, n.pinned, n.positions_asof, n.value_chf, n.actual_percent, n.created_at, n.updated_at
+            FROM InstrumentNote n
+            LEFT JOIN NewsType nt ON nt.id = n.type_id
+            WHERE \(whereClause)
+            ORDER BY \(order)
+        """
+        return fetchInstrumentNotes(sql: sql) { stmt in
             var idx: Int32 = 1
-            for b in binds {
-                if let i = b as? Int { sqlite3_bind_int(stmt, idx, Int32(i)) }
-                else if let s = b as? String {
-                    let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
-                    sqlite3_bind_text(stmt, idx, s, -1, SQLITE_TRANSIENT)
-                }
-                idx += 1
+            if let tid = typeId {
+                sqlite3_bind_int(stmt, idx, Int32(tid)); idx += 1
             }
-            while sqlite3_step(stmt) == SQLITE_ROW {
-                let id = Int(sqlite3_column_int(stmt, 0))
-                let themeId = Int(sqlite3_column_int(stmt, 1))
-                let instrumentId = Int(sqlite3_column_int(stmt, 2))
-                let title = String(cString: sqlite3_column_text(stmt, 3))
-                let body = String(cString: sqlite3_column_text(stmt, 4))
-                let typeId = sqlite3_column_type(stmt, 5) == SQLITE_NULL ? nil : Int(sqlite3_column_int(stmt, 5))
-                let typeStr = sqlite3_column_text(stmt, 6).map { String(cString: $0) } ?? ""
-                let typeName = sqlite3_column_text(stmt, 7).map { String(cString: $0) }
-                let author = String(cString: sqlite3_column_text(stmt, 8))
-                let pinned = sqlite3_column_int(stmt, 9) == 1
-                let positionsAsOf = sqlite3_column_text(stmt, 10).map { String(cString: $0) }
-                let value = sqlite3_column_type(stmt, 11) != SQLITE_NULL ? sqlite3_column_double(stmt, 11) : nil
-                let actual = sqlite3_column_type(stmt, 12) != SQLITE_NULL ? sqlite3_column_double(stmt, 12) : nil
-                let created = String(cString: sqlite3_column_text(stmt, 13))
-                let updated = String(cString: sqlite3_column_text(stmt, 14))
-                items.append(PortfolioThemeAssetUpdate(id: id, themeId: themeId, instrumentId: instrumentId, title: title, bodyMarkdown: body, typeId: typeId, typeCode: typeStr, typeDisplayName: typeName, author: author, pinned: pinned, positionsAsOf: positionsAsOf, valueChf: value, actualPercent: actual, createdAt: created, updatedAt: updated))
+            if let q = searchQuery, !q.isEmpty {
+                let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+                sqlite3_bind_text(stmt, idx, q, -1, SQLITE_TRANSIENT); idx += 1
+                sqlite3_bind_text(stmt, idx, q, -1, SQLITE_TRANSIENT); idx += 1
             }
         }
-        sqlite3_finalize(stmt)
-        return items
     }
 }

--- a/DragonShield/DatabaseManager+PortfolioThemes.swift
+++ b/DragonShield/DatabaseManager+PortfolioThemes.swift
@@ -588,10 +588,7 @@ extension DatabaseManager {
         // Count direct links to provide actionable guidance
         let assetLinks = singleIntQuery("SELECT COUNT(*) FROM PortfolioThemeAsset WHERE theme_id = ?") { stmt in sqlite3_bind_int(stmt, 1, Int32(id)) } ?? 0
         let themeUpdates = singleIntQuery("SELECT COUNT(*) FROM PortfolioThemeUpdate WHERE theme_id = ? AND soft_delete = 0") { stmt in sqlite3_bind_int(stmt, 1, Int32(id)) } ?? 0
-        var instrumentUpdates = 0
-        if tableExists("PortfolioThemeAssetUpdate") {
-            instrumentUpdates = singleIntQuery("SELECT COUNT(*) FROM PortfolioThemeAssetUpdate WHERE theme_id = ?") { stmt in sqlite3_bind_int(stmt, 1, Int32(id)) } ?? 0
-        }
+        let instrumentUpdates = singleIntQuery("SELECT COUNT(*) FROM InstrumentNote WHERE theme_id = ?") { stmt in sqlite3_bind_int(stmt, 1, Int32(id)) } ?? 0
         if assetLinks > 0 || themeUpdates > 0 || instrumentUpdates > 0 {
             // Build a precise message with only non-zero categories
             var parts: [String] = []

--- a/DragonShield/DatabaseManager.swift
+++ b/DragonShield/DatabaseManager.swift
@@ -187,6 +187,14 @@ class DatabaseManager: ObservableObject {
         #endif
     }
 
+    func lastSQLErrorMessage() -> String {
+        guard let db else { return "database not open" }
+        if let cString = sqlite3_errmsg(db) {
+            return String(cString: cString)
+        }
+        return "unknown database error"
+    }
+
     /// Open a specific SQLite file in read-only mode (used by the iOS app to open a snapshot).
     /// The manager will point to the provided path until reopened or switched.
     @discardableResult

--- a/DragonShield/Models/InstrumentNote.swift
+++ b/DragonShield/Models/InstrumentNote.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Represents a note captured for an instrument. Notes can exist at the instrument level
+/// (no portfolio linkage) or be scoped to a specific portfolio theme.
+public struct InstrumentNote: Identifiable, Codable {
+    public let id: Int
+    public let instrumentId: Int
+    public var themeId: Int?
+    public var title: String
+    public var bodyMarkdown: String
+    public var typeId: Int?
+    public var typeCode: String
+    public var typeDisplayName: String?
+    public let author: String
+    public var pinned: Bool
+    public var positionsAsOf: String?
+    public var valueChf: Double?
+    public var actualPercent: Double?
+    public let createdAt: String
+    public var updatedAt: String
+
+    /// True when the note applies to the instrument without any specific theme.
+    public var isInstrumentOnly: Bool { themeId == nil }
+
+    public static func isValidTitle(_ title: String) -> Bool {
+        let count = title.trimmingCharacters(in: .whitespacesAndNewlines).count
+        return count >= 1 && count <= 120
+    }
+
+    public static func isValidBody(_ body: String) -> Bool {
+        let count = body.trimmingCharacters(in: .whitespacesAndNewlines).count
+        return count >= 1 && count <= 5000
+    }
+}

--- a/DragonShield/Models/PortfolioThemeAssetUpdate.swift
+++ b/DragonShield/Models/PortfolioThemeAssetUpdate.swift
@@ -1,36 +1,6 @@
-// DragonShield/Models/PortfolioThemeAssetUpdate.swift
-// MARK: - Version 1.1
-// MARK: - History
-// - 1.0: Initial instrument-level update model for Step 7A.
-// - 1.0 -> 1.1: Add Markdown body and pin flag for Phase 7B.
-
 import Foundation
 
-struct PortfolioThemeAssetUpdate: Identifiable, Codable {
-
-    let id: Int
-    let themeId: Int
-    let instrumentId: Int
-    var title: String
-    var bodyMarkdown: String
-    var typeId: Int?
-    var typeCode: String
-    var typeDisplayName: String?
-    let author: String
-    var pinned: Bool
-    var positionsAsOf: String?
-    var valueChf: Double?
-    var actualPercent: Double?
-    let createdAt: String
-    var updatedAt: String
-
-    static func isValidTitle(_ title: String) -> Bool {
-        let count = title.trimmingCharacters(in: .whitespacesAndNewlines).count
-        return count >= 1 && count <= 120
-    }
-
-    static func isValidBody(_ body: String) -> Bool {
-        let count = body.trimmingCharacters(in: .whitespacesAndNewlines).count
-        return count >= 1 && count <= 5000
-    }
-}
+/// Backwards compatibility alias. Theme-linked instrument notes now reuse the
+/// `InstrumentNote` model; legacy call sites continue referencing
+/// `PortfolioThemeAssetUpdate`.
+public typealias PortfolioThemeAssetUpdate = InstrumentNote

--- a/DragonShield/Services/AttachmentService.swift
+++ b/DragonShield/Services/AttachmentService.swift
@@ -193,7 +193,7 @@ final class AttachmentService {
             _ = sqlite3_step(stmt)
             sqlite3_finalize(stmt)
         }
-        let unlink2 = "DELETE FROM ThemeAssetUpdateAttachment WHERE attachment_id = ?"
+        let unlink2 = "DELETE FROM InstrumentNoteAttachment WHERE attachment_id = ?"
         if sqlite3_prepare_v2(db, unlink2, -1, &stmt, nil) == SQLITE_OK {
             sqlite3_bind_int(stmt, 1, Int32(attachmentId))
             _ = sqlite3_step(stmt)
@@ -228,7 +228,7 @@ final class AttachmentService {
 
     func cleanupOrphans() -> Int {
         guard let db = dbManager.db else { return 0 }
-        let sql = "SELECT id, sha256, ext FROM Attachment WHERE id NOT IN (SELECT attachment_id FROM ThemeUpdateAttachment UNION SELECT attachment_id FROM ThemeAssetUpdateAttachment)"
+        let sql = "SELECT id, sha256, ext FROM Attachment WHERE id NOT IN (SELECT attachment_id FROM ThemeUpdateAttachment UNION SELECT attachment_id FROM InstrumentNoteAttachment)"
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return 0 }
         var deleted = 0
@@ -266,4 +266,3 @@ final class AttachmentService {
 
     private static let sqliteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
 }
-

--- a/DragonShield/ThemeAssetUpdateRepository.swift
+++ b/DragonShield/ThemeAssetUpdateRepository.swift
@@ -15,7 +15,7 @@ final class ThemeAssetUpdateRepository {
     func linkAttachment(updateId: Int, attachmentId: Int) -> Bool {
         guard let db = dbManager.db else { return false }
         let sql = """
-        INSERT INTO ThemeAssetUpdateAttachment (theme_asset_update_id, attachment_id, created_at)
+        INSERT INTO InstrumentNoteAttachment (instrument_note_id, attachment_id, created_at)
         VALUES (?, ?, STRFTIME('%Y-%m-%dT%H:%M:%fZ','now'))
         """
         var stmt: OpaquePointer?
@@ -33,7 +33,7 @@ final class ThemeAssetUpdateRepository {
     @discardableResult
     func unlinkAttachment(updateId: Int, attachmentId: Int) -> Bool {
         guard let db = dbManager.db else { return false }
-        let sql = "DELETE FROM ThemeAssetUpdateAttachment WHERE theme_asset_update_id = ? AND attachment_id = ?"
+        let sql = "DELETE FROM InstrumentNoteAttachment WHERE instrument_note_id = ? AND attachment_id = ?"
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
             LoggingService.shared.log("prepare unlinkAttachment failed: \(String(cString: sqlite3_errmsg(db)))", type: .error, logger: .database)
@@ -50,9 +50,9 @@ final class ThemeAssetUpdateRepository {
         guard let db = dbManager.db else { return [] }
         let sql = """
         SELECT a.id, a.sha256, a.original_filename, a.mime, a.byte_size, a.ext, a.created_at, a.created_by
-        FROM ThemeAssetUpdateAttachment t
+        FROM InstrumentNoteAttachment t
         JOIN Attachment a ON a.id = t.attachment_id
-        WHERE t.theme_asset_update_id = ?
+        WHERE t.instrument_note_id = ?
         ORDER BY t.id
         """
         var stmt: OpaquePointer?

--- a/DragonShield/Views/DashboardTiles/DashboardTiles.swift
+++ b/DragonShield/Views/DashboardTiles/DashboardTiles.swift
@@ -512,8 +512,13 @@ struct AllNotesTile: DashboardTile {
                 .environmentObject(dbManager)
         }
         .sheet(item: $editingInstrument) { upd in
-            InstrumentUpdateEditorView(themeId: upd.themeId, instrumentId: upd.instrumentId, instrumentName: instrumentNames[upd.instrumentId] ?? "#\(upd.instrumentId)", themeName: themeNames[upd.themeId] ?? "", existing: upd, onSave: { _ in editingInstrument = nil; load() }, onCancel: { editingInstrument = nil })
-                .environmentObject(dbManager)
+            if let themeId = upd.themeId {
+                InstrumentUpdateEditorView(themeId: themeId, instrumentId: upd.instrumentId, instrumentName: instrumentNames[upd.instrumentId] ?? "#\(upd.instrumentId)", themeName: themeNames[themeId] ?? "", existing: upd, onSave: { _ in editingInstrument = nil; load() }, onCancel: { editingInstrument = nil })
+                    .environmentObject(dbManager)
+            } else {
+                InstrumentNoteEditorView(instrumentId: upd.instrumentId, instrumentName: instrumentNames[upd.instrumentId] ?? "#\(upd.instrumentId)", existing: upd, onSave: { _ in editingInstrument = nil; load() }, onCancel: { editingInstrument = nil })
+                    .environmentObject(dbManager)
+            }
         }
     }
 
@@ -529,7 +534,13 @@ struct AllNotesTile: DashboardTile {
             let combined: [Row] = Array(theme.prefix(3)).map { t in
                 Row(id: "t-\(t.id)", title: t.title, subtitle: "Theme: \(themeNameMap[t.themeId] ?? "#\(t.themeId)")", type: t.typeDisplayName ?? t.typeCode, when: DateFormatting.userFriendly(t.createdAt))
             } + Array(instr.prefix(3)).map { u in
-                Row(id: "i-\(u.id)", title: u.title, subtitle: "Instr: \(instrumentNameMap[u.instrumentId] ?? "#\(u.instrumentId)") · Theme: \(themeNameMap[u.themeId] ?? "#\(u.themeId)")", type: u.typeDisplayName ?? u.typeCode, when: DateFormatting.userFriendly(u.createdAt))
+                let themeLabel: String
+                if let tid = u.themeId {
+                    themeLabel = themeNameMap[tid] ?? "#\(tid)"
+                } else {
+                    themeLabel = "General"
+                }
+                return Row(id: "i-\(u.id)", title: u.title, subtitle: "Instr: \(instrumentNameMap[u.instrumentId] ?? "#\(u.instrumentId)") · Theme: \(themeLabel)", type: u.typeDisplayName ?? u.typeCode, when: DateFormatting.userFriendly(u.createdAt))
             }
             DispatchQueue.main.async {
                 self.totalCount = theme.count + instr.count

--- a/DragonShield/Views/InstrumentEditView.swift
+++ b/DragonShield/Views/InstrumentEditView.swift
@@ -531,7 +531,7 @@ struct InstrumentEditView: View {
     private var updatesInThemesSection: some View {
         VStack(alignment: .leading, spacing: 16) {
             HStack {
-                sectionHeader(title: "Updates in Themes", icon: "doc.text", color: .blue)
+                sectionHeader(title: "Instrument Notes/Updates", icon: "doc.text", color: .blue)
                 Spacer()
                 Button("Open Instrument Notes") { openInstrumentNotes() }
                     .buttonStyle(.borderedProminent)
@@ -550,7 +550,11 @@ struct InstrumentEditView: View {
     
     private func openInstrumentNotes() {
         let last = UserDefaults.standard.string(forKey: "instrumentNotesLastTab")
-        notesInitialTab = last == "mentions" ? .mentions : .updates
+        switch last {
+        case "general": notesInitialTab = .general
+        case "mentions": notesInitialTab = .mentions
+        default: notesInitialTab = .updates
+        }
         showNotes = true
         let payload: [String: Any] = ["instrumentId": instrumentId, "action": "instrument_notes_open", "source": "panel"]
         if let data = try? JSONSerialization.data(withJSONObject: payload), let log = String(data: data, encoding: .utf8) {

--- a/DragonShield/Views/InstrumentNoteEditorView.swift
+++ b/DragonShield/Views/InstrumentNoteEditorView.swift
@@ -1,0 +1,180 @@
+import SwiftUI
+import AppKit
+
+struct InstrumentNoteEditorView: View {
+    @EnvironmentObject var dbManager: DatabaseManager
+    let instrumentId: Int
+    let instrumentName: String
+    var existing: InstrumentNote?
+    var onSave: (InstrumentNote) -> Void
+    var onCancel: () -> Void
+
+    enum Mode { case write, preview }
+
+    @State private var title: String
+    @State private var bodyMarkdown: String
+    @State private var selectedTypeId: Int?
+    @State private var newsTypes: [NewsTypeRow] = []
+    @State private var pinned: Bool
+    @State private var mode: Mode = .write
+    @State private var showHelp = false
+    @State private var feedback: SaveFeedback?
+
+    init(instrumentId: Int, instrumentName: String, existing: InstrumentNote? = nil, onSave: @escaping (InstrumentNote) -> Void, onCancel: @escaping () -> Void) {
+        self.instrumentId = instrumentId
+        self.instrumentName = instrumentName
+        self.existing = existing
+        self.onSave = onSave
+        self.onCancel = onCancel
+        _title = State(initialValue: existing?.title ?? "")
+        _bodyMarkdown = State(initialValue: existing?.bodyMarkdown ?? "")
+        _selectedTypeId = State(initialValue: existing?.typeId)
+        _pinned = State(initialValue: existing?.pinned ?? false)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(existing == nil ? "New Note — \(instrumentName)" : "Edit Note — \(instrumentName)")
+                .font(.headline)
+            TextField("Title (1–120)", text: $title)
+            Picker("Type", selection: $selectedTypeId) {
+                ForEach(newsTypes, id: \.id) { nt in
+                    Text(nt.displayName).tag(Optional(nt.id))
+                }
+            }
+            Toggle("Pin this note", isOn: $pinned)
+            HStack {
+                Picker("Mode", selection: $mode) {
+                    Text("Write").tag(Mode.write)
+                    Text("Preview").tag(Mode.preview)
+                }
+                .pickerStyle(.segmented)
+                Button("Help") { showHelp = true }
+                    .popover(isPresented: $showHelp) {
+                        MarkdownHelpView().frame(width: 300, height: 200)
+                    }
+            }
+            if mode == .write {
+                TextEditor(text: $bodyMarkdown)
+                    .frame(minHeight: 160)
+            } else {
+                ScrollView {
+                    Text(MarkdownRenderer.attributedString(from: bodyMarkdown))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .frame(minHeight: 160)
+            }
+            HStack {
+                Text("\(bodyMarkdown.count) / 5000")
+                    .font(.caption)
+                    .foregroundColor(bodyMarkdown.count > 5000 ? .red : .secondary)
+                Spacer()
+                if let existing = existing {
+                    Text("Created: \(DateFormatting.userFriendly(existing.createdAt))   Edited: \(DateFormatting.userFriendly(existing.updatedAt))")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+            HStack {
+                Spacer()
+                Button("Cancel") { onCancel() }
+                    .keyboardShortcut(.cancelAction)
+                if existing != nil {
+                    Button("Delete", role: .destructive) { deleteExisting() }
+                }
+                Button("Save") { save() }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(!valid)
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 480, minHeight: 320)
+        .onAppear {
+            newsTypes = NewsTypeRepository(dbManager: dbManager).listActive()
+            if selectedTypeId == nil {
+                selectedTypeId = newsTypes.first?.id
+            }
+        }
+        .alert(item: $feedback) { info in
+            Alert(title: Text(info.title), message: Text(info.message), dismissButton: .default(Text("OK")))
+        }
+    }
+
+    private var valid: Bool {
+        InstrumentNote.isValidTitle(title) && InstrumentNote.isValidBody(bodyMarkdown)
+    }
+
+    private func save() {
+        let code = newsTypes.first(where: { $0.id == selectedTypeId })?.code ?? PortfolioUpdateType.General.rawValue
+        if let existing = existing {
+            let updated = dbManager.updateInstrumentUpdate(
+                id: existing.id,
+                title: title,
+                bodyMarkdown: bodyMarkdown,
+                newsTypeCode: code,
+                pinned: pinned,
+                actor: NSFullUserName(),
+                expectedUpdatedAt: existing.updatedAt
+            )
+            if let row = updated ?? dbManager.getInstrumentUpdate(id: existing.id) {
+                onSave(row)
+            } else {
+                feedback = SaveFeedback(title: "Save Failed", message: dbManager.lastSQLErrorMessage())
+            }
+        } else {
+            if let created = dbManager.createInstrumentNote(instrumentId: instrumentId, title: title, bodyMarkdown: bodyMarkdown, newsTypeCode: code, pinned: pinned, author: NSFullUserName()) {
+                onSave(created)
+            } else {
+                feedback = SaveFeedback(title: "Save Failed", message: dbManager.lastSQLErrorMessage())
+            }
+        }
+    }
+
+    private func deleteExisting() {
+        guard let existing = existing else { return }
+        let alert = NSAlert()
+        alert.messageText = "Delete this note?"
+        alert.informativeText = "This cannot be undone."
+        alert.addButton(withTitle: "Delete")
+        alert.addButton(withTitle: "Cancel")
+        if alert.runModal() == .alertFirstButtonReturn {
+            if dbManager.deleteInstrumentUpdate(id: existing.id, actor: NSFullUserName()) {
+                onCancel()
+            }
+        }
+    }
+}
+
+private struct MarkdownHelpView: View {
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 8) {
+                helpRow("# Heading", rendered: "# Heading")
+                helpRow("This is **bold**, *italic*, `code`.", rendered: "This is **bold**, *italic*, `code`.")
+                helpRow("- Bullet item", rendered: "- Bullet item")
+                helpRow("1. Numbered", rendered: "1. Numbered")
+                helpRow("Link: [text](https://example.com)", rendered: "Link: [text](https://example.com)")
+                Text("Images and raw HTML are not rendered.")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding()
+        }
+    }
+
+    private func helpRow(_ syntax: String, rendered: String) -> some View {
+        HStack(alignment: .top) {
+            Text(syntax)
+                .font(.system(.body, design: .monospaced))
+            Spacer()
+            Text(MarkdownRenderer.attributedString(from: rendered))
+        }
+    }
+}
+
+private struct SaveFeedback: Identifiable {
+    let id = UUID()
+    let title: String
+    let message: String
+}

--- a/DragonShield/Views/PortfolioView.swift
+++ b/DragonShield/Views/PortfolioView.swift
@@ -1488,6 +1488,7 @@ struct NotesIconView: View {
         .accessibilityLabel("Open notes for \(instrumentName)")
         .help(tooltip)
         .contextMenu {
+            Button("Open General Notes") { openGeneral() }
             Button("Open Updates") { openUpdates() }
             Button("Open Mentions") { openMentions() }
         }
@@ -1516,7 +1517,16 @@ struct NotesIconView: View {
 
     private func openDefault() {
         let last = UserDefaults.standard.string(forKey: "instrumentNotesLastTab")
-        initialTab = last == "mentions" ? .mentions : .updates
+        switch last {
+        case "general": initialTab = .general
+        case "mentions": initialTab = .mentions
+        default: initialTab = .updates
+        }
+        showModal = true
+    }
+
+    private func openGeneral() {
+        initialTab = .general
         showModal = true
     }
 

--- a/DragonShieldTests/PortfolioThemeAssetUpdateTests.swift
+++ b/DragonShieldTests/PortfolioThemeAssetUpdateTests.swift
@@ -100,4 +100,14 @@ final class PortfolioThemeAssetUpdateTests: XCTestCase {
         XCTAssertEqual(summary.updates, 1)
         XCTAssertEqual(summary.mentions, 1)
     }
+
+    func testCreateGeneralInstrumentNote() {
+        let general = manager.createInstrumentNote(instrumentId: 42, title: "General", bodyMarkdown: "Body", type: .General, pinned: false, author: "Tester")
+        XCTAssertNotNil(general)
+        XCTAssertNil(general?.themeId)
+        XCTAssertTrue(general?.isInstrumentOnly ?? false)
+        let list = manager.listInstrumentGeneralNotes(instrumentId: 42)
+        XCTAssertEqual(list.count, 1)
+        XCTAssertNil(list.first?.themeId)
+    }
 }

--- a/DragonShieldTests/ThemeAssetUpdateAttachmentRepositoryTests.swift
+++ b/DragonShieldTests/ThemeAssetUpdateAttachmentRepositoryTests.swift
@@ -66,7 +66,7 @@ final class ThemeAssetUpdateAttachmentRepositoryTests: XCTestCase {
 
         XCTAssertTrue(manager.deleteInstrumentUpdate(id: update.id, actor: "tester"))
         var stmt: OpaquePointer?
-        sqlite3_prepare_v2(manager.db, "SELECT COUNT(*) FROM ThemeAssetUpdateAttachment WHERE attachment_id = ?", -1, &stmt, nil)
+        sqlite3_prepare_v2(manager.db, "SELECT COUNT(*) FROM InstrumentNoteAttachment WHERE attachment_id = ?", -1, &stmt, nil)
         sqlite3_bind_int(stmt, 1, Int32(attachmentId))
         _ = sqlite3_step(stmt)
         let count = sqlite3_column_int(stmt, 0)


### PR DESCRIPTION
## Summary
- add instrument note model and editor views for instruments
- extend database APIs and migrations so instrument-only notes persist independently of themes
- expose instrument notes in dashboard and edit flows, including bugfix keeping general notes from being auto-linked to themes

## Testing
- not run (not requested)
