### PR TITLE
Add archived column and bulk archive to To-Do board

### DIFF
--- a/DragonShield iOS/Shared/KanbanModels.swift
+++ b/DragonShield iOS/Shared/KanbanModels.swift
@@ -79,6 +79,7 @@ enum KanbanColumn: String, CaseIterable, Identifiable, Codable {
     case prioritised
     case doing
     case done
+    case archived
 
     var id: String { rawValue }
 
@@ -88,6 +89,7 @@ enum KanbanColumn: String, CaseIterable, Identifiable, Codable {
         case .prioritised: return "Prioritised"
         case .doing: return "Doing"
         case .done: return "Done"
+        case .archived: return "Archived"
         }
     }
 
@@ -97,6 +99,7 @@ enum KanbanColumn: String, CaseIterable, Identifiable, Codable {
         case .prioritised: return Color.orange
         case .doing: return Color.accentColor
         case .done: return Color.green
+        case .archived: return Color.purple
         }
     }
 
@@ -106,6 +109,7 @@ enum KanbanColumn: String, CaseIterable, Identifiable, Codable {
         case .prioritised: return "flag.circle.fill"
         case .doing: return "hammer"
         case .done: return "checkmark.circle"
+        case .archived: return "archivebox"
         }
     }
 
@@ -115,6 +119,7 @@ enum KanbanColumn: String, CaseIterable, Identifiable, Codable {
         case .prioritised: return "Drag tasks here when they are next up."
         case .doing: return "Drop work in progress into this column."
         case .done: return "Completed tasks will collect here."
+        case .archived: return "Archived tasks live here for reference."
         }
     }
 }
@@ -277,6 +282,31 @@ final class KanbanBoardViewModel: ObservableObject {
         if oldColumn != column {
             normalizeSortOrders(for: oldColumn)
         }
+        save()
+    }
+
+    func archiveDoneTodos() {
+        let doneEntries = todos.enumerated().filter { $0.element.column == .done }
+        guard !doneEntries.isEmpty else { return }
+
+        let sortedDone = doneEntries.sorted { lhs, rhs in
+            if lhs.element.sortOrder == rhs.element.sortOrder {
+                return lhs.element.createdAt < rhs.element.createdAt
+            }
+            return lhs.element.sortOrder < rhs.element.sortOrder
+        }
+
+        let startingOrder = (todos.filter { $0.column == .archived }.map(\.sortOrder).max() ?? -1) + 1
+        var nextOrder = startingOrder
+
+        for entry in sortedDone {
+            todos[entry.offset].column = .archived
+            todos[entry.offset].sortOrder = nextOrder
+            nextOrder += 1
+        }
+
+        normalizeSortOrders(for: .done)
+        normalizeSortOrders(for: .archived)
         save()
     }
 

--- a/DragonShield iOS/Views/Todos/TodoBoardView.swift
+++ b/DragonShield iOS/Views/Todos/TodoBoardView.swift
@@ -7,7 +7,7 @@ struct TodoBoardView: View {
     @State private var tagsByID: [Int: TagRow] = [:]
     @State private var visibleColumns: Set<KanbanColumn> = [.doing, .prioritised, .backlog]
 
-    private let columnOrder: [KanbanColumn] = [.doing, .prioritised, .backlog, .done]
+    private let columnOrder: [KanbanColumn] = [.doing, .prioritised, .backlog, .done, .archived]
 
     private var filteredColumns: [KanbanColumn] {
         columnOrder.filter { visibleColumns.contains($0) }
@@ -113,7 +113,7 @@ struct TodoBoardView: View {
                         visibleColumns = Set(columnOrder)
                     }
                     Button("Hide Completed") {
-                        visibleColumns = Set(columnOrder.filter { $0 != .done })
+                        visibleColumns = Set(columnOrder.filter { ![.done, .archived].contains($0) })
                     }
                 }
             } label: {

--- a/DragonShield/Views/SidebarView.swift
+++ b/DragonShield/Views/SidebarView.swift
@@ -60,7 +60,7 @@ struct SidebarView: View {
                     Label("Asset Allocation", systemImage: "chart.pie")
                 }
                 NavigationLink(destination: NewPortfoliosView().environmentObject(dbManager)) {
-                    Label("New Portfolios", systemImage: "tablecells.badge.ellipsis")
+                    Label("Portfolios", systemImage: "tablecells.badge.ellipsis")
                 }
 
                 NavigationLink(destination: InstrumentPricesMaintenanceView().environmentObject(dbManager)) {
@@ -629,6 +629,7 @@ struct TodoKanbanBoardView: View {
                 CounterBadge(title: "Prioritised", count: viewModel.count(for: .prioritised), color: KanbanColumn.prioritised.accentColor)
                 CounterBadge(title: "Doing", count: viewModel.count(for: .doing), color: KanbanColumn.doing.accentColor)
                 CounterBadge(title: "Done", count: viewModel.count(for: .done), color: KanbanColumn.done.accentColor)
+                CounterBadge(title: "Archived", count: viewModel.count(for: .archived), color: KanbanColumn.archived.accentColor)
             }
         }
     }
@@ -653,6 +654,21 @@ struct TodoKanbanBoardView: View {
                     .foregroundColor(column.accentColor)
                 Text(column.title)
                     .font(.title3.weight(.semibold))
+                if column == .done {
+                    Button {
+                        viewModel.archiveDoneTodos()
+                    } label: {
+                        Label("Archive Done", systemImage: "archivebox")
+                            .labelStyle(.iconOnly)
+                            .font(.title3.weight(.semibold))
+                            .foregroundColor(KanbanColumn.archived.accentColor)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(items.isEmpty)
+                    .opacity(items.isEmpty ? 0.35 : 1.0)
+                    .help("Move all Done items to the Archived column")
+                    .accessibilityLabel("Archive all done items")
+                }
                 Spacer()
                 Text(items.count, format: .number)
                     .font(.footnote)


### PR DESCRIPTION
## Summary
- add Archived column to Kanban models and UI
- expose bulk archive action from the Done column
- include archived pillar in the iOS board filters

## Testing
- not run
