### PR TITLE
Adopt shared maintenance table for account and asset types

### DIFF
--- a/DragonShield/DatabaseManager+Configuration.swift
+++ b/DragonShield/DatabaseManager+Configuration.swift
@@ -53,9 +53,13 @@ extension DatabaseManager {
                 'ios_snapshot_auto_enabled', 'ios_snapshot_frequency', 'ios_snapshot_target_path', 'ios_snapshot_target_bookmark',
                 'institutions_table_font', 'institutions_table_column_fractions',
                 'instruments_table_font', 'instruments_table_column_fractions',
+                'asset_subclasses_table_font', 'asset_subclasses_table_column_fractions',
+                'asset_classes_table_font', 'asset_classes_table_column_fractions',
                 'currencies_table_font', 'currencies_table_column_fractions',
                 'accounts_table_font', 'accounts_table_column_fractions',
                 'portfolio_themes_table_font', 'portfolio_themes_table_column_fractions',
+                'transaction_types_table_font', 'transaction_types_table_column_fractions',
+                'account_types_table_font', 'account_types_table_column_fractions',
                 'todo_board_font'
             );
         """
@@ -146,6 +150,20 @@ extension DatabaseManager {
                     let parsed = DatabaseManager.decodeFractionDictionary(from: value)
                     print("ℹ️ [config] Loaded instruments_table_column_fractions=\(parsed)")
                     pendingAssignments.append { $0.instrumentsTableColumnFractions = parsed }
+                case "asset_subclasses_table_font":
+                    print("ℹ️ [config] Loaded asset_subclasses_table_font=\(value)")
+                    pendingAssignments.append { $0.assetSubClassesTableFontSize = value }
+                case "asset_subclasses_table_column_fractions":
+                    let parsed = DatabaseManager.decodeFractionDictionary(from: value)
+                    print("ℹ️ [config] Loaded asset_subclasses_table_column_fractions=\(parsed)")
+                    pendingAssignments.append { $0.assetSubClassesTableColumnFractions = parsed }
+                case "asset_classes_table_font":
+                    print("ℹ️ [config] Loaded asset_classes_table_font=\(value)")
+                    pendingAssignments.append { $0.assetClassesTableFontSize = value }
+                case "asset_classes_table_column_fractions":
+                    let parsed = DatabaseManager.decodeFractionDictionary(from: value)
+                    print("ℹ️ [config] Loaded asset_classes_table_column_fractions=\(parsed)")
+                    pendingAssignments.append { $0.assetClassesTableColumnFractions = parsed }
                 case "currencies_table_font":
                     print("ℹ️ [config] Loaded currencies_table_font=\(value)")
                     pendingAssignments.append { $0.currenciesTableFontSize = value }
@@ -167,6 +185,20 @@ extension DatabaseManager {
                     let parsed = DatabaseManager.decodeFractionDictionary(from: value)
                     print("ℹ️ [config] Loaded portfolio_themes_table_column_fractions=\(parsed)")
                     pendingAssignments.append { $0.portfolioThemesTableColumnFractions = parsed }
+                case "transaction_types_table_font":
+                    print("ℹ️ [config] Loaded transaction_types_table_font=\(value)")
+                    pendingAssignments.append { $0.transactionTypesTableFontSize = value }
+                case "transaction_types_table_column_fractions":
+                    let parsed = DatabaseManager.decodeFractionDictionary(from: value)
+                    print("ℹ️ [config] Loaded transaction_types_table_column_fractions=\(parsed)")
+                    pendingAssignments.append { $0.transactionTypesTableColumnFractions = parsed }
+                case "account_types_table_font":
+                    print("ℹ️ [config] Loaded account_types_table_font=\(value)")
+                    pendingAssignments.append { $0.accountTypesTableFontSize = value }
+                case "account_types_table_column_fractions":
+                    let parsed = DatabaseManager.decodeFractionDictionary(from: value)
+                    print("ℹ️ [config] Loaded account_types_table_column_fractions=\(parsed)")
+                    pendingAssignments.append { $0.accountTypesTableColumnFractions = parsed }
                 case "todo_board_font":
                     print("ℹ️ [config] Loaded todo_board_font=\(value)")
                     pendingAssignments.append { $0.todoBoardFontSize = value }
@@ -416,6 +448,89 @@ extension DatabaseManager {
                                 value: payload,
                                 dataType: "string",
                                 description: "Column width fractions for New Portfolios table")
+    }
+
+    func setAssetSubClassesTableFontSize(_ value: String) {
+        guard assetSubClassesTableFontSize != value else { return }
+        print("📝 [config] Request to store asset_subclasses_table_font=\(value)")
+        _ = upsertConfiguration(key: "asset_subclasses_table_font",
+                                value: value,
+                                dataType: "string",
+                                description: "Preferred font size for Asset Subclasses table")
+    }
+
+    func setAssetSubClassesTableColumnFractions(_ fractions: [String: Double]) {
+        let cleaned = DatabaseManager.normaliseFractionsForStorage(fractions)
+        guard assetSubClassesTableColumnFractions != cleaned else { return }
+        print("📝 [config] Request to store asset_subclasses_table_column_fractions=\(cleaned)")
+        let payload = DatabaseManager.encodeFractionDictionary(cleaned) ?? "{}"
+        _ = upsertConfiguration(key: "asset_subclasses_table_column_fractions",
+                                value: payload,
+                                dataType: "string",
+                                description: "Column width fractions for Asset Subclasses table")
+    }
+
+    func setAssetClassesTableFontSize(_ value: String) {
+        guard assetClassesTableFontSize != value else { return }
+        print("📝 [config] Request to store asset_classes_table_font=\(value)")
+        _ = upsertConfiguration(key: "asset_classes_table_font",
+                                value: value,
+                                dataType: "string",
+                                description: "Preferred font size for Asset Classes table")
+    }
+
+    func setAssetClassesTableColumnFractions(_ fractions: [String: Double]) {
+        let cleaned = DatabaseManager.normaliseFractionsForStorage(fractions)
+        guard assetClassesTableColumnFractions != cleaned else { return }
+        print("📝 [config] Request to store asset_classes_table_column_fractions=\(cleaned)")
+        assetClassesTableColumnFractions = cleaned
+        let payload = DatabaseManager.encodeFractionDictionary(cleaned) ?? "{}"
+        _ = upsertConfiguration(key: "asset_classes_table_column_fractions",
+                                value: payload,
+                                dataType: "string",
+                                description: "Column width fractions for Asset Classes table")
+    }
+
+    func setTransactionTypesTableFontSize(_ value: String) {
+        guard transactionTypesTableFontSize != value else { return }
+        print("📝 [config] Request to store transaction_types_table_font=\(value)")
+        _ = upsertConfiguration(key: "transaction_types_table_font",
+                                value: value,
+                                dataType: "string",
+                                description: "Preferred font size for Transaction Types table")
+    }
+
+    func setTransactionTypesTableColumnFractions(_ fractions: [String: Double]) {
+        let cleaned = DatabaseManager.normaliseFractionsForStorage(fractions)
+        guard transactionTypesTableColumnFractions != cleaned else { return }
+        print("📝 [config] Request to store transaction_types_table_column_fractions=\(cleaned)")
+        transactionTypesTableColumnFractions = cleaned
+        let payload = DatabaseManager.encodeFractionDictionary(cleaned) ?? "{}"
+        _ = upsertConfiguration(key: "transaction_types_table_column_fractions",
+                                value: payload,
+                                dataType: "string",
+                                description: "Column width fractions for Transaction Types table")
+    }
+
+    func setAccountTypesTableFontSize(_ value: String) {
+        guard accountTypesTableFontSize != value else { return }
+        print("📝 [config] Request to store account_types_table_font=\(value)")
+        _ = upsertConfiguration(key: "account_types_table_font",
+                                value: value,
+                                dataType: "string",
+                                description: "Preferred font size for Account Types table")
+    }
+
+    func setAccountTypesTableColumnFractions(_ fractions: [String: Double]) {
+        let cleaned = DatabaseManager.normaliseFractionsForStorage(fractions)
+        guard accountTypesTableColumnFractions != cleaned else { return }
+        print("📝 [config] Request to store account_types_table_column_fractions=\(cleaned)")
+        accountTypesTableColumnFractions = cleaned
+        let payload = DatabaseManager.encodeFractionDictionary(cleaned) ?? "{}"
+        _ = upsertConfiguration(key: "account_types_table_column_fractions",
+                                value: payload,
+                                dataType: "string",
+                                description: "Column width fractions for Account Types table")
     }
 
     func setTodoBoardFontSize(_ value: String) {

--- a/DragonShield/DatabaseManager.swift
+++ b/DragonShield/DatabaseManager.swift
@@ -56,12 +56,20 @@ class DatabaseManager: ObservableObject {
     @Published var institutionsTableColumnFractions: [String: Double] = [:]
     @Published var instrumentsTableFontSize: String = "medium"
     @Published var instrumentsTableColumnFractions: [String: Double] = [:]
+    @Published var assetSubClassesTableFontSize: String = "medium"
+    @Published var assetSubClassesTableColumnFractions: [String: Double] = [:]
+    @Published var assetClassesTableFontSize: String = "medium"
+    @Published var assetClassesTableColumnFractions: [String: Double] = [:]
     @Published var currenciesTableFontSize: String = "medium"
     @Published var currenciesTableColumnFractions: [String: Double] = [:]
     @Published var accountsTableFontSize: String = "medium"
     @Published var accountsTableColumnFractions: [String: Double] = [:]
     @Published var portfolioThemesTableFontSize: String = "medium"
     @Published var portfolioThemesTableColumnFractions: [String: Double] = [:]
+    @Published var transactionTypesTableFontSize: String = "medium"
+    @Published var transactionTypesTableColumnFractions: [String: Double] = [:]
+    @Published var accountTypesTableFontSize: String = "medium"
+    @Published var accountTypesTableColumnFractions: [String: Double] = [:]
     @Published var todoBoardFontSize: String = "medium"
     // Last trade error for UI feedback
     @Published var lastTradeErrorMessage: String? = nil

--- a/DragonShield/Views/AccountTypesView.swift
+++ b/DragonShield/Views/AccountTypesView.swift
@@ -1,51 +1,202 @@
-// DragonShield/Views/AccountTypesView.swift
-// MARK: - Version 1.4
-// MARK: - History
-// - 1.3 -> 1.4: Implemented Edit functionality for account types.
-// - 1.2 -> 1.3: Corrected .alert modifier logic to resolve compiler errors.
-// - 1.1 -> 1.2: Re-included helper structs to fix scope issues.
-// - 1.0 -> 1.1: Implemented Add and Delete functionality.
-
 import SwiftUI
+#if os(macOS)
+import AppKit
+#endif
+
+private enum AccountTypeColumn: String, CaseIterable, Codable, MaintenanceTableColumn {
+    case name
+    case code
+    case description
+    case isActive
+
+    var title: String {
+        switch self {
+        case .name: return "Name"
+        case .code: return "Code"
+        case .description: return "Description"
+        case .isActive: return "Active"
+        }
+    }
+
+    var menuTitle: String { title }
+}
+
+private struct AccountTypeItem: Identifiable, Equatable {
+    let id: Int
+    let code: String
+    let name: String
+    let description: String
+    let isActive: Bool
+
+    var statusLabel: String { isActive ? "Active" : "Inactive" }
+}
 
 struct AccountTypesView: View {
     @EnvironmentObject var dbManager: DatabaseManager
-    @State private var accountTypes: [DatabaseManager.AccountTypeData] = []
-    @State private var selectedType: DatabaseManager.AccountTypeData? = nil
+
+    @State private var accountTypes: [AccountTypeItem] = []
+    @State private var selectedType: AccountTypeItem? = nil
     @State private var searchText = ""
-
     @State private var showAddTypeSheet = false
-    @State private var showEditTypeSheet = false // Added for edit sheet
-    
+    @State private var showEditTypeSheet = false
     @State private var showingDeleteAlert = false
-    @State private var typeToDelete: DatabaseManager.AccountTypeData? = nil
+    @State private var typeToDelete: AccountTypeItem? = nil
 
-    // Animation states
+    @State private var sortColumn: SortColumn = .name
+    @State private var sortAscending: Bool = true
+    @State private var statusFilters: Set<String> = []
+    @StateObject private var tableModel = ResizableTableViewModel<AccountTypeColumn>(configuration: AccountTypesView.tableConfiguration)
+
     @State private var headerOpacity: Double = 0
     @State private var contentOffset: CGFloat = 30
     @State private var buttonsOpacity: Double = 0
-    
-    var filteredTypes: [DatabaseManager.AccountTypeData] {
-        if searchText.isEmpty {
-            return accountTypes
-        } else {
-            return accountTypes.filter { type in
-                type.name.localizedCaseInsensitiveContains(searchText) ||
-                type.code.localizedCaseInsensitiveContains(searchText) ||
-                (type.description?.localizedCaseInsensitiveContains(searchText) ?? false)
+
+    private static let visibleColumnsKey = "AccountTypesView.visibleColumns.v1"
+
+    private enum SortColumn: String, CaseIterable {
+        case name
+        case code
+        case description
+        case isActive
+    }
+
+    private static let tableConfiguration: MaintenanceTableConfiguration<AccountTypeColumn> = {
+#if os(macOS)
+        MaintenanceTableConfiguration(
+            preferenceKind: .accountTypes,
+            columnOrder: AccountTypeColumn.allCases,
+            defaultVisibleColumns: Set(AccountTypeColumn.allCases),
+            requiredColumns: [.name, .code],
+            defaultColumnWidths: [
+                .name: 240,
+                .code: 140,
+                .description: 360,
+                .isActive: 120
+            ],
+            minimumColumnWidths: [
+                .name: 200,
+                .code: 110,
+                .description: 260,
+                .isActive: 90
+            ],
+            visibleColumnsDefaultsKey: visibleColumnsKey,
+            columnHandleWidth: 10,
+            columnHandleHitSlop: 8,
+            columnTextInset: 12,
+            headerBackground: Color.indigo.opacity(0.08),
+            fontConfigBuilder: { size in
+                MaintenanceTableFontConfig(
+                    primary: size.baseSize,
+                    secondary: max(11, size.secondarySize),
+                    header: size.headerSize,
+                    badge: max(10, size.badgeSize)
+                )
+            },
+            columnResizeCursor: nil
+        )
+#else
+        MaintenanceTableConfiguration(
+            preferenceKind: .accountTypes,
+            columnOrder: AccountTypeColumn.allCases,
+            defaultVisibleColumns: Set(AccountTypeColumn.allCases),
+            requiredColumns: [.name, .code],
+            defaultColumnWidths: [
+                .name: 240,
+                .code: 140,
+                .description: 360,
+                .isActive: 120
+            ],
+            minimumColumnWidths: [
+                .name: 200,
+                .code: 110,
+                .description: 260,
+                .isActive: 90
+            ],
+            visibleColumnsDefaultsKey: visibleColumnsKey,
+            columnHandleWidth: 10,
+            columnHandleHitSlop: 8,
+            columnTextInset: 12,
+            headerBackground: Color.indigo.opacity(0.08),
+            fontConfigBuilder: { size in
+                MaintenanceTableFontConfig(
+                    primary: size.baseSize,
+                    secondary: max(11, size.secondarySize),
+                    header: size.headerSize,
+                    badge: max(10, size.badgeSize)
+                )
+            }
+        )
+#endif
+    }()
+
+    private var selectedFontSize: MaintenanceTableFontSize { tableModel.selectedFontSize }
+    private var visibleColumns: Set<AccountTypeColumn> { tableModel.visibleColumns }
+    private var fontSizeBinding: Binding<MaintenanceTableFontSize> {
+        Binding(
+            get: { tableModel.selectedFontSize },
+            set: { newValue in
+                DispatchQueue.main.async {
+                    tableModel.selectedFontSize = newValue
+                }
+            }
+        )
+    }
+
+    private var filteredTypes: [AccountTypeItem] {
+        var result = accountTypes
+
+        let trimmedQuery = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedQuery.isEmpty {
+            let query = trimmedQuery.lowercased()
+            result = result.filter { type in
+                type.name.lowercased().contains(query) ||
+                type.code.lowercased().contains(query) ||
+                type.description.lowercased().contains(query)
             }
         }
+
+        if !statusFilters.isEmpty {
+            result = result.filter { statusFilters.contains($0.statusLabel) }
+        }
+
+        return result
     }
-    
+
+    private var sortedTypes: [AccountTypeItem] {
+        let base = filteredTypes
+        guard base.count > 1 else { return base }
+
+        let sorted = base.sorted { lhs, rhs in
+            switch sortColumn {
+            case .name:
+                return compare(lhs.name, rhs.name)
+            case .code:
+                return compare(lhs.code, rhs.code)
+            case .description:
+                return compare(lhs.description, rhs.description)
+            case .isActive:
+                return compareBool(lhs.isActive, rhs.isActive)
+            }
+        }
+
+        return sortAscending ? sorted : Array(sorted.reversed())
+    }
+
     var body: some View {
         ZStack {
             LinearGradient(
-                colors: [Color(red: 0.98, green: 0.99, blue: 1.0), Color(red: 0.95, green: 0.97, blue: 0.99), Color(red: 0.93, green: 0.95, blue: 0.98)],
-                startPoint: .topLeading, endPoint: .bottomTrailing
-            ).ignoresSafeArea()
-            
+                colors: [
+                    Color(red: 0.98, green: 0.99, blue: 1.0),
+                    Color(red: 0.95, green: 0.97, blue: 0.99),
+                    Color(red: 0.93, green: 0.95, blue: 0.98)
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .ignoresSafeArea()
+
             AccountTypesParticleBackground()
-            
+
             VStack(spacing: 0) {
                 modernHeader
                 searchAndStats
@@ -54,108 +205,251 @@ struct AccountTypesView: View {
             }
         }
         .onAppear {
+            tableModel.connect(to: dbManager)
+            tableModel.recalcColumnWidths(shouldPersist: false)
+            ensureFiltersWithinVisibleColumns()
             loadAccountTypes()
             animateEntrance()
         }
         .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("RefreshAccountTypes"))) { _ in
             loadAccountTypes()
         }
+        .onChange(of: tableModel.visibleColumns) { _, _ in
+            ensureFiltersWithinVisibleColumns()
+        }
         .sheet(isPresented: $showAddTypeSheet) {
             AddAccountTypeView().environmentObject(dbManager)
         }
-        // NEW: Sheet for editing an account type
         .sheet(isPresented: $showEditTypeSheet) {
             if let type = selectedType {
                 EditAccountTypeView(accountTypeId: type.id).environmentObject(dbManager)
             }
         }
-        .alert(isPresented: $showingDeleteAlert) {
-            guard let type = typeToDelete else {
-                return Alert(title: Text("Error"), message: Text("No type selected for deletion."), dismissButton: .default(Text("OK")))
+        .alert("Delete Account Type", isPresented: $showingDeleteAlert) {
+            Button("Cancel", role: .cancel) { typeToDelete = nil }
+            Button("Delete", role: .destructive) {
+                if let type = typeToDelete {
+                    confirmDelete(type)
+                }
             }
-
-            let deleteCheckResult = dbManager.canDeleteAccountType(id: type.id)
-
-            if deleteCheckResult.canDelete {
-                return Alert(
-                    title: Text("Delete Account Type"),
-                    message: Text("Are you sure you want to delete '\(type.name)'? This action cannot be undone."),
-                    primaryButton: .destructive(Text("Delete")) {
-                        performDelete(type)
-                    },
-                    secondaryButton: .cancel {
-                        typeToDelete = nil
-                    }
-                )
-            } else {
-                return Alert(
-                    title: Text("Cannot Delete Account Type"),
-                    message: Text(deleteCheckResult.message),
-                    dismissButton: .default(Text("OK")) {
-                        typeToDelete = nil
-                    }
-                )
+        } message: {
+            if let type = typeToDelete {
+                Text("Are you sure you want to delete '\(type.name)'?")
             }
         }
     }
-    
+
     private var modernHeader: some View {
         HStack {
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 12) {
                     Image(systemName: "creditcard.circle.fill")
                         .font(.system(size: 32))
-                        .foregroundColor(Color.indigo)
+                        .foregroundColor(.indigo)
+
                     Text("Account Types")
                         .font(.system(size: 32, weight: .bold, design: .rounded))
-                        .foregroundStyle(LinearGradient(colors: [.black, .gray], startPoint: .top, endPoint: .bottom))
+                        .foregroundStyle(
+                            LinearGradient(
+                                colors: [.black, .gray],
+                                startPoint: .top,
+                                endPoint: .bottom
+                            )
+                        )
                 }
-                Text("Manage types for your accounts")
-                    .font(.subheadline).foregroundColor(.gray)
+
+                Text("Manage your account categories")
+                    .font(.subheadline)
+                    .foregroundColor(.gray)
             }
+
             Spacer()
+
             HStack(spacing: 16) {
-                modernStatCard(title: "Total", value: "\(accountTypes.count)", icon: "number.circle.fill", color: .indigo)
-                modernStatCard(title: "Active", value: "\(accountTypes.filter { $0.isActive }.count)", icon: "checkmark.circle.fill", color: .green)
+                modernStatCard(
+                    title: "Total",
+                    value: "\(accountTypes.count)",
+                    icon: "number.circle.fill",
+                    color: .indigo
+                )
+
+                modernStatCard(
+                    title: "Active",
+                    value: "\(accountTypes.filter { $0.isActive }.count)",
+                    icon: "checkmark.circle.fill",
+                    color: .green
+                )
             }
-        }.padding(.horizontal, 24).padding(.vertical, 20).opacity(headerOpacity)
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 20)
+        .opacity(headerOpacity)
     }
-    
+
     private var searchAndStats: some View {
         VStack(spacing: 12) {
             HStack {
-                Image(systemName: "magnifyingglass").foregroundColor(.gray)
-                TextField("Search account types (name, code, description...)", text: $searchText).textFieldStyle(PlainTextFieldStyle())
-                if !searchText.isEmpty { Button { searchText = "" } label: { Image(systemName: "xmark.circle.fill").foregroundColor(.gray) }.buttonStyle(PlainButtonStyle()) }
-            }.padding(.horizontal, 16).padding(.vertical, 10)
-            .background(RoundedRectangle(cornerRadius: 12).fill(.regularMaterial).overlay(RoundedRectangle(cornerRadius: 12).stroke(Color.gray.opacity(0.2), lineWidth: 1)))
+                Image(systemName: "magnifyingglass")
+                    .foregroundColor(.gray)
+
+                TextField("Search account types...", text: $searchText)
+                    .textFieldStyle(PlainTextFieldStyle())
+
+                if !searchText.isEmpty {
+                    Button { searchText = "" } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundColor(.gray)
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(.regularMaterial)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(Color.gray.opacity(0.2), lineWidth: 1)
+                    )
+            )
             .shadow(color: .black.opacity(0.05), radius: 3, x: 0, y: 1)
-            if !searchText.isEmpty && !filteredTypes.isEmpty { HStack { Text("Found \(filteredTypes.count) of \(accountTypes.count) types").font(.caption).foregroundColor(.gray); Spacer() } }
-        }.padding(.horizontal, 24).offset(y: contentOffset)
+
+            if !searchText.isEmpty || hasActiveFilters {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Found \(filteredTypes.count) of \(accountTypes.count) types")
+                        .font(.caption)
+                        .foregroundColor(.gray)
+
+                    if hasActiveFilters {
+                        HStack(spacing: 8) {
+                            ForEach(statusFilters.sorted(), id: \.self) { value in
+                                filterChip(text: value) { statusFilters.remove(value) }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 24)
+        .offset(y: contentOffset)
     }
-    
+
     private var typesContent: some View {
         VStack(spacing: 16) {
-            if accountTypes.isEmpty && searchText.isEmpty { emptyStateView }
-            else if filteredTypes.isEmpty && !searchText.isEmpty { emptyStateView }
-            else { typesTable }
-        }.padding(.horizontal, 24).padding(.top, 16).offset(y: contentOffset)
+            tableControls
+            if sortedTypes.isEmpty {
+                emptyStateView
+            } else {
+                typesTable
+            }
+        }
+        .padding(.horizontal, 24)
+        .padding(.top, 16)
+        .offset(y: contentOffset)
     }
-    
+
+    private var tableControls: some View {
+        HStack(spacing: 12) {
+            columnsMenu
+            fontSizePicker
+            if hasActiveFilters {
+                Button("Reset Filters", action: clearFilters)
+                    .buttonStyle(.link)
+            }
+            Spacer()
+            if visibleColumns != AccountTypesView.tableConfiguration.defaultVisibleColumns || selectedFontSize != .medium {
+                Button("Reset View", action: resetTablePreferences)
+                    .buttonStyle(.link)
+            }
+        }
+        .padding(.horizontal, 4)
+        .font(.system(size: 12))
+    }
+
+    private var columnsMenu: some View {
+        Menu {
+            ForEach(AccountTypeColumn.allCases, id: \.self) { column in
+                let isVisible = visibleColumns.contains(column)
+                Button {
+                    toggleColumn(column)
+                } label: {
+                    Label(column.menuTitle, systemImage: isVisible ? "checkmark" : "")
+                }
+                .disabled(isVisible && (visibleColumns.count == 1 || AccountTypesView.tableConfiguration.requiredColumns.contains(column)))
+            }
+            Divider()
+            Button("Reset Columns", action: resetVisibleColumns)
+        } label: {
+            Label("Columns", systemImage: "slider.horizontal.3")
+        }
+    }
+
+    private var fontSizePicker: some View {
+        Picker("Font Size", selection: fontSizeBinding) {
+            ForEach(MaintenanceTableFontSize.allCases, id: \.self) { size in
+                Text(size.label).tag(size)
+            }
+        }
+        .pickerStyle(.segmented)
+        .frame(maxWidth: 240)
+        .labelsHidden()
+    }
+
+    private var typesTable: some View {
+        MaintenanceTableView(
+            model: tableModel,
+            rows: sortedTypes,
+            rowSpacing: CGFloat(dbManager.tableRowSpacing),
+            showHorizontalIndicators: true,
+            rowContent: { type, context in
+                AccountTypeRowView(
+                    type: type,
+                    columns: context.columns,
+                    fontConfig: context.fontConfig,
+                    rowPadding: CGFloat(dbManager.tableRowPadding),
+                    isSelected: selectedType?.id == type.id,
+                    onTap: { selectedType = type },
+                    onEdit: {
+                        selectedType = type
+                        showEditTypeSheet = true
+                    },
+                    widthFor: { context.widthForColumn($0) }
+                )
+            },
+            headerContent: { column, fontConfig in
+                accountTypeHeaderContent(for: column, fontConfig: fontConfig)
+            }
+        )
+    }
+
     private var emptyStateView: some View {
         VStack(spacing: 20) {
             Spacer()
             VStack(spacing: 16) {
-                Image(systemName: searchText.isEmpty && accountTypes.isEmpty ? "doc.plaintext.fill" : "magnifyingglass")
+                Image(systemName: searchText.isEmpty ? "doc.plaintext.fill" : "magnifyingglass")
                     .font(.system(size: 64))
-                    .foregroundStyle(LinearGradient(colors: [.gray.opacity(0.5), .gray.opacity(0.3)], startPoint: .top, endPoint: .bottom))
+                    .foregroundStyle(
+                        LinearGradient(
+                            colors: [.gray.opacity(0.5), .gray.opacity(0.3)],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+
                 VStack(spacing: 8) {
-                    Text(searchText.isEmpty && accountTypes.isEmpty ? "No account types found" : "No matching account types")
-                        .font(.title2).fontWeight(.semibold).foregroundColor(.gray)
-                    Text(searchText.isEmpty && accountTypes.isEmpty ? "Add your first account type using the button below." : "Try adjusting your search terms.")
-                        .font(.body).foregroundColor(.gray).multilineTextAlignment(.center)
+                    Text(searchText.isEmpty ? "No account types yet" : "No matching account types")
+                        .font(.title2)
+                        .fontWeight(.semibold)
+                        .foregroundColor(.gray)
+
+                    Text(searchText.isEmpty ? "Add your first account type to classify accounts" : "Try adjusting your search or filters")
+                        .font(.body)
+                        .foregroundColor(.gray)
+                        .multilineTextAlignment(.center)
                 }
-                if searchText.isEmpty && accountTypes.isEmpty {
+
+                if searchText.isEmpty {
                     Button { showAddTypeSheet = true } label: {
                         Label("Add Account Type", systemImage: "plus")
                     }
@@ -166,45 +460,16 @@ struct AccountTypesView: View {
                 }
             }
             Spacer()
-        }.frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-    
-    private var typesTable: some View {
-        VStack(spacing: 0) {
-            modernTableHeader
-            ScrollView {
-                LazyVStack(spacing: CGFloat(dbManager.tableRowSpacing)) {
-                    ForEach(filteredTypes) { type in
-                        ModernAccountTypeRowView(
-                            type: type, isSelected: selectedType?.id == type.id,
-                            rowPadding: CGFloat(dbManager.tableRowPadding),
-                            onTap: { selectedType = type },
-                            onEdit: { // Added onEdit closure
-                                selectedType = type
-                                showEditTypeSheet = true
-                            }
-                        )
-                    }
-                }
-            }.background(RoundedRectangle(cornerRadius: 12).fill(.regularMaterial).overlay(RoundedRectangle(cornerRadius: 12).stroke(Color.gray.opacity(0.1), lineWidth: 1)))
-            .clipShape(RoundedRectangle(cornerRadius: 12)).shadow(color: .black.opacity(0.05), radius: 8, x: 0, y: 4)
         }
-    }
-    
-    private var modernTableHeader: some View {
-        HStack {
-            Text("Name").font(.system(size: 14, weight: .semibold)).foregroundColor(.gray).frame(width: 200, alignment: .leading)
-            Text("Code").font(.system(size: 14, weight: .semibold)).foregroundColor(.gray).frame(width: 100, alignment: .leading)
-            Text("Description").font(.system(size: 14, weight: .semibold)).foregroundColor(.gray).frame(maxWidth: .infinity, alignment: .leading)
-            Text("Status").font(.system(size: 14, weight: .semibold)).foregroundColor(.gray).frame(width: 80, alignment: .center)
-        }.padding(.horizontal, CGFloat(dbManager.tableRowPadding))
-        .padding(.vertical, 12)
-        .background(RoundedRectangle(cornerRadius: 12).fill(Color.gray.opacity(0.1))).padding(.bottom, 1)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private var modernActionBar: some View {
         VStack(spacing: 0) {
-            Rectangle().fill(Color.gray.opacity(0.2)).frame(height: 1)
+            Rectangle()
+                .fill(Color.gray.opacity(0.2))
+                .frame(height: 1)
+
             HStack(spacing: 16) {
                 Button { showAddTypeSheet = true } label: {
                     Label("Add Account Type", systemImage: "plus")
@@ -214,61 +479,236 @@ struct AccountTypesView: View {
                 .foregroundColor(.black)
 
                 if selectedType != nil {
-                     // MODIFIED: Edit button is now enabled
-                     Button {
-                         showEditTypeSheet = true
-                     } label: {
-                        HStack(spacing: 6) { Image(systemName: "pencil"); Text("Edit") }
-                        .font(.system(size: 14, weight: .medium)).foregroundColor(.blue)
-                        .padding(.horizontal, 16).padding(.vertical, 10)
-                        .background(Color.blue.opacity(0.1)).clipShape(Capsule())
-                        .overlay(Capsule().stroke(Color.blue.opacity(0.3), lineWidth: 1))
-                    }.buttonStyle(ScaleButtonStyle())
+                    Button {
+                        showEditTypeSheet = true
+                    } label: {
+                        HStack(spacing: 6) {
+                            Image(systemName: "pencil")
+                            Text("Edit")
+                        }
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundColor(.blue)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 10)
+                        .background(Color.blue.opacity(0.1))
+                        .clipShape(Capsule())
+                        .overlay(
+                            Capsule()
+                                .stroke(Color.blue.opacity(0.3), lineWidth: 1)
+                        )
+                    }
+                    .buttonStyle(ScaleButtonStyle())
 
                     Button {
                         if let type = selectedType {
-                            self.typeToDelete = type
-                            self.showingDeleteAlert = true
+                            typeToDelete = type
+                            showingDeleteAlert = true
                         }
                     } label: {
-                        HStack(spacing: 6) { Image(systemName: "trash"); Text("Delete") }
-                        .font(.system(size: 14, weight: .medium)).foregroundColor(.red)
-                        .padding(.horizontal, 16).padding(.vertical, 10)
-                        .background(Color.red.opacity(0.1)).clipShape(Capsule())
-                        .overlay(Capsule().stroke(Color.red.opacity(0.3), lineWidth: 1))
-                    }.buttonStyle(ScaleButtonStyle())
+                        HStack(spacing: 6) {
+                            Image(systemName: "trash")
+                            Text("Delete")
+                        }
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundColor(.red)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 10)
+                        .background(Color.red.opacity(0.1))
+                        .clipShape(Capsule())
+                        .overlay(
+                            Capsule()
+                                .stroke(Color.red.opacity(0.3), lineWidth: 1)
+                        )
+                    }
+                    .buttonStyle(ScaleButtonStyle())
                 }
+
                 Spacer()
+
                 if let type = selectedType {
                     HStack(spacing: 8) {
-                        Image(systemName: "checkmark.circle.fill").foregroundColor(.indigo)
-                        Text("Selected: \(type.name)").font(.system(size: 14, weight: .medium)).foregroundColor(.secondary).lineLimit(1)
-                    }.padding(.horizontal, 12).padding(.vertical, 6).background(Color.indigo.opacity(0.05)).clipShape(Capsule())
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(.indigo)
+                        Text("Selected: \(type.name)")
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(Color.indigo.opacity(0.05))
+                    .clipShape(Capsule())
                 }
-            }.padding(.horizontal, 24).padding(.vertical, 16).background(.regularMaterial)
-        }.opacity(buttonsOpacity)
+            }
+            .padding(.horizontal, 24)
+            .padding(.vertical, 16)
+            .background(.regularMaterial)
+        }
+        .opacity(buttonsOpacity)
     }
 
-    private func modernStatCard(title: String, value: String, icon: String, color: Color) -> some View {
-        VStack(spacing: 4) {
-            HStack(spacing: 4) { Image(systemName: icon).font(.system(size: 12)).foregroundColor(color); Text(title).font(.system(size: 11, weight: .medium)).foregroundColor(.gray) }
-            Text(value).font(.system(size: 18, weight: .bold)).foregroundColor(.primary)
-        }.padding(.horizontal, 12).padding(.vertical, 8)
-        .background(RoundedRectangle(cornerRadius: 8).fill(.regularMaterial).overlay(RoundedRectangle(cornerRadius: 8).stroke(color.opacity(0.2), lineWidth: 1)))
-        .shadow(color: color.opacity(0.1), radius: 3, x: 0, y: 1)
+    private func accountTypeHeaderContent(for column: AccountTypeColumn, fontConfig: MaintenanceTableFontConfig) -> some View {
+        let targetSort = sortColumn(from: column)
+        let isActiveSort = sortColumn == targetSort
+        let filterBinding = filterBinding(for: column)
+        let options = filterOptions(for: column)
+
+        return HStack(spacing: 6) {
+            Button(action: { toggleSort(for: column) }) {
+                HStack(spacing: 4) {
+                    Text(column.title)
+                        .font(.system(size: fontConfig.header, weight: .semibold))
+                        .foregroundColor(.black)
+                    Image(systemName: "triangle.fill")
+                        .font(.system(size: 9, weight: .bold))
+                        .foregroundColor(isActiveSort ? .accentColor : .gray.opacity(0.3))
+                        .rotationEffect(.degrees(isActiveSort && !sortAscending ? 180 : 0))
+                        .opacity(isActiveSort ? 1 : 0)
+                }
+            }
+            .buttonStyle(.plain)
+
+            if let binding = filterBinding, !options.isEmpty {
+                Menu {
+                    ForEach(options, id: \.self) { value in
+                        Button {
+                            if binding.wrappedValue.contains(value) {
+                                binding.wrappedValue.remove(value)
+                            } else {
+                                binding.wrappedValue.insert(value)
+                            }
+                        } label: {
+                            Label(value, systemImage: binding.wrappedValue.contains(value) ? "checkmark" : "")
+                        }
+                    }
+                } label: {
+                    Image(systemName: "line.3.horizontal.decrease.circle")
+                        .foregroundColor(binding.wrappedValue.isEmpty ? .gray : .accentColor)
+                }
+                .menuStyle(BorderlessButtonMenuStyle())
+            }
+        }
     }
 
-    private func animateEntrance() {
-        withAnimation(.easeOut(duration: 0.6).delay(0.1)) { headerOpacity = 1.0 }
-        withAnimation(.spring(response: 0.6, dampingFraction: 0.8).delay(0.3)) { contentOffset = 0 }
-        withAnimation(.easeOut(duration: 0.4).delay(0.5)) { buttonsOpacity = 1.0 }
+    private func toggleColumn(_ column: AccountTypeColumn) {
+        tableModel.toggleColumn(column)
+        ensureFiltersWithinVisibleColumns()
     }
 
-    func loadAccountTypes() {
-         accountTypes = dbManager.fetchAccountTypes(activeOnly: false)
+    private func resetVisibleColumns() {
+        tableModel.resetVisibleColumns()
+        clearFilters()
     }
 
-    private func performDelete(_ type: DatabaseManager.AccountTypeData) {
+    private func resetTablePreferences() {
+        tableModel.resetTablePreferences()
+        clearFilters()
+    }
+
+    private var hasActiveFilters: Bool { !statusFilters.isEmpty }
+
+    private func filterBinding(for column: AccountTypeColumn) -> Binding<Set<String>>? {
+        column == .isActive ? $statusFilters : nil
+    }
+
+    private func filterOptions(for column: AccountTypeColumn) -> [String] {
+        column == .isActive ? ["Active", "Inactive"] : []
+    }
+
+    private func filterChip(text: String, onRemove: @escaping () -> Void) -> some View {
+        HStack(spacing: 4) {
+            Text(text)
+                .font(.caption)
+            Button(action: onRemove) {
+                Image(systemName: "xmark.circle.fill")
+            }
+            .buttonStyle(PlainButtonStyle())
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(Color.indigo.opacity(0.12))
+        .clipShape(Capsule())
+    }
+
+    private func clearFilters() {
+        statusFilters.removeAll()
+    }
+
+    private func ensureFiltersWithinVisibleColumns() {
+        if !visibleColumns.contains(.isActive) {
+            statusFilters.removeAll()
+        }
+    }
+
+    private func sortColumn(from column: AccountTypeColumn) -> SortColumn {
+        switch column {
+        case .name: return .name
+        case .code: return .code
+        case .description: return .description
+        case .isActive: return .isActive
+        }
+    }
+
+    private func toggleSort(for column: AccountTypeColumn) {
+        let target = sortColumn(from: column)
+        if sortColumn == target {
+            sortAscending.toggle()
+        } else {
+            sortColumn = target
+            sortAscending = true
+        }
+    }
+
+    private func compare(_ lhs: String, _ rhs: String) -> Bool {
+        let result = lhs.localizedCaseInsensitiveCompare(rhs)
+        if result == .orderedSame {
+            return lhs < rhs
+        }
+        return result == .orderedAscending
+    }
+
+    private func compareBool(_ lhs: Bool, _ rhs: Bool) -> Bool {
+        if lhs == rhs {
+            return compare(lhs ? "Yes" : "No", rhs ? "Yes" : "No")
+        }
+        return lhs && !rhs
+    }
+
+    private func loadAccountTypes() {
+        let currentId = selectedType?.id
+        accountTypes = dbManager.fetchAccountTypes(activeOnly: false).map { type in
+            AccountTypeItem(
+                id: type.id,
+                code: type.code,
+                name: type.name,
+                description: type.description ?? "",
+                isActive: type.isActive
+            )
+        }
+        if let currentId, let match = accountTypes.first(where: { $0.id == currentId }) {
+            selectedType = match
+        }
+    }
+
+    private func confirmDelete(_ type: AccountTypeItem) {
+        let result = dbManager.canDeleteAccountType(id: type.id)
+        guard result.canDelete else {
+#if os(macOS)
+            let alert = NSAlert()
+            alert.messageText = "Cannot Delete Account Type"
+            alert.informativeText = result.message
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: "OK")
+            alert.runModal()
+#else
+            print("⚠️ Cannot delete account type: \(result.message)")
+#endif
+            typeToDelete = nil
+            return
+        }
+        performDelete(type)
+    }
+
+    private func performDelete(_ type: AccountTypeItem) {
         let success = dbManager.deleteAccountType(id: type.id)
         if success {
             loadAccountTypes()
@@ -276,70 +716,145 @@ struct AccountTypesView: View {
             typeToDelete = nil
         }
     }
-}
 
-// MODIFIED: Added onEdit closure
-struct ModernAccountTypeRowView: View {
-    let type: DatabaseManager.AccountTypeData
-    let isSelected: Bool
-    let rowPadding: CGFloat
-    let onTap: () -> Void
-    let onEdit: () -> Void
-    
-    var body: some View {
-        HStack {
-            Text(type.name)
-                .font(.system(size: 15, weight: .medium)).foregroundColor(.primary)
-                .frame(width: 200, alignment: .leading)
-            
-            Text(type.code)
-                .font(.system(size: 13, design: .monospaced)).foregroundColor(.secondary)
-                .padding(.horizontal, 6).padding(.vertical, 2)
-                .background(Color.gray.opacity(0.1)).clipShape(RoundedRectangle(cornerRadius: 4))
-                .frame(width: 100, alignment: .leading)
-            
-            Text(type.description ?? "")
-                .font(.system(size: 14)).foregroundColor(.secondary)
-                .lineLimit(1)
-                .frame(maxWidth: .infinity, alignment: .leading)
-            
-            HStack(spacing: 4) {
-                Circle().fill(type.isActive ? Color.green : Color.orange).frame(width: 8, height: 8)
-                Text(type.isActive ? "Active" : "Inactive")
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(type.isActive ? .green : .orange)
-            }.frame(width: 80, alignment: .center)
+    private func animateEntrance() {
+        withAnimation(.easeOut(duration: 0.6).delay(0.1)) {
+            headerOpacity = 1.0
         }
-        .padding(.horizontal, rowPadding)
-        .padding(.vertical, rowPadding / 1.5)
-        .background(RoundedRectangle(cornerRadius: 8).fill(isSelected ? Color.indigo.opacity(0.1) : Color.clear).overlay(RoundedRectangle(cornerRadius: 8).stroke(isSelected ? Color.indigo.opacity(0.3) : Color.clear, lineWidth: 1)))
-        .contentShape(Rectangle())
-        .onTapGesture { onTap() }
-        .onTapGesture(count: 2) { onEdit() } // Double-tap to edit
-        .animation(.easeInOut(duration: 0.2), value: isSelected)
-        .contextMenu { // Added Edit to context menu
-             Button("Edit '\(type.name)'") {
-                onEdit()
-            }
-            Divider()
-            Button("Select") {
-                onTap()
-            }
+
+        withAnimation(.spring(response: 0.6, dampingFraction: 0.8).delay(0.3)) {
+            contentOffset = 0
+        }
+
+        withAnimation(.easeOut(duration: 0.4).delay(0.5)) {
+            buttonsOpacity = 1.0
         }
     }
 }
 
-// Background particle struct and view remain the same
-struct AccountTypeParticle: Identifiable {
+private struct AccountTypeRowView: View {
+    let type: AccountTypeItem
+    let columns: [AccountTypeColumn]
+    let fontConfig: MaintenanceTableFontConfig
+    let rowPadding: CGFloat
+    let isSelected: Bool
+    let onTap: () -> Void
+    let onEdit: () -> Void
+    let widthFor: (AccountTypeColumn) -> CGFloat
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(columns, id: \.self) { column in
+                columnView(for: column)
+            }
+        }
+        .padding(.trailing, 12)
+        .padding(.vertical, max(rowPadding, 8))
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(isSelected ? Color.indigo.opacity(0.12) : Color.clear)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(isSelected ? Color.indigo.opacity(0.3) : Color.clear, lineWidth: 1)
+                )
+        )
+        .contentShape(Rectangle())
+        .onTapGesture { onTap() }
+        .onTapGesture(count: 2) { onEdit() }
+#if os(macOS)
+        .contextMenu {
+            Button("Edit Type", action: onEdit)
+            Button("Select Type", action: onTap)
+            Divider()
+            Button("Copy Name") {
+                NSPasteboard.general.setString(type.name, forType: .string)
+            }
+            Button("Copy Code") {
+                NSPasteboard.general.setString(type.code, forType: .string)
+            }
+        }
+#endif
+        .animation(.easeInOut(duration: 0.2), value: isSelected)
+    }
+
+    @ViewBuilder
+    private func columnView(for column: AccountTypeColumn) -> some View {
+        switch column {
+        case .name:
+            Text(type.name)
+                .font(.system(size: fontConfig.primary, weight: .medium))
+                .foregroundColor(.primary)
+                .padding(.leading, 16)
+                .padding(.trailing, 8)
+                .frame(width: widthFor(.name), alignment: .leading)
+        case .code:
+            Text(type.code)
+                .font(.system(size: fontConfig.secondary, design: .monospaced))
+                .foregroundColor(.secondary)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(Color.gray.opacity(0.12))
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+                .frame(width: widthFor(.code), alignment: .leading)
+        case .description:
+            Text(type.description)
+                .font(.system(size: fontConfig.secondary))
+                .foregroundColor(.secondary)
+                .lineLimit(2)
+                .padding(.horizontal, 8)
+                .frame(width: widthFor(.description), alignment: .leading)
+        case .isActive:
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(type.isActive ? Color.green : Color.gray.opacity(0.3))
+                    .frame(width: max(fontConfig.badge, 8), height: max(fontConfig.badge, 8))
+                Text(type.statusLabel)
+                    .font(.system(size: fontConfig.secondary, weight: .medium))
+                    .foregroundColor(type.isActive ? .green : .secondary)
+            }
+            .frame(width: widthFor(.isActive), alignment: .center)
+        }
+    }
+}
+
+private func modernStatCard(title: String, value: String, icon: String, color: Color) -> some View {
+    VStack(spacing: 4) {
+        HStack(spacing: 4) {
+            Image(systemName: icon)
+                .font(.system(size: 12))
+                .foregroundColor(color)
+            Text(title)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(.gray)
+        }
+
+        Text(value)
+            .font(.system(size: 18, weight: .bold))
+            .foregroundColor(.primary)
+    }
+    .padding(.horizontal, 12)
+    .padding(.vertical, 8)
+    .background(
+        RoundedRectangle(cornerRadius: 8)
+            .fill(.regularMaterial)
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(color.opacity(0.2), lineWidth: 1)
+            )
+    )
+    .shadow(color: color.opacity(0.1), radius: 3, x: 0, y: 1)
+}
+
+private struct AccountTypeParticle: Identifiable {
     let id = UUID()
     var position: CGPoint
     var size: CGFloat
     var opacity: Double
 }
 
-struct AccountTypesParticleBackground: View {
+private struct AccountTypesParticleBackground: View {
     @State private var particles: [AccountTypeParticle] = []
-    
+
     var body: some View {
         ZStack {
             ForEach(particles) { particle in
@@ -355,7 +870,7 @@ struct AccountTypesParticleBackground: View {
             animateParticles()
         }
     }
-    
+
     private func createParticles() {
         particles = (0..<15).map { _ in
             AccountTypeParticle(
@@ -365,7 +880,7 @@ struct AccountTypesParticleBackground: View {
             )
         }
     }
-    
+
     private func animateParticles() {
         withAnimation(.linear(duration: 30).repeatForever(autoreverses: false)) {
             for index in particles.indices {

--- a/DragonShield/Views/Components/MaintenanceTable/MaintenanceTableTypes.swift
+++ b/DragonShield/Views/Components/MaintenanceTable/MaintenanceTableTypes.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+
+protocol MaintenanceTableColumn: CaseIterable, Hashable, RawRepresentable where RawValue == String {}
+
+struct MaintenanceTableFontConfig {
+    let primary: CGFloat
+    let secondary: CGFloat
+    let header: CGFloat
+    let badge: CGFloat
+}
+
+enum MaintenanceTableFontSize: String, CaseIterable {
+    case xSmall, small, medium, large, xLarge
+
+    var label: String {
+        switch self {
+        case .xSmall: return "XS"
+        case .small: return "S"
+        case .medium: return "M"
+        case .large: return "L"
+        case .xLarge: return "XL"
+        }
+    }
+
+    var baseSize: CGFloat {
+        let index: Int
+        switch self {
+        case .xSmall: index = 0
+        case .small: index = 1
+        case .medium: index = 2
+        case .large: index = 3
+        case .xLarge: index = 4
+        }
+        return TableFontMetrics.baseSize(for: index)
+    }
+
+    var secondarySize: CGFloat { baseSize - 1 }
+    var headerSize: CGFloat { baseSize - 1 }
+    var badgeSize: CGFloat { max(baseSize - 2, 10) }
+}
+
+struct MaintenanceTableConfiguration<Column: MaintenanceTableColumn> {
+    let preferenceKind: TablePreferenceKind
+    let columnOrder: [Column]
+    let defaultVisibleColumns: Set<Column>
+    let requiredColumns: Set<Column>
+    let defaultColumnWidths: [Column: CGFloat]
+    let minimumColumnWidths: [Column: CGFloat]
+    let visibleColumnsDefaultsKey: String
+    let columnHandleWidth: CGFloat
+    let columnHandleHitSlop: CGFloat
+    let columnTextInset: CGFloat
+    let headerBackground: Color
+    let fontConfigBuilder: (MaintenanceTableFontSize) -> MaintenanceTableFontConfig
+#if os(macOS)
+    let columnResizeCursor: NSCursor?
+#endif
+
+#if os(macOS)
+    init(
+        preferenceKind: TablePreferenceKind,
+        columnOrder: [Column],
+        defaultVisibleColumns: Set<Column>,
+        requiredColumns: Set<Column>,
+        defaultColumnWidths: [Column: CGFloat],
+        minimumColumnWidths: [Column: CGFloat],
+        visibleColumnsDefaultsKey: String,
+        columnHandleWidth: CGFloat = 10,
+        columnHandleHitSlop: CGFloat = 8,
+        columnTextInset: CGFloat = 12,
+        headerBackground: Color,
+        fontConfigBuilder: @escaping (MaintenanceTableFontSize) -> MaintenanceTableFontConfig,
+        columnResizeCursor: NSCursor? = nil
+    ) {
+        self.preferenceKind = preferenceKind
+        self.columnOrder = columnOrder
+        self.defaultVisibleColumns = defaultVisibleColumns
+        self.requiredColumns = requiredColumns
+        self.defaultColumnWidths = defaultColumnWidths
+        self.minimumColumnWidths = minimumColumnWidths
+        self.visibleColumnsDefaultsKey = visibleColumnsDefaultsKey
+        self.columnHandleWidth = columnHandleWidth
+        self.columnHandleHitSlop = columnHandleHitSlop
+        self.columnTextInset = columnTextInset
+        self.headerBackground = headerBackground
+        self.fontConfigBuilder = fontConfigBuilder
+        self.columnResizeCursor = columnResizeCursor
+    }
+#else
+    init(
+        preferenceKind: TablePreferenceKind,
+        columnOrder: [Column],
+        defaultVisibleColumns: Set<Column>,
+        requiredColumns: Set<Column>,
+        defaultColumnWidths: [Column: CGFloat],
+        minimumColumnWidths: [Column: CGFloat],
+        visibleColumnsDefaultsKey: String,
+        columnHandleWidth: CGFloat = 10,
+        columnHandleHitSlop: CGFloat = 8,
+        columnTextInset: CGFloat = 12,
+        headerBackground: Color,
+        fontConfigBuilder: @escaping (MaintenanceTableFontSize) -> MaintenanceTableFontConfig
+    ) {
+        self.preferenceKind = preferenceKind
+        self.columnOrder = columnOrder
+        self.defaultVisibleColumns = defaultVisibleColumns
+        self.requiredColumns = requiredColumns
+        self.defaultColumnWidths = defaultColumnWidths
+        self.minimumColumnWidths = minimumColumnWidths
+        self.visibleColumnsDefaultsKey = visibleColumnsDefaultsKey
+        self.columnHandleWidth = columnHandleWidth
+        self.columnHandleHitSlop = columnHandleHitSlop
+        self.columnTextInset = columnTextInset
+        self.headerBackground = headerBackground
+        self.fontConfigBuilder = fontConfigBuilder
+    }
+#endif
+}

--- a/DragonShield/Views/Components/MaintenanceTable/MaintenanceTableView.swift
+++ b/DragonShield/Views/Components/MaintenanceTable/MaintenanceTableView.swift
@@ -1,0 +1,169 @@
+import SwiftUI
+
+struct MaintenanceTableRowContext<Column: MaintenanceTableColumn> {
+    let columns: [Column]
+    let fontConfig: MaintenanceTableFontConfig
+    let widthForColumn: (Column) -> CGFloat
+}
+
+struct MaintenanceTableView<Data: RandomAccessCollection, Column: MaintenanceTableColumn, HeaderContent: View, RowView: View>: View where Data.Element: Identifiable {
+    @ObservedObject var model: ResizableTableViewModel<Column>
+    let rows: Data
+    let rowSpacing: CGFloat
+    let showHorizontalIndicators: Bool
+    let rowContent: (Data.Element, MaintenanceTableRowContext<Column>) -> RowView
+    let headerContent: (Column, MaintenanceTableFontConfig) -> HeaderContent
+
+    init(
+        model: ResizableTableViewModel<Column>,
+        rows: Data,
+        rowSpacing: CGFloat = 0,
+        showHorizontalIndicators: Bool = true,
+        @ViewBuilder rowContent: @escaping (Data.Element, MaintenanceTableRowContext<Column>) -> RowView,
+        @ViewBuilder headerContent: @escaping (Column, MaintenanceTableFontConfig) -> HeaderContent
+    ) {
+        self.model = model
+        self.rows = rows
+        self.rowSpacing = rowSpacing
+        self.showHorizontalIndicators = showHorizontalIndicators
+        self.rowContent = rowContent
+        self.headerContent = headerContent
+    }
+
+    var body: some View {
+        GeometryReader { proxy in
+            let availableWidth = max(proxy.size.width, 0)
+            let targetWidth = max(availableWidth, model.totalMinimumWidth)
+
+            ScrollView(.horizontal, showsIndicators: showHorizontalIndicators) {
+                VStack(spacing: 0) {
+                    header
+                    rowsView
+                }
+                .frame(width: targetWidth, alignment: .leading)
+            }
+            .frame(width: availableWidth, alignment: .leading)
+            .onAppear {
+                model.updateAvailableWidth(targetWidth)
+            }
+            .onChange(of: proxy.size.width) { _, newWidth in
+                model.updateAvailableWidth(max(newWidth, model.totalMinimumWidth))
+            }
+        }
+        .frame(maxWidth: .infinity, minHeight: 0)
+    }
+
+    private var header: some View {
+        HStack(spacing: 0) {
+            ForEach(model.activeColumns, id: \.self) { column in
+                headerCell(for: column)
+                    .frame(width: model.width(for: column), alignment: .leading)
+            }
+        }
+        .padding(.trailing, 12)
+        .padding(.vertical, 2)
+        .background(
+            Rectangle()
+                .fill(model.configuration.headerBackground)
+                .overlay(Rectangle().stroke(Color.blue.opacity(0.15), lineWidth: 1))
+        )
+        .frame(width: max(model.availableTableWidth, model.totalMinimumWidth), alignment: .leading)
+    }
+
+    private var rowsView: some View {
+        let context = MaintenanceTableRowContext(
+            columns: model.activeColumns,
+            fontConfig: model.fontConfig,
+            widthForColumn: { model.width(for: $0) }
+        )
+
+        return ScrollView {
+            LazyVStack(spacing: rowSpacing) {
+                ForEach(rows) { row in
+                    rowContent(row, context)
+                }
+            }
+        }
+        .background(
+            Rectangle()
+                .fill(.regularMaterial)
+                .overlay(Rectangle().stroke(Color.gray.opacity(0.12), lineWidth: 1))
+        )
+        .shadow(color: .black.opacity(0.05), radius: 8, x: 0, y: 4)
+        .frame(width: max(model.availableTableWidth, model.totalMinimumWidth), alignment: .leading)
+    }
+
+    private func headerCell(for column: Column) -> some View {
+        let leadingTarget = model.leadingHandleTarget(for: column)
+        let isLast = model.isLastActiveColumn(column)
+        let inset = model.configuration.columnTextInset
+        let handleWidth = model.configuration.columnHandleWidth
+
+        return ZStack(alignment: .leading) {
+            if let target = leadingTarget {
+                resizeHandle(for: target)
+            }
+            if isLast {
+                resizeHandle(for: column)
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+            }
+
+            HStack(spacing: 6) {
+                headerContent(column, model.fontConfig)
+            }
+            .padding(.leading, inset + (leadingTarget == nil ? 0 : handleWidth))
+            .padding(.trailing, isLast ? handleWidth + 8 : 8)
+        }
+    }
+
+    private func resizeHandle(for column: Column) -> some View {
+        let handleWidth = model.configuration.columnHandleWidth
+        let hitSlop = model.configuration.columnHandleHitSlop
+
+        return Rectangle()
+            .fill(Color.clear)
+            .frame(width: handleWidth + hitSlop * 2, height: 28)
+            .offset(x: -hitSlop)
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+#if os(macOS)
+                        if let cursor = model.configuration.columnResizeCursor {
+                            cursor.set()
+                        } else {
+                            NSCursor.resizeLeftRight.set()
+                        }
+#endif
+                        model.beginDrag(for: column)
+                        model.updateDrag(for: column, translation: value.translation.width)
+                    }
+                    .onEnded { _ in
+                        model.finalizeDrag()
+#if os(macOS)
+                        NSCursor.arrow.set()
+#endif
+                    }
+            )
+            .overlay(alignment: .leading) {
+                RoundedRectangle(cornerRadius: 0.5)
+                    .fill(Color.gray.opacity(0.8))
+                    .frame(width: 2, height: 22)
+            }
+            .padding(.vertical, 2)
+            .background(Color.clear)
+#if os(macOS)
+            .onHover { inside in
+                if inside {
+                    if let cursor = model.configuration.columnResizeCursor {
+                        cursor.set()
+                    } else {
+                        NSCursor.resizeLeftRight.set()
+                    }
+                } else {
+                    NSCursor.arrow.set()
+                }
+            }
+#endif
+    }
+}

--- a/DragonShield/Views/Components/MaintenanceTable/ResizableTableViewModel.swift
+++ b/DragonShield/Views/Components/MaintenanceTable/ResizableTableViewModel.swift
@@ -1,0 +1,535 @@
+import SwiftUI
+import Combine
+
+final class ResizableTableViewModel<Column: MaintenanceTableColumn>: ObservableObject {
+    @Published private(set) var visibleColumns: Set<Column>
+    @Published var selectedFontSize: MaintenanceTableFontSize {
+        didSet {
+            guard selectedFontSize != oldValue else { return }
+            persistFontSize()
+        }
+    }
+    @Published private(set) var columnFractions: [Column: CGFloat]
+    @Published private(set) var resolvedColumnWidths: [Column: CGFloat]
+    @Published var availableTableWidth: CGFloat = 0
+
+    let configuration: MaintenanceTableConfiguration<Column>
+
+    private var cancellables: Set<AnyCancellable> = []
+    private weak var dbManager: DatabaseManager?
+    private var isHydratingPreferences = false
+    private var hasHydratedPreferences = false
+    private var dragContext: ColumnDragContext?
+    private var hasAppliedHydratedLayout = false
+
+    private struct ColumnDragContext {
+        let primary: Column
+        let neighbor: Column
+        let primaryBaseWidth: CGFloat
+        let neighborBaseWidth: CGFloat
+    }
+
+    init(configuration: MaintenanceTableConfiguration<Column>) {
+        self.configuration = configuration
+        var initialVisible = ResizableTableViewModel.initialVisibleColumns(configuration)
+        ResizableTableViewModel.enforceRequiredColumns(configuration, on: &initialVisible)
+        self.visibleColumns = initialVisible
+        self.selectedFontSize = .medium
+        self.columnFractions = ResizableTableViewModel.initialFractions(configuration)
+        self.resolvedColumnWidths = configuration.defaultColumnWidths
+    }
+
+    func connect(to manager: DatabaseManager) {
+        if dbManager === manager { return }
+        dbManager = manager
+        cancellables.removeAll()
+        hasAppliedHydratedLayout = false
+        debugLog("Connecting to manager; hasHydrated=\(hasHydratedPreferences)")
+        observe(manager: manager)
+        hydratePreferencesIfNeeded()
+    }
+
+    var fontConfig: MaintenanceTableFontConfig {
+        configuration.fontConfigBuilder(selectedFontSize)
+    }
+
+    var activeColumns: [Column] {
+        let order = configuration.columnOrder
+        let filtered = order.filter { visibleColumns.contains($0) }
+        if filtered.isEmpty, let first = order.first {
+            return [first]
+        }
+        return filtered
+    }
+
+    func width(for column: Column) -> CGFloat {
+        guard visibleColumns.contains(column) else { return 0 }
+        if let width = resolvedColumnWidths[column], width > 0 {
+            return width
+        }
+        if let fallback = configuration.defaultColumnWidths[column] {
+            return fallback
+        }
+        return minimumWidth(for: column)
+    }
+
+    func minimumWidth(for column: Column) -> CGFloat {
+        configuration.minimumColumnWidths[column] ?? 80
+    }
+
+    var totalMinimumWidth: CGFloat {
+        activeColumns.reduce(0) { $0 + minimumWidth(for: $1) }
+    }
+
+    func leadingHandleTarget(for column: Column) -> Column? {
+        let columns = activeColumns
+        guard let index = columns.firstIndex(of: column) else { return nil }
+        if index == 0 {
+            return column
+        }
+        return columns[index - 1]
+    }
+
+    func isLastActiveColumn(_ column: Column) -> Bool {
+        activeColumns.last == column
+    }
+
+    func beginDrag(for column: Column) {
+        if let context = dragContext, context.primary == column { return }
+        guard let neighbor = neighborColumn(for: column) else { return }
+        let primaryWidth = width(for: column)
+        let neighborWidth = width(for: neighbor)
+        dragContext = ColumnDragContext(primary: column, neighbor: neighbor, primaryBaseWidth: primaryWidth, neighborBaseWidth: neighborWidth)
+    }
+
+    func updateDrag(for column: Column, translation: CGFloat) {
+        guard let context = dragContext, context.primary == column else { return }
+        let totalWidth = max(availableTableWidth, totalMinimumWidth)
+        guard totalWidth > 0 else { return }
+
+        let minPrimary = minimumWidth(for: context.primary)
+        let minNeighbor = minimumWidth(for: context.neighbor)
+        let combined = context.primaryBaseWidth + context.neighborBaseWidth
+
+        var newPrimary = context.primaryBaseWidth + translation
+        let maximumPrimary = combined - minNeighbor
+        newPrimary = min(max(newPrimary, minPrimary), maximumPrimary)
+        let newNeighbor = combined - newPrimary
+
+        var updatedFractions = columnFractions
+        updatedFractions[context.primary] = max(0.0001, newPrimary / totalWidth)
+        updatedFractions[context.neighbor] = max(0.0001, newNeighbor / totalWidth)
+        columnFractions = normalizedFractions(updatedFractions)
+        adjustResolvedWidths(for: totalWidth)
+    }
+
+    func finalizeDrag() {
+        dragContext = nil
+        debugLog("Finalize drag → persisting fractions")
+        persistColumnFractions(force: true)
+    }
+
+    func toggleColumn(_ column: Column) {
+        var updated = visibleColumns
+        if updated.contains(column) {
+            if updated.count == 1 { return }
+            if configuration.requiredColumns.contains(column) { return }
+            updated.remove(column)
+        } else {
+            updated.insert(column)
+        }
+        setVisibleColumns(updated)
+    }
+
+    func setVisibleColumns(_ columns: Set<Column>) {
+        visibleColumns = normalizedVisibleColumns(columns)
+        persistVisibleColumns()
+        ensureValidSelectionAfterVisibilityChange()
+        recalcColumnWidths()
+    }
+
+    func resetVisibleColumns() {
+        var defaults = configuration.defaultVisibleColumns
+        ResizableTableViewModel.enforceRequiredColumns(configuration, on: &defaults)
+        visibleColumns = defaults
+        persistVisibleColumns()
+        ensureValidSelectionAfterVisibilityChange()
+        recalcColumnWidths()
+    }
+
+    func resetTablePreferences() {
+        var defaults = configuration.defaultVisibleColumns
+        ResizableTableViewModel.enforceRequiredColumns(configuration, on: &defaults)
+        visibleColumns = defaults
+        selectedFontSize = .medium
+        columnFractions = defaultFractions()
+        recalcColumnWidths()
+        persistVisibleColumns()
+        persistFontSize()
+        persistColumnFractions()
+    }
+
+    func updateAvailableWidth(_ width: CGFloat) {
+        let targetWidth = max(width, totalMinimumWidth)
+        if abs(availableTableWidth - targetWidth) < 0.5 { return }
+        availableTableWidth = targetWidth
+        adjustResolvedWidths(for: targetWidth)
+        if hasHydratedPreferences && !hasAppliedHydratedLayout {
+            hasAppliedHydratedLayout = true
+            debugLog("updateAvailableWidth target=\(String(format: "%.1f", Double(targetWidth))) → applied hydrated layout (no persist)")
+            return
+        }
+
+        if canPersistFractions {
+            debugLog("updateAvailableWidth target=\(String(format: "%.1f", Double(targetWidth))) → persist")
+            persistColumnFractions()
+        } else {
+            debugLog("updateAvailableWidth target=\(String(format: "%.1f", Double(targetWidth))) → skip (not ready)")
+        }
+    }
+
+    func recalcColumnWidths(shouldPersist: Bool = true) {
+        let width = max(availableTableWidth, totalMinimumWidth)
+        guard width > 0 else { return }
+        adjustResolvedWidths(for: width)
+        if shouldPersist {
+            if canPersistFractions {
+                debugLog("recalcColumnWidths width=\(String(format: "%.1f", Double(width))) → persist")
+                persistColumnFractions()
+            } else {
+                debugLog("recalcColumnWidths width=\(String(format: "%.1f", Double(width))) → skip (not ready)")
+            }
+        }
+    }
+
+    // MARK: - Private helpers
+
+    private static func initialVisibleColumns(_ configuration: MaintenanceTableConfiguration<Column>) -> Set<Column> {
+        let defaults = UserDefaults.standard
+        if let stored = defaults.array(forKey: configuration.visibleColumnsDefaultsKey) as? [String] {
+            let mapped = stored.compactMap(Column.init(rawValue:))
+            if !mapped.isEmpty {
+                return Set(mapped)
+            }
+        }
+        return configuration.defaultVisibleColumns
+    }
+
+    private static func initialFractions(_ configuration: MaintenanceTableConfiguration<Column>) -> [Column: CGFloat] {
+        let defaults = configuration.defaultColumnWidths
+        let total = defaults.values.reduce(0, +)
+        guard total > 0 else {
+            let share = 1.0 / CGFloat(configuration.columnOrder.count)
+            return configuration.columnOrder.reduce(into: [:]) { dict, column in
+                dict[column] = share
+            }
+        }
+        return configuration.columnOrder.reduce(into: [:]) { dict, column in
+            let width = defaults[column] ?? 0
+            dict[column] = max(0.0001, width / total)
+        }
+    }
+
+    private static func enforceRequiredColumns(_ configuration: MaintenanceTableConfiguration<Column>, on set: inout Set<Column>) {
+        set.formUnion(configuration.requiredColumns)
+    }
+
+    private func normalizedVisibleColumns(_ input: Set<Column>) -> Set<Column> {
+        var updated = input
+        ResizableTableViewModel.enforceRequiredColumns(configuration, on: &updated)
+        if updated.isEmpty, let first = configuration.columnOrder.first {
+            updated.insert(first)
+        }
+        return updated
+    }
+
+    private func neighborColumn(for column: Column) -> Column? {
+        let columns = activeColumns
+        guard let index = columns.firstIndex(of: column) else { return nil }
+        if index < columns.count - 1 {
+            return columns[index + 1]
+        }
+        if index > 0 {
+            return columns[index - 1]
+        }
+        return nil
+    }
+
+    private func hydratePreferencesIfNeeded() {
+        guard !hasHydratedPreferences, let manager = dbManager else { return }
+        debugLog("Hydrating preferences…")
+        hasHydratedPreferences = true
+        isHydratingPreferences = true
+
+        migrateLegacyFontIfNeeded(manager)
+        if let stored = MaintenanceTableFontSize(rawValue: manager.tableFontSize(for: configuration.preferenceKind)) {
+            selectedFontSize = stored
+        }
+
+        restoreColumnFractions(using: manager)
+
+        isHydratingPreferences = false
+
+        if availableTableWidth > 0 {
+            hasAppliedHydratedLayout = true
+            debugLog("Hydration width already known (\(String(format: "%.1f", Double(availableTableWidth)))) → recalc immediately")
+            recalcColumnWidths(shouldPersist: false)
+        } else {
+            hasAppliedHydratedLayout = false
+            debugLog("Hydration deferred recalc until layout provides width")
+        }
+        debugLog("Hydration finished; activeFractionCount=\(columnFractions.filter { $0.value > 0 }.count)")
+    }
+
+    private func migrateLegacyFontIfNeeded(_ manager: DatabaseManager) {
+        guard let legacy = manager.legacyTableFontSize(for: configuration.preferenceKind) else { return }
+        if manager.tableFontSize(for: configuration.preferenceKind) != legacy {
+            manager.setTableFontSize(legacy, for: configuration.preferenceKind)
+        }
+        manager.clearLegacyTableFontSize(for: configuration.preferenceKind)
+    }
+
+    private func restoreColumnFractions(using manager: DatabaseManager) {
+        let live = manager.tableColumnFractions(for: configuration.preferenceKind)
+        if applyFractions(live) {
+            debugLog("Applied live fractions from manager: \(describeFractions(live))")
+            return
+        }
+
+        if let legacy = manager.legacyTableColumnFractions(for: configuration.preferenceKind) {
+            debugLog("Live fractions empty; attempting legacy fractions")
+            if applyFractions(legacy) {
+                debugLog("Applied legacy fractions: \(describeFractions(legacy))")
+                manager.setTableColumnFractions(legacy, for: configuration.preferenceKind)
+            }
+            manager.clearLegacyTableColumnFractions(for: configuration.preferenceKind)
+            return
+        }
+
+        columnFractions = defaultFractions()
+        let defaults = columnFractions.reduce(into: [String: Double]()) { $0[$1.key.rawValue] = Double($1.value) }
+        debugLog("Falling back to default fractions: \(describeFractions(defaults))")
+    }
+
+    private func applyFractions(_ raw: [String: Double]) -> Bool {
+        let typed = typedFractions(from: raw)
+        guard !typed.isEmpty else {
+            debugLog("Incoming fractions empty → skip apply")
+            return false
+        }
+        columnFractions = normalizedFractions(typed)
+        debugLog("Normalized fractions: \(describeFractions(raw))")
+        return true
+    }
+
+    private func typedFractions(from raw: [String: Double]) -> [Column: CGFloat] {
+        raw.reduce(into: [Column: CGFloat]()) { result, entry in
+            guard let column = Column(rawValue: entry.key), entry.value.isFinite else { return }
+            let fraction = max(0, entry.value)
+            if fraction > 0 {
+                result[column] = CGFloat(fraction)
+            }
+        }
+    }
+
+    private func defaultFractions() -> [Column: CGFloat] {
+        ResizableTableViewModel.initialFractions(configuration)
+    }
+
+    private func normalizedFractions(_ input: [Column: CGFloat]? = nil) -> [Column: CGFloat] {
+        let source = input ?? columnFractions
+        var result: [Column: CGFloat] = [:]
+        let activeSet = Set(activeColumns)
+        let total = activeColumns.reduce(0) { $0 + max(0, source[$1] ?? 0) }
+
+        if total <= 0 {
+            let share = activeColumns.isEmpty ? 0 : 1.0 / CGFloat(activeColumns.count)
+            for column in configuration.columnOrder {
+                result[column] = activeSet.contains(column) ? share : 0
+            }
+            return result
+        }
+
+        for column in configuration.columnOrder {
+            if activeSet.contains(column) {
+                result[column] = max(0.0001, source[column] ?? 0) / total
+            } else {
+                result[column] = 0
+            }
+        }
+        return result
+    }
+
+    private func adjustResolvedWidths(for width: CGFloat) {
+        guard width > 0 else { return }
+        let fractions = normalizedFractions()
+        var resolved: [Column: CGFloat] = [:]
+        for column in configuration.columnOrder {
+            guard visibleColumns.contains(column) else {
+                resolved[column] = 0
+                continue
+            }
+            let fraction = fractions[column] ?? 0
+            let proposed = fraction * width
+            let minWidth = minimumWidth(for: column)
+            resolved[column] = max(minWidth, proposed)
+        }
+
+        balanceResolvedWidths(&resolved, targetWidth: width)
+        resolvedColumnWidths = resolved
+        columnFractions = normalizedFractions(resolved)
+    }
+
+    private func balanceResolvedWidths(_ resolved: inout [Column: CGFloat], targetWidth: CGFloat) {
+        let columns = activeColumns
+        guard !columns.isEmpty else { return }
+        let currentTotal = columns.reduce(0) { $0 + (resolved[$1] ?? 0) }
+        let difference = targetWidth - currentTotal
+        guard abs(difference) > 0.5 else { return }
+
+        if difference > 0 {
+            let share = difference / CGFloat(columns.count)
+            for column in columns {
+                resolved[column, default: minimumWidth(for: column)] += share
+            }
+        } else {
+            var remainingDifference = difference
+            var adjustable = columns
+
+            while remainingDifference < -0.5, !adjustable.isEmpty {
+                let share = remainingDifference / CGFloat(adjustable.count)
+                var columnsAtMinimum: [Column] = []
+                for column in adjustable {
+                    let minWidth = minimumWidth(for: column)
+                    let current = resolved[column] ?? minWidth
+                    let adjusted = max(minWidth, current + share)
+                    resolved[column] = adjusted
+                    remainingDifference -= (adjusted - current)
+                    if adjusted - minWidth < 0.5 {
+                        columnsAtMinimum.append(column)
+                    }
+                    if remainingDifference >= -0.5 { break }
+                }
+                adjustable.removeAll { columnsAtMinimum.contains($0) }
+                if adjustable.isEmpty { break }
+            }
+        }
+    }
+
+    private func ensureValidSelectionAfterVisibilityChange() {
+        // Intentionally left empty for now; hook for future view-specific validation.
+    }
+
+    private func persistVisibleColumns() {
+        let ordered = configuration.columnOrder.filter { visibleColumns.contains($0) }
+        UserDefaults.standard.set(ordered.map(\.rawValue), forKey: configuration.visibleColumnsDefaultsKey)
+    }
+
+    private func persistFontSize() {
+        guard !isHydratingPreferences, let manager = dbManager else { return }
+        isHydratingPreferences = true
+        manager.setTableFontSize(selectedFontSize.rawValue, for: configuration.preferenceKind)
+        DispatchQueue.main.async { [weak self] in
+            self?.isHydratingPreferences = false
+        }
+    }
+
+    private func persistColumnFractions(force: Bool = false) {
+        guard let manager = dbManager else {
+            debugLog("Skipping persistColumnFractions (no manager)")
+            return
+        }
+        if !force && !canPersistFractions {
+            debugLog("Skipping persistColumnFractions (not ready and force=false)")
+            return
+        }
+        guard !isHydratingPreferences else {
+            debugLog("Skipping persistColumnFractions (currently hydrating)")
+            return
+        }
+        let payload = columnFractions.reduce(into: [String: Double]()) { result, entry in
+            guard entry.value.isFinite else { return }
+            result[entry.key.rawValue] = Double(entry.value)
+        }
+        debugLog("Persisting fractions: \(describeFractions(payload))")
+        isHydratingPreferences = true
+        manager.setTableColumnFractions(payload, for: configuration.preferenceKind)
+        DispatchQueue.main.async { [weak self] in
+            self?.isHydratingPreferences = false
+        }
+    }
+
+    private func observe(manager: DatabaseManager) {
+        fontPublisher(for: manager)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] raw in
+                guard let self else { return }
+                guard !self.isHydratingPreferences else { return }
+                guard let size = MaintenanceTableFontSize(rawValue: raw) else { return }
+                self.selectedFontSize = size
+            }
+            .store(in: &cancellables)
+
+        fractionsPublisher(for: manager)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] raw in
+                guard let self else { return }
+                guard !self.isHydratingPreferences else {
+                    self.debugLog("Ignoring fractions update while hydrating")
+                    return
+                }
+                if self.applyFractions(raw) {
+                    self.debugLog("Applying fractions update from manager")
+                    self.recalcColumnWidths(shouldPersist: false)
+                }
+            }
+            .store(in: &cancellables)
+    }
+
+    private func fontPublisher(for manager: DatabaseManager) -> AnyPublisher<String, Never> {
+        switch configuration.preferenceKind {
+        case .institutions: return manager.$institutionsTableFontSize.eraseToAnyPublisher()
+        case .instruments: return manager.$instrumentsTableFontSize.eraseToAnyPublisher()
+        case .assetSubClasses: return manager.$assetSubClassesTableFontSize.eraseToAnyPublisher()
+        case .assetClasses: return manager.$assetClassesTableFontSize.eraseToAnyPublisher()
+        case .currencies: return manager.$currenciesTableFontSize.eraseToAnyPublisher()
+        case .accounts: return manager.$accountsTableFontSize.eraseToAnyPublisher()
+        case .portfolioThemes: return manager.$portfolioThemesTableFontSize.eraseToAnyPublisher()
+        case .transactionTypes: return manager.$transactionTypesTableFontSize.eraseToAnyPublisher()
+        case .accountTypes: return manager.$accountTypesTableFontSize.eraseToAnyPublisher()
+        }
+    }
+
+    private func fractionsPublisher(for manager: DatabaseManager) -> AnyPublisher<[String: Double], Never> {
+        switch configuration.preferenceKind {
+        case .institutions: return manager.$institutionsTableColumnFractions.eraseToAnyPublisher()
+        case .instruments: return manager.$instrumentsTableColumnFractions.eraseToAnyPublisher()
+        case .assetSubClasses: return manager.$assetSubClassesTableColumnFractions.eraseToAnyPublisher()
+        case .assetClasses: return manager.$assetClassesTableColumnFractions.eraseToAnyPublisher()
+        case .currencies: return manager.$currenciesTableColumnFractions.eraseToAnyPublisher()
+        case .accounts: return manager.$accountsTableColumnFractions.eraseToAnyPublisher()
+        case .portfolioThemes: return manager.$portfolioThemesTableColumnFractions.eraseToAnyPublisher()
+        case .transactionTypes: return manager.$transactionTypesTableColumnFractions.eraseToAnyPublisher()
+        case .accountTypes: return manager.$accountTypesTableColumnFractions.eraseToAnyPublisher()
+        }
+    }
+
+    private func describeFractions(_ input: [String: Double]) -> String {
+        guard !input.isEmpty else { return "<empty>" }
+        let sorted = input.sorted { $0.key < $1.key }
+        let parts = sorted.map { "\($0.key)=\(String(format: "%.4f", $0.value))" }
+        return parts.joined(separator: ", ")
+    }
+
+    private var canPersistFractions: Bool {
+        (!hasHydratedPreferences || hasAppliedHydratedLayout) && !isHydratingPreferences
+    }
+
+#if DEBUG
+    private func debugLog(_ message: String) {
+        print("🧭 [table:\(configuration.preferenceKind.logLabel)] \(message)")
+    }
+#else
+    private func debugLog(_ message: String) { }
+#endif
+}

--- a/DragonShield/Views/InstitutionsView.swift
+++ b/DragonShield/Views/InstitutionsView.swift
@@ -591,13 +591,13 @@ struct AddInstitutionView: View {
                 Picker("Default Currency", selection: $defaultCurrency) {
                     Text("None").tag("")
                     ForEach(availableCurrencies, id: \.code) { curr in
-                        Text("\\(curr.code)").tag(curr.code)
+                        Text("\(curr.code) – \(curr.name)").tag(curr.code)
                     }
                 }
                 Picker("Country", selection: $countryCode) {
                     Text("None").tag("")
                     ForEach(availableCountries, id: \.self) { code in
-                        Text("\\(flagEmoji(code)) \\(code)").tag(code)
+                        Text("\(flagEmoji(code)) \(code)").tag(code)
                     }
                 }
                 Text("Notes")
@@ -680,13 +680,13 @@ struct EditInstitutionView: View {
                 Picker("Default Currency", selection: $defaultCurrency) {
                     Text("None").tag("")
                     ForEach(availableCurrencies, id: \.code) { curr in
-                        Text("\\(curr.code)").tag(curr.code)
+                        Text("\(curr.code) – \(curr.name)").tag(curr.code)
                     }
                 }
                 Picker("Country", selection: $countryCode) {
                     Text("None").tag("")
                     ForEach(availableCountries, id: \.self) { code in
-                        Text("\\(flagEmoji(code)) \\(code)").tag(code)
+                        Text("\(flagEmoji(code)) \(code)").tag(code)
                     }
                 }
                 Text("Notes")

--- a/DragonShield/helpers/TablePreferences.swift
+++ b/DragonShield/helpers/TablePreferences.swift
@@ -3,17 +3,39 @@ import Foundation
 enum TablePreferenceKind {
     case institutions
     case instruments
+    case assetSubClasses
+    case assetClasses
     case currencies
     case accounts
     case portfolioThemes
+    case transactionTypes
+    case accountTypes
+
+    var logLabel: String {
+        switch self {
+        case .institutions: return "institutions"
+        case .instruments: return "instruments"
+        case .assetSubClasses: return "asset-subclasses"
+        case .assetClasses: return "asset-classes"
+        case .currencies: return "currencies"
+        case .accounts: return "accounts"
+        case .portfolioThemes: return "portfolio-themes"
+        case .transactionTypes: return "transaction-types"
+        case .accountTypes: return "account-types"
+        }
+    }
 
     var fractionsKeyPath: ReferenceWritableKeyPath<DatabaseManager, [String: Double]> {
         switch self {
         case .institutions: return \DatabaseManager.institutionsTableColumnFractions
         case .instruments: return \DatabaseManager.instrumentsTableColumnFractions
+        case .assetSubClasses: return \DatabaseManager.assetSubClassesTableColumnFractions
+        case .assetClasses: return \DatabaseManager.assetClassesTableColumnFractions
         case .currencies: return \DatabaseManager.currenciesTableColumnFractions
         case .accounts: return \DatabaseManager.accountsTableColumnFractions
         case .portfolioThemes: return \DatabaseManager.portfolioThemesTableColumnFractions
+        case .transactionTypes: return \DatabaseManager.transactionTypesTableColumnFractions
+        case .accountTypes: return \DatabaseManager.accountTypesTableColumnFractions
         }
     }
 
@@ -21,9 +43,13 @@ enum TablePreferenceKind {
         switch self {
         case .institutions: return \DatabaseManager.institutionsTableFontSize
         case .instruments: return \DatabaseManager.instrumentsTableFontSize
+        case .assetSubClasses: return \DatabaseManager.assetSubClassesTableFontSize
+        case .assetClasses: return \DatabaseManager.assetClassesTableFontSize
         case .currencies: return \DatabaseManager.currenciesTableFontSize
         case .accounts: return \DatabaseManager.accountsTableFontSize
         case .portfolioThemes: return \DatabaseManager.portfolioThemesTableFontSize
+        case .transactionTypes: return \DatabaseManager.transactionTypesTableFontSize
+        case .accountTypes: return \DatabaseManager.accountTypesTableFontSize
         }
     }
 
@@ -31,9 +57,13 @@ enum TablePreferenceKind {
         switch self {
         case .institutions: return "InstitutionsView.columnFractions.v1"
         case .instruments: return "PortfolioView.instrumentColumnFractions.v2"
+        case .assetSubClasses: return "AssetSubClassesView.columnFractions.v1"
+        case .assetClasses: return "AssetClassesView.columnFractions.v1"
         case .currencies: return "CurrenciesView.columnFractions.v1"
         case .accounts: return "AccountsView.columnFractions.v1"
         case .portfolioThemes: return "NewPortfoliosView.columnFractions.v1"
+        case .transactionTypes: return "TransactionTypesView.columnFractions.v1"
+        case .accountTypes: return "AccountTypesView.columnFractions.v1"
         }
     }
 
@@ -41,9 +71,13 @@ enum TablePreferenceKind {
         switch self {
         case .institutions: return "InstitutionsView.tableFontSize.v1"
         case .instruments: return "PortfolioView.tableFontSize.v1"
+        case .assetSubClasses: return "AssetSubClassesView.tableFontSize.v1"
+        case .assetClasses: return "AssetClassesView.tableFontSize.v1"
         case .currencies: return "CurrenciesView.tableFontSize.v1"
         case .accounts: return "AccountsView.tableFontSize.v1"
         case .portfolioThemes: return "NewPortfoliosView.tableFontSize.v1"
+        case .transactionTypes: return "TransactionTypesView.tableFontSize.v1"
+        case .accountTypes: return "AccountTypesView.tableFontSize.v1"
         }
     }
 }
@@ -57,9 +91,13 @@ extension DatabaseManager {
         switch kind {
         case .institutions: setInstitutionsTableColumnFractions(fractions)
         case .instruments: setInstrumentsTableColumnFractions(fractions)
+        case .assetSubClasses: setAssetSubClassesTableColumnFractions(fractions)
+        case .assetClasses: setAssetClassesTableColumnFractions(fractions)
         case .currencies: setCurrenciesTableColumnFractions(fractions)
         case .accounts: setAccountsTableColumnFractions(fractions)
         case .portfolioThemes: setPortfolioThemesTableColumnFractions(fractions)
+        case .transactionTypes: setTransactionTypesTableColumnFractions(fractions)
+        case .accountTypes: setAccountTypesTableColumnFractions(fractions)
         }
     }
 
@@ -71,9 +109,13 @@ extension DatabaseManager {
         switch kind {
         case .institutions: setInstitutionsTableFontSize(value)
         case .instruments: setInstrumentsTableFontSize(value)
+        case .assetSubClasses: setAssetSubClassesTableFontSize(value)
+        case .assetClasses: setAssetClassesTableFontSize(value)
         case .currencies: setCurrenciesTableFontSize(value)
         case .accounts: setAccountsTableFontSize(value)
         case .portfolioThemes: setPortfolioThemesTableFontSize(value)
+        case .transactionTypes: setTransactionTypesTableFontSize(value)
+        case .accountTypes: setAccountTypesTableFontSize(value)
         }
     }
 


### PR DESCRIPTION
## Summary
- 

## Checklist
- [ ] I validated that any new or updated table view uses the Dragon Shield table UX pattern (search header, column controls, draggable columns with persisted widths/font).
- [ ] I updated documentation/code comments when behaviour changed.
- [ ] I ran the relevant tests or builds (`xcodebuild -scheme DragonShield` or equivalent) before requesting review.

> Refer to docs/UX_UI_concept/dragon_shield_ui_guide.md for the table UX standard.
